### PR TITLE
Add render_uncached_placeholder templatetag

### DIFF
--- a/cms/models/placeholdermodel.py
+++ b/cms/models/placeholdermodel.py
@@ -128,7 +128,7 @@ class Placeholder(models.Model):
     def has_delete_permission(self, request):
         return self._get_permission(request, 'delete')
 
-    def render(self, context, width, lang=None, editable=True):
+    def render(self, context, width, lang=None, editable=True, use_cache=True):
         '''
         Set editable = False to disable front-end rendering for this render.
         '''
@@ -138,7 +138,8 @@ class Placeholder(models.Model):
         width = width or self.default_width
         if width:
             context.update({'width': width})
-        return render_placeholder(self, context, lang=lang, editable=editable)
+        return render_placeholder(self, context, lang=lang, editable=editable,
+                                  use_cache=use_cache)
 
     def _get_attached_fields(self):
         """

--- a/cms/plugin_rendering.py
+++ b/cms/plugin_rendering.py
@@ -88,7 +88,8 @@ def render_plugins(plugins, context, placeholder, processors=None):
 
 
 def render_placeholder(placeholder, context_to_copy,
-        name_fallback="Placeholder", lang=None, default=None, editable=True):
+        name_fallback="Placeholder", lang=None, default=None, editable=True,
+        use_cache=True):
     """
     Renders plugins for a placeholder on the given page using shallow copies of the
     given context, and returns a string containing the rendered output.
@@ -127,7 +128,7 @@ def render_placeholder(placeholder, context_to_copy,
         processors = None
         edit = False
     from django.core.cache import cache
-    if get_cms_setting('PLACEHOLDER_CACHE'):
+    if get_cms_setting('PLACEHOLDER_CACHE') and use_cache:
         cache_key = placeholder.get_cache_key(lang)
         if not edit and placeholder and not hasattr(placeholder, 'cache_checked'):
             cached_value = cache.get(cache_key)
@@ -176,7 +177,7 @@ def render_placeholder(placeholder, context_to_copy,
     context['edit'] = edit
     result = render_to_string("cms/toolbar/content.html", context)
     changes = watcher.get_changes()
-    if placeholder and not edit and placeholder.cache_placeholder and get_cms_setting('PLACEHOLDER_CACHE'):
+    if placeholder and not edit and placeholder.cache_placeholder and get_cms_setting('PLACEHOLDER_CACHE') and use_cache:
         cache.set(cache_key, {'content': result, 'sekizai': changes}, get_cms_setting('CACHE_DURATIONS')['content'])
     context.pop()
     return result

--- a/cms/templatetags/cms_tags.py
+++ b/cms/templatetags/cms_tags.py
@@ -1120,6 +1120,7 @@ class RenderPlaceholder(AsTag):
         request = context.get('request', None)
         placeholder = kwargs.get('placeholder')
         width = kwargs.get('width')
+        nocache = kwargs.get('nocache', False)
         language = kwargs.get('language')
 
         if not request:
@@ -1129,7 +1130,8 @@ class RenderPlaceholder(AsTag):
         if not hasattr(request, 'placeholders'):
             request.placeholders = []
         request.placeholders.append(placeholder)
-        return safe(placeholder.render(context, width, lang=language, editable=editable))
+        return safe(placeholder.render(context, width, lang=language,
+                                       editable=editable, use_cache=not nocache))
 
     def get_value_for_context(self, context, **kwargs):
         return self._get_value(context, editable=False, **kwargs)
@@ -1139,6 +1141,20 @@ class RenderPlaceholder(AsTag):
 
 register.tag(RenderPlaceholder)
 
+
+class RenderPlaceholderUncached(RenderPlaceholder):
+    """
+    Uncached version of RenderPlaceholder
+    This templatetag will neither get the result from cache, nor will update
+    the cache value for the given placeholder
+    """
+    name = 'render_placeholder_uncached'
+
+    def _get_value(self, context, editable=True, **kwargs):
+        kwargs['nocache'] = True
+        return super(RenderPlaceholderUncached, self)._get_value(context, editable, **kwargs)
+
+register.tag(RenderPlaceholderUncached)
 
 NULL = object()
 

--- a/cms/templatetags/cms_tags.py
+++ b/cms/templatetags/cms_tags.py
@@ -1142,19 +1142,19 @@ class RenderPlaceholder(AsTag):
 register.tag(RenderPlaceholder)
 
 
-class RenderPlaceholderUncached(RenderPlaceholder):
+class RenderUncachedPlaceholder(RenderPlaceholder):
     """
     Uncached version of RenderPlaceholder
     This templatetag will neither get the result from cache, nor will update
     the cache value for the given placeholder
     """
-    name = 'render_placeholder_uncached'
+    name = 'render_uncached_placeholder'
 
     def _get_value(self, context, editable=True, **kwargs):
         kwargs['nocache'] = True
-        return super(RenderPlaceholderUncached, self)._get_value(context, editable, **kwargs)
+        return super(RenderUncachedPlaceholder, self)._get_value(context, editable, **kwargs)
 
-register.tag(RenderPlaceholderUncached)
+register.tag(RenderUncachedPlaceholder)
 
 NULL = object()
 

--- a/cms/tests/rendering.py
+++ b/cms/tests/rendering.py
@@ -13,9 +13,7 @@ from cms.plugin_rendering import render_plugins, PluginContext, render_placehold
 from cms.test_utils.project.placeholderapp.models import Example1
 from cms.test_utils.testcases import SettingsOverrideTestCase
 from cms.test_utils.util.context_managers import SettingsOverride, ChangeModel
-from cms.test_utils.util.fuzzy_int import FuzzyInt
 from cms.test_utils.util.mock import AttributeObject
-from cms.utils.compat import DJANGO_1_5
 
 TEMPLATE_NAME = 'tests/rendering/base.html'
 
@@ -271,7 +269,6 @@ class RenderingTestCase(SettingsOverrideTestCase):
             '<h1>%s</h1>' % render_uncached_placeholder_body,
             r
         )
-
         self.assertIn(
             '<h2></h2>',
             r
@@ -281,7 +278,6 @@ class RenderingTestCase(SettingsOverrideTestCase):
             '<h3>%s</h3>' % render_uncached_placeholder_body,
             r
         )
-
 
     def test_render_uncached_placeholder_tag_no_use_cache(self):
         """
@@ -294,16 +290,15 @@ class RenderingTestCase(SettingsOverrideTestCase):
 
         add_plugin(ex1.placeholder, u"TextPlugin", u"en", body=render_uncached_placeholder_body)
 
-        t = '{% load cms_tags %}<h1>{% render_uncached_placeholder ex1.placeholder %}</h1>'
+        template = '{% load cms_tags %}<h1>{% render_uncached_placeholder ex1.placeholder %}</h1>'
 
         cache_key = ex1.placeholder.get_cache_key(u"en")
         cache_value_before = cache.get(cache_key)
-        r = self.render(t, self.test_page, {'ex1': ex1})
+        self.render(template, self.test_page, {'ex1': ex1})
         cache_value_after = cache.get(cache_key)
 
         self.assertEqual(cache_value_before, cache_value_after)
         self.assertIsNone(cache_value_after)
-
 
     def test_render_placeholder_tag_use_cache(self):
         """
@@ -316,17 +311,16 @@ class RenderingTestCase(SettingsOverrideTestCase):
 
         add_plugin(ex1.placeholder, u"TextPlugin", u"en", body=render_placeholder_body)
 
-        t = '{% load cms_tags %}<h1>{% render_placeholder ex1.placeholder %}</h1>'
+        template = '{% load cms_tags %}<h1>{% render_placeholder ex1.placeholder %}</h1>'
 
         cache_key = ex1.placeholder.get_cache_key(u"en")
         cache_value_before = cache.get(cache_key)
-        r = self.render(t, self.test_page, {'ex1': ex1})
+        self.render(template, self.test_page, {'ex1': ex1})
         cache_value_after = cache.get(cache_key)
 
         self.assertNotEqual(cache_value_before, cache_value_after)
         self.assertIsNone(cache_value_before)
         self.assertIsNotNone(cache_value_after)
-
 
     def test_show_placeholder(self):
         """

--- a/cms/tests/rendering.py
+++ b/cms/tests/rendering.py
@@ -13,7 +13,9 @@ from cms.plugin_rendering import render_plugins, PluginContext, render_placehold
 from cms.test_utils.project.placeholderapp.models import Example1
 from cms.test_utils.testcases import SettingsOverrideTestCase
 from cms.test_utils.util.context_managers import SettingsOverride, ChangeModel
+from cms.test_utils.util.fuzzy_int import FuzzyInt
 from cms.test_utils.util.mock import AttributeObject
+from cms.utils.compat import DJANGO_1_5
 
 TEMPLATE_NAME = 'tests/rendering/base.html'
 
@@ -243,6 +245,88 @@ class RenderingTestCase(SettingsOverrideTestCase):
             '<h3>%s</h3>' % render_placeholder_body,
             r
         )
+
+    def test_render_uncached_placeholder_tag(self):
+        """
+        Tests the {% render_uncached_placeholder %} templatetag.
+        """
+        render_uncached_placeholder_body = "I'm the render uncached placeholder body"
+        ex1 = Example1(char_1="char_1", char_2="char_2", char_3="char_3",
+                       char_4="char_4")
+        ex1.save()
+
+        add_plugin(ex1.placeholder, u"TextPlugin", u"en", body=render_uncached_placeholder_body)
+
+        t = '''{% extends "base.html" %}
+{% load cms_tags %}
+
+{% block content %}
+<h1>{% render_uncached_placeholder ex1.placeholder %}</h1>
+<h2>{% render_uncached_placeholder ex1.placeholder as tempvar %}</h2>
+<h3>{{ tempvar }}</h3>
+{% endblock content %}
+'''
+        r = self.render(t, self.test_page, {'ex1': ex1})
+        self.assertIn(
+            '<h1>%s</h1>' % render_uncached_placeholder_body,
+            r
+        )
+
+        self.assertIn(
+            '<h2></h2>',
+            r
+        )
+
+        self.assertIn(
+            '<h3>%s</h3>' % render_uncached_placeholder_body,
+            r
+        )
+
+
+    def test_render_uncached_placeholder_tag_no_use_cache(self):
+        """
+        Tests that {% render_uncached_placeholder %} does not populate cache.
+        """
+        render_uncached_placeholder_body = "I'm the render uncached placeholder body"
+        ex1 = Example1(char_1="char_1", char_2="char_2", char_3="char_3",
+                       char_4="char_4")
+        ex1.save()
+
+        add_plugin(ex1.placeholder, u"TextPlugin", u"en", body=render_uncached_placeholder_body)
+
+        t = '{% load cms_tags %}<h1>{% render_uncached_placeholder ex1.placeholder %}</h1>'
+
+        cache_key = ex1.placeholder.get_cache_key(u"en")
+        cache_value_before = cache.get(cache_key)
+        r = self.render(t, self.test_page, {'ex1': ex1})
+        cache_value_after = cache.get(cache_key)
+
+        self.assertEqual(cache_value_before, cache_value_after)
+        self.assertIsNone(cache_value_after)
+
+
+    def test_render_placeholder_tag_use_cache(self):
+        """
+        Tests that {% render_placeholder %} populates cache.
+        """
+        render_placeholder_body = "I'm the render placeholder body"
+        ex1 = Example1(char_1="char_1", char_2="char_2", char_3="char_3",
+                       char_4="char_4")
+        ex1.save()
+
+        add_plugin(ex1.placeholder, u"TextPlugin", u"en", body=render_placeholder_body)
+
+        t = '{% load cms_tags %}<h1>{% render_placeholder ex1.placeholder %}</h1>'
+
+        cache_key = ex1.placeholder.get_cache_key(u"en")
+        cache_value_before = cache.get(cache_key)
+        r = self.render(t, self.test_page, {'ex1': ex1})
+        cache_value_after = cache.get(cache_key)
+
+        self.assertNotEqual(cache_value_before, cache_value_after)
+        self.assertIsNone(cache_value_before)
+        self.assertIsNotNone(cache_value_after)
+
 
     def test_show_placeholder(self):
         """


### PR DESCRIPTION
This templatetag is a version of `render_placeholder` which does not use cache, in a similar way to `show_placeholder`, `show_uncached_placeholder`