### PR TITLE
Fixed plugin ordering for live plugins.

### DIFF
--- a/cms/models/pluginmodel.py
+++ b/cms/models/pluginmodel.py
@@ -286,7 +286,6 @@ class CMSPlugin(with_metaclass(PluginModelBase, MP_Node)):
             new_plugin.parent = parent
         new_plugin.language = target_language
         new_plugin.plugin_type = self.plugin_type
-        new_plugin.position = CMSPlugin.objects.filter(parent=parent, language=target_language, placeholder=target_placeholder).count()
         if no_signals:
             from cms.signals import pre_save_plugins
 
@@ -306,8 +305,6 @@ class CMSPlugin(with_metaclass(PluginModelBase, MP_Node)):
             plugin_instance.depth = new_plugin.depth
             plugin_instance.path = new_plugin.path
             plugin_instance.numchild = new_plugin.numchild
-            # added to retain the position when creating a public copy of a plugin
-            plugin_instance.position = new_plugin.position
             plugin_instance._no_reorder = True
             plugin_instance.save()
             #new_plugin._inst = plugin_instance

--- a/cms/tests/plugins.py
+++ b/cms/tests/plugins.py
@@ -180,25 +180,43 @@ class PluginsTestCase(PluginsTestBaseCase):
         """
         Test that plugin position is saved after creation
         """
-        page_en = api.create_page("PluginOrderPage", "col_two.html", "en",
+        draft_page = api.create_page("PluginOrderPage", "col_two.html", "en",
                               slug="page1", published=True, in_navigation=True)
-        ph_en = page_en.placeholders.get(slot="col_left")
+        placeholder = draft_page.placeholders.get(slot="col_left")
 
         # We check created objects and objects from the DB to be sure the position value
         # has been saved correctly
-        text_plugin_1 = api.add_plugin(ph_en, "TextPlugin", "en", body="I'm the first")
-        text_plugin_2 = api.add_plugin(ph_en, "TextPlugin", "en", body="I'm the second")
-        db_plugin_1 = CMSPlugin.objects.get(pk=text_plugin_1.pk)
-        db_plugin_2 = CMSPlugin.objects.get(pk=text_plugin_2.pk)
+        text_plugin_2 = api.add_plugin(placeholder, "TextPlugin", "en", body="I'm the second")
+        text_plugin_3 = api.add_plugin(placeholder, "TextPlugin", "en", body="I'm the third")
+        # Publish to create a 'live' version
+        api.publish_page(draft_page, self.super_user, "en")
+        # Add a plugin and move it to the first position
+        text_plugin_1 = api.add_plugin(placeholder, "TextPlugin", "en", body="I'm the first")
+        data = {
+            'placeholder_id': placeholder.id,
+            'plugin_id': text_plugin_1.id,
+            'plugin_parent': '',
+            'plugin_language': 'en',
+            'plugin_order[]': [text_plugin_1.id, text_plugin_2.id, text_plugin_3.id],
+        }
+        response = self.client.post(URL_CMS_PLUGIN_MOVE, data)
+        api.publish_page(draft_page, self.super_user, "en")
+
+        live_page = draft_page.publisher_public
+        live_placeholder = live_page.placeholders.get(slot="col_left")
 
         with SettingsOverride(CMS_PERMISSION=False):
-            self.assertEqual(text_plugin_1.position, 0)
-            self.assertEqual(db_plugin_1.position, 0)
-            self.assertEqual(text_plugin_2.position, 1)
-            self.assertEqual(db_plugin_2.position, 1)
+            self.assertEqual(CMSPlugin.objects.get(pk=text_plugin_1.pk).position, 0)
+            self.assertEqual(CMSPlugin.objects.get(pk=text_plugin_2.pk).position, 1)
+            self.assertEqual(CMSPlugin.objects.get(pk=text_plugin_3.pk).position, 2)
+
             ## Finally we render the placeholder to test the actual content
-            rendered_placeholder = ph_en.render(self.get_context(page_en.get_absolute_url(), page=page_en), None)
-            self.assertEqual(rendered_placeholder, "I'm the firstI'm the second")
+            rendered_placeholder = placeholder.render(self.get_context(draft_page.get_absolute_url(), page=draft_page), None)
+            self.assertEqual(rendered_placeholder, "I'm the firstI'm the secondI'm the third")
+            rendered_live_placeholder = live_placeholder.render(self.get_context(live_page.get_absolute_url(), page=live_page), None)
+            self.assertEqual(rendered_live_placeholder, "I'm the firstI'm the secondI'm the third")
+
+
 
     def test_add_cancel_plugin(self):
         """


### PR DESCRIPTION
Refs #3637

When publishing a page, the draft plugins are copied to new 'live' versions of themselves. The code was incorrectly overwriting the position of the plugins. This change means the position remains identical to the position of the draft plugin, which is the only correct value.

This pull request is incomplete because it lacks a test case demonstrating that the issue exists as well as proving that this change fixes it. I've had challenges getting a test case to exercise the appropriate code paths since setting up the test data appears to require front-end editing and can't be triggered via the api as the current `test_plugin_order` does.