### PR TITLE
[WIP] menu_tags context's stack bug

### DIFF
--- a/cms/test_utils/project/templates/tests/dolly/one.html
+++ b/cms/test_utils/project/templates/tests/dolly/one.html
@@ -1,0 +1,4 @@
+<h1>Dolly vs Magic Pony Fight</h1>
+{% block main %}
+<div id="maincolumn">some content</div>
+{% endblock %}

--- a/cms/test_utils/project/templates/tests/dolly/two.html
+++ b/cms/test_utils/project/templates/tests/dolly/two.html
@@ -1,0 +1,15 @@
+{% extends "tests/dolly/one.html" %}
+{% load menu_tags %}
+{% block main %}
+    {% with template='Magic Pony is the best !' %}
+        <h2>{{ template }}</h2>
+        {% block sidebar %}
+            <aside>
+                But Dolly could be a problem !
+                {% show_sub_menu 1 %}
+                <h3>{{ template }}</h3>
+            </aside>
+        {% endblock %}
+        {{ block.super }}
+    {% endwith %}
+{% endblock %}

--- a/cms/tests/menu.py
+++ b/cms/tests/menu.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from django.contrib.auth.models import AnonymousUser, Permission, Group
 from django.template import Template, TemplateSyntaxError
 from django.test.utils import override_settings
+from django.shotcuts import render_to_response
 from django.utils.translation import activate
 from menus.base import NavigationNode, Menu
 from menus.menu_pool import menu_pool, _build_nodes_inner_for_one_menu
@@ -194,6 +195,12 @@ class ExtendedFixturesMenuTests(ExtendedMenusFixture, BaseMenuTest):
         nodes = context["children"]
         # default nephew limit, P2 and P9 in the nodes list
         self.assertEqual(len(nodes), 2)
+
+    def test_show_submenu_inside_inherited_block_with_super_display(self):
+        context = self.get_context(path=self.get_page(1).get_absolute_url())
+        response = render_to_response('tests/dolly/two.html', context)
+        self.assertTrue(b'<h2>Magic Pony is the best !</h2>' in response.content)
+        self.assertTrue(b'<h3>Magic Pony is the best !</h3>' in response.content)
 
 
 class FixturesMenuTests(MenusFixture, BaseMenuTest):

--- a/cms/tests/menu.py
+++ b/cms/tests/menu.py
@@ -4,9 +4,9 @@ import copy
 
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser, Permission, Group
+from django.shortcuts import render_to_response
 from django.template import Template, TemplateSyntaxError
 from django.test.utils import override_settings
-from django.shotcuts import render_to_response
 from django.utils.translation import activate
 from menus.base import NavigationNode, Menu
 from menus.menu_pool import menu_pool, _build_nodes_inner_for_one_menu


### PR DESCRIPTION
Because context.update add a new level in the Context's stack and because there is never a context.pop called in menu_tags, the context AFTER a menu_tags call is not the same than BEFORE the call and some funny things happen.

## How to reproduce

onecolum.html :

```
<h1>Dolly vs Magic Pony Fight</h1>
{% block main %}
<div id="maincolumn">some content</div>
{% endblock %}
```

twocolumns.html :

```
{% extends "one_olumn.html" %}
{% load menu_tags %}
{% block main %}
    {% with template='Magic Pony is the best !' %}
        <h2>{{ template }}</h2>
        {% block sidebar %}
            <aside>
                But Dolly could be a problem !
                {% show_sub_menu 1 %}
                <h2>{{ template }}</h2>
            </aside>
        {% endblock %}
        {{ block.super }}
    {% endwith %}
{% endblock %}
```

### Expected Result

When twocolumns.html is rendered, we should have :

```
<h1>Dolly vs Magic Pony Fight</h1>
<h2>Magic Pony is the best !</h2>
<aside>
    But Dolly could be a problem !
    <h2>Magic Pony is the best !</h2>
</aside>
<div id="maincolumn">some content</div>
```

### Current Result

But when twocolumns.html is rendered, we currently have :

```
<h1>Dolly vs Magic Pony Fight</h1>
<h2>Magic Pony is the best !</h2>
<aside>
    But Dolly could be a problem !
    <h2>menu/sub_menu.html</h2>
</aside>
<aside>
    But Dolly could be a problem !
    <h2>menu/sub_menu.html</h2>
</aside>
```