### PR TITLE
speed up travis build times by using pip-accel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,6 @@ env:
   global:
     - SAUCE_USERNAME=digi604
     - secure: NWiSBCHFB6LbTMget2qLIdqZlx0zeu3j+Y7Lsqb8kuYXyT2IUBGFVedcGWuGv/9Mzypb80EQWtVTokA3/3QIbesqr29uG95pMPHiYWLdnTO6UHcLMcNXiSzhBGdRDZ40iHSVv2dDHs4GNwGOH5+UCA0z3j7SWmChuFbNXh+Vsqw=
-    - PIP_ACCEL_S3_BUCKET=travisci.pip-cache.django-cms.org
-    - PIP_ACCEL_S3_PREFIX=travis
-    - secure: "ZGA13cE7KNq3toapVy8j5jfUHcaJkhbcFQTkMVn8XCmRnJOYUltFC7pagoR7u89jwdkgivknSTaMzwg6IQp3zUn4kMje1v3vKBqWvft6aK0Z3XTaUNWIrW7vAzZlrJsGnFajFxmgPpwZLXux79C9YE/MfMhtkvxmJDwPeIsUevc=" # AWS_ACCESS_KEY_ID
-    - secure: "pAOA0Lj+KYpJU8NeWEsxIETgPwTt1uULapDhiJAOUFMu1qH3uygwxNjD19N5CTPscyGMMmDIk3igYvrhW9w8PM8OgsoKcjoslZl/amLodF3+sYu9JYEid3O5raMT/gkXHQp06kV22co+x+nxUideeUQm33bMtVGGJbe+m+AZHok=" # AWS_SECRET_ACCESS_KEY
   matrix:
     - DJANGO=1.6 DATABASE_URL='sqlite://localhost/:memory:' SELENIUM=0
     - DJANGO=1.6 DATABASE_URL='mysql://root@127.0.0.1/djangocms_test' SELENIUM=0

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,4 +84,4 @@ matrix:
 
 cache:
   directories:
-    .pip-accel
+    $HOME/.pip-accel

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ env:
   global:
     - SAUCE_USERNAME=digi604
     - secure: NWiSBCHFB6LbTMget2qLIdqZlx0zeu3j+Y7Lsqb8kuYXyT2IUBGFVedcGWuGv/9Mzypb80EQWtVTokA3/3QIbesqr29uG95pMPHiYWLdnTO6UHcLMcNXiSzhBGdRDZ40iHSVv2dDHs4GNwGOH5+UCA0z3j7SWmChuFbNXh+Vsqw=
+    - PIP_ACCEL_S3_BUCKET=travisci.pip-cache.django-cms.org
+    - PIP_ACCEL_S3_PREFIX=travis
+    - secure: "ZGA13cE7KNq3toapVy8j5jfUHcaJkhbcFQTkMVn8XCmRnJOYUltFC7pagoR7u89jwdkgivknSTaMzwg6IQp3zUn4kMje1v3vKBqWvft6aK0Z3XTaUNWIrW7vAzZlrJsGnFajFxmgPpwZLXux79C9YE/MfMhtkvxmJDwPeIsUevc=" # AWS_ACCESS_KEY_ID
+    - secure: "pAOA0Lj+KYpJU8NeWEsxIETgPwTt1uULapDhiJAOUFMu1qH3uygwxNjD19N5CTPscyGMMmDIk3igYvrhW9w8PM8OgsoKcjoslZl/amLodF3+sYu9JYEid3O5raMT/gkXHQp06kV22co+x+nxUideeUQm33bMtVGGJbe+m+AZHok=" # AWS_SECRET_ACCESS_KEY
   matrix:
     - DJANGO=1.6 DATABASE_URL='sqlite://localhost/:memory:' SELENIUM=0
     - DJANGO=1.6 DATABASE_URL='mysql://root@127.0.0.1/djangocms_test' SELENIUM=0
@@ -33,10 +37,11 @@ before_script:
     fi"
 
 install:
-  - pip install -q -r "test_requirements/django-$DJANGO.txt"
-  - if [ $DATABASE_URL == 'postgres://postgres@127.0.0.1/djangocms_test' ]; then pip
+  - pip install 'pip-accel[s3]'
+  - pip-accel install -q -r "test_requirements/django-$DJANGO.txt"
+  - if [ $DATABASE_URL == 'postgres://postgres@127.0.0.1/djangocms_test' ]; then pip-accel
     install -q psycopg2 ; fi
-  - if [ $DATABASE_URL == 'mysql://root@127.0.0.1/djangocms_test' ]; then pip install
+  - if [ $DATABASE_URL == 'mysql://root@127.0.0.1/djangocms_test' ]; then pip-accel install
     -q mysql-python ; fi
 
 script: coverage run --rcfile=.coverage.rc develop.py test --migrate

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ env:
   global:
     - SAUCE_USERNAME=digi604
     - secure: NWiSBCHFB6LbTMget2qLIdqZlx0zeu3j+Y7Lsqb8kuYXyT2IUBGFVedcGWuGv/9Mzypb80EQWtVTokA3/3QIbesqr29uG95pMPHiYWLdnTO6UHcLMcNXiSzhBGdRDZ40iHSVv2dDHs4GNwGOH5+UCA0z3j7SWmChuFbNXh+Vsqw=
-    - AWS_ACCESS_KEY_ID_READONLY="AKIAIQ5HFADZDRR6K6OA"
-    - AWS_SECRET_ACCESS_KEY_READONLY="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"
   matrix:
     - DJANGO=1.6 DATABASE_URL='sqlite://localhost/:memory:' SELENIUM=0
     - DJANGO=1.6 DATABASE_URL='mysql://root@127.0.0.1/djangocms_test' SELENIUM=0
@@ -34,13 +32,8 @@ before_script:
     -e 'create database IF NOT EXISTS djangocms_test CHARACTER SET utf8 COLLATE utf8_general_ci;';
     fi"
     
-before_install:
-  - if [ -n "$AWS_ACCESS_KEY_ID_READWRITE" ]; then export AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID_READWRITE"; else export AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID_READONLY"; fi
-  - if [ -n "$AWS_SECRET_ACCESS_KEY_READWRITE" ]; then export AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY_READWRITE"; else export AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY_READONLY"; fi
-  - if [ -n "$AWS_SECRET_ACCESS_KEY_READWRITE" ]; then export PIP_ACCEL_S3_READONLY=""; else export PIP_ACCEL_S3_READONLY="true"; fi
-
 install:
-  - pip install 'pip-accel[s3]'
+  - pip install 'pip-accel'
   - pip-accel install -q -r "test_requirements/django-$DJANGO.txt"
   - if [ $DATABASE_URL == 'postgres://postgres@127.0.0.1/djangocms_test' ]; then pip-accel
     install -q psycopg2 ; fi
@@ -88,3 +81,7 @@ matrix:
       env: DJANGO=1.7 DATABASE_URL='mysql://root@127.0.0.1/djangocms_test' SELENIUM=0
 
   fast_finish: true
+
+cache:
+  directories:
+    .pip-accel

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ env:
   global:
     - SAUCE_USERNAME=digi604
     - secure: NWiSBCHFB6LbTMget2qLIdqZlx0zeu3j+Y7Lsqb8kuYXyT2IUBGFVedcGWuGv/9Mzypb80EQWtVTokA3/3QIbesqr29uG95pMPHiYWLdnTO6UHcLMcNXiSzhBGdRDZ40iHSVv2dDHs4GNwGOH5+UCA0z3j7SWmChuFbNXh+Vsqw=
+    - AWS_ACCESS_KEY_ID_READONLY="AKIAIQ5HFADZDRR6K6OA"
+    - AWS_SECRET_ACCESS_KEY_READONLY="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"
   matrix:
     - DJANGO=1.6 DATABASE_URL='sqlite://localhost/:memory:' SELENIUM=0
     - DJANGO=1.6 DATABASE_URL='mysql://root@127.0.0.1/djangocms_test' SELENIUM=0
@@ -31,6 +33,11 @@ before_script:
   - sh -c "if [ '$DATABASE_URL' = 'mysql://root@127.0.0.1/djangocms_test' ]; then mysql
     -e 'create database IF NOT EXISTS djangocms_test CHARACTER SET utf8 COLLATE utf8_general_ci;';
     fi"
+    
+before_install:
+  - if [ -n "$AWS_ACCESS_KEY_ID_READWRITE" ]; then export AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID_READWRITE"; else export AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID_READONLY"; fi
+  - if [ -n "$AWS_SECRET_ACCESS_KEY_READWRITE" ]; then export AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY_READWRITE"; else export AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY_READONLY"; fi
+  - if [ -n "$AWS_SECRET_ACCESS_KEY_READWRITE" ]; then export PIP_ACCEL_S3_READONLY=""; else export PIP_ACCEL_S3_READONLY="true"; fi
 
 install:
   - pip install 'pip-accel[s3]'


### PR DESCRIPTION
A few notes:

 * AWS S3 is used as the cache. When travis enables caching for
   free accounts, this dependency can be removed
 * it currently uses credentials for my personal AWS account. I'm
   fine with this as long as costs don't balloon. I'll keep an
   eye on it
 * build time of this PR isn't an indication of the speed-up, since
   the cache is empty