### PR TITLE
Send custom events when the structureboard is shown and hidden.

### DIFF
--- a/cms/static/cms/js/modules/cms.structureboard.js
+++ b/cms/static/cms/js/modules/cms.structureboard.js
@@ -295,6 +295,8 @@ $(document).ready(function () {
 			this.interval = setInterval(function () {
 				$(window).trigger('resize.sideframe');
 			}, interval);
+
+			$(window).trigger('structureboard_shown.sideframe');
 		},
 
 		_hideBoard: function () {
@@ -309,6 +311,8 @@ $(document).ready(function () {
 
 			// clear interval
 			clearInterval(this.interval);
+
+			$(window).trigger('structureboard_hidden.sideframe');
 		},
 
 		_resizeBoard: function () {


### PR DESCRIPTION
This allows websites to adapt by changing page styles for example, so that
all placeholders are visible. This is useful for rotators and other features
that hide parts of the page or place them offscreen.