### PR TITLE
Fixes missing add_sideframe_button method.

### DIFF
--- a/cms/toolbar/items.py
+++ b/cms/toolbar/items.py
@@ -451,6 +451,16 @@ class ButtonList(BaseItem):
         self.buttons.append(item)
         return item
 
+    def add_sideframe_button(self, name, url, active=False, disabled=False, extra_classes=None, on_close=URL_CHANGE):
+        item = SideframeButton(name, url,
+                      active=active,
+                      disabled=disabled,
+                      extra_classes=extra_classes,
+                      on_close=on_close,
+        )
+        self.buttons.append(item)
+        return item
+
     def get_context(self):
         return {
             'buttons': self.buttons,

--- a/cms/toolbar/items.py
+++ b/cms/toolbar/items.py
@@ -451,7 +451,7 @@ class ButtonList(BaseItem):
         self.buttons.append(item)
         return item
 
-    def add_sideframe_button(self, name, url, active=False, disabled=False, extra_classes=None, on_close=URL_CHANGE):
+    def add_sideframe_button(self, name, url, active=False, disabled=False, extra_classes=None, on_close=None):
         item = SideframeButton(name, url,
                       active=active,
                       disabled=disabled,


### PR DESCRIPTION
When trying to use the `CMSToolbar.add_sideframe_button()` method an exception is thrown because `add_sideframe_button()` is not implemented on `ButtonList()`.  This implements the missing method based on the pattern of the other methods in `ButtonList()`.