### PR TITLE
Fix makemigrations in develop.py and let it make initial migrations as required

### DIFF
--- a/develop.py
+++ b/develop.py
@@ -10,7 +10,7 @@ import os
 import sys
 import warnings
 
-from StringIO import StringIO
+from django.utils.six.moves import StringIO
 
 from django import VERSION
 from django.core.exceptions import DjangoRuntimeWarning

--- a/develop.py
+++ b/develop.py
@@ -189,7 +189,7 @@ def shell():
     call_command('shell')
 
 
-class capture_all_output(object):
+class swallow_all_output(object):
     def __init__(self):
         self.output = StringIO()
         self.original_stdout = sys.stdout
@@ -198,7 +198,7 @@ class capture_all_output(object):
         sys.stderr = self.output
 
     def __enter__(self):
-        return self.output.getvalue()
+        pass
 
     def __exit__(self, *_):
         sys.stdout = self.original_stdout
@@ -239,9 +239,8 @@ def makemigrations(migrate_plugins=True, merge=False, squash=False):
                 print('WARNING: The app: {0} could not be found.'.format(application))
             else:
                 try:
-                    with capture_all_output() as content:
+                    with swallow_all_output():
                         call_command('schemamigration', application, auto=True)
-                    print(content)
                 except SystemExit:
                     pass
     else:

--- a/develop.py
+++ b/develop.py
@@ -189,22 +189,6 @@ def shell():
     call_command('shell')
 
 
-class swallow_all_output(object):
-    def __init__(self):
-        self.output = StringIO()
-        self.original_stdout = sys.stdout
-        self.original_stderr = sys.stderr
-        sys.stdout = self.output
-        sys.stderr = self.output
-
-    def __enter__(self):
-        pass
-
-    def __exit__(self, *_):
-        sys.stdout = self.original_stdout
-        sys.stderr = self.original_stderr
-
-
 def makemigrations(migrate_plugins=True, merge=False, squash=False):
     applications = [
         # core applications
@@ -239,8 +223,7 @@ def makemigrations(migrate_plugins=True, merge=False, squash=False):
                 print('WARNING: The app: {0} could not be found.'.format(application))
             else:
                 try:
-                    with swallow_all_output():
-                        call_command('schemamigration', application, auto=True)
+                    call_command('schemamigration', application, auto=True)
                 except SystemExit:
                     pass
     else:
@@ -287,7 +270,7 @@ def main():
 
     if args['pyflakes']:
         return static_analysis.pyflakes((cms, menus))
-    
+
     if args['authors']:
         return generate_authors()
 

--- a/develop.py
+++ b/develop.py
@@ -195,7 +195,7 @@ def makemigrations(migrate_plugins=True, merge=False, squash=False):
         'cms', 'menus',
         # testing applications
         'meta', 'manytomany_rel', 'fileapp', 'placeholderapp', 'sampleapp', 'fakemlng', 'one_thing', 'extensionapp',
-        'objectpermissionsapp', 'bunch_of_plugins', 'emailuserapp'
+        'objectpermissionsapp', 'bunch_of_plugins',
     ]
     if os.environ.get("AUTH_USER_MODEL") == "emailuserapp.EmailUser":
         applications.append('emailuserapp')

--- a/develop.py
+++ b/develop.py
@@ -21,9 +21,6 @@ from django.utils.encoding import force_text
 
 from docopt import docopt
 
-from south.exceptions import NoMigrations
-from south.migration import Migrations
-
 import cms
 from cms.test_utils.cli import configure
 from cms.test_utils.util import static_analysis
@@ -224,6 +221,9 @@ def makemigrations(migrate_plugins=True, merge=False, squash=False):
             'djangocms_flash', 'djangocms_video',
         ])
     if DJANGO_1_6:
+        from south.exceptions import NoMigrations
+        from south.migration import Migrations
+
         if merge:
             raise DjangoRuntimeWarning(u'Option not implemented for Django 1.6')
         for application in applications:

--- a/develop.py
+++ b/develop.py
@@ -197,6 +197,8 @@ def makemigrations(migrate_plugins=True, merge=False, squash=False):
         'meta', 'manytomany_rel', 'fileapp', 'placeholderapp', 'sampleapp', 'fakemlng', 'one_thing', 'extensionapp',
         'objectpermissionsapp', 'bunch_of_plugins', 'emailuserapp'
     ]
+    if os.environ.get("AUTH_USER_MODEL") == "emailuserapp.EmailUser":
+        applications.append('emailuserapp')
     if migrate_plugins:
         applications.extend([
             # official plugins


### PR DESCRIPTION
The `call_command('schemamigration'…)` returns a `SystemExit` when it is complete. Without a try/except block around it, this will cause a loop to prematurely terminate in a seemingly normal way. This is what was happening before this fix, and this effectively caused `develop.py makemigrations` to only ever make migrations for cms, which happens to be the first appliation in the list it works with.

Also, I've added code that will first check to see if an app already has migrations and if not, it will run the equivalent of `manage.py schemamigration [app] --initial` and emit a notice of the same.

Finally, this now detects if an application in the list if not found, and emits a notice of this too.