### PR TITLE
Fix copy plugins

### DIFF
--- a/cms/models/pluginmodel.py
+++ b/cms/models/pluginmodel.py
@@ -292,9 +292,8 @@ class CMSPlugin(with_metaclass(PluginModelBase, MPTTModel)):
             new_plugin._no_reorder = True
         new_plugin.save()
         if plugin_instance:
-            if plugin_instance.__class__ == CMSPlugin:
-                # get a new instance so references do not get mixed up
-                plugin_instance = CMSPlugin.objects.get(pk=plugin_instance.pk)
+            # get a new instance so references do not get mixed up
+            plugin_instance = plugin_instance.__class__.objects.get(pk=plugin_instance.pk)
             plugin_instance.pk = new_plugin.pk
             plugin_instance.id = new_plugin.pk
             plugin_instance.placeholder = target_placeholder

--- a/cms/models/pluginmodel.py
+++ b/cms/models/pluginmodel.py
@@ -262,6 +262,26 @@ class CMSPlugin(with_metaclass(PluginModelBase, MPTTModel)):
     def copy_plugin(self, target_placeholder, target_language, parent_cache, no_signals=False):
         """
         Copy this plugin and return the new plugin.
+
+        The logic of this method is the following:
+
+         # get a new generic plugin instance
+         # assign the position in the plugin tree
+         # save it to let mptt calculate the tree attributes
+         # then get a copy of the current plugin instance
+         # assign to it the id of the generic plugin instance above;
+           this will effectively change the generic plugin created above
+           into a concrete one
+         # copy the tree related attributes from the generic plugin to
+           the concrete one
+         # save the concrete plugin
+         # trigger the copy relations
+         # return the generic plugin instance
+
+        This copy logic is required because we don't know what the fields of
+        the real plugin are. By getting another instance of it at step 4 and
+        then overwriting its ID at step 5, the ORM will copy the custom
+        fields for us.
         """
         try:
             plugin_instance, cls = self.get_plugin_instance()

--- a/cms/tests/plugins.py
+++ b/cms/tests/plugins.py
@@ -478,7 +478,7 @@ class PluginsTestCase(PluginsTestBaseCase):
         mcol1 = self.reload(mcol1)
         self.assertEqual(mcol1.get_descendants().count(), 2)
 
-        with self.assertNumQueries(FuzzyInt(0, 200)):
+        with self.assertNumQueries(FuzzyInt(0, 207)):
             page_en.publish('en')
 
     def test_plugin_validation(self):

--- a/cms/tests/plugins.py
+++ b/cms/tests/plugins.py
@@ -49,7 +49,7 @@ from djangocms_link.forms import LinkForm
 from djangocms_link.models import Link
 from djangocms_picture.models import Picture
 from djangocms_text_ckeditor.models import Text
-from djangocms_text_ckeditor.utils import plugin_tags_to_id_list
+from djangocms_text_ckeditor.utils import plugin_tags_to_id_list, plugin_to_tag
 
 
 class DumbFixturePlugin(CMSPluginBase):
@@ -320,6 +320,63 @@ class PluginsTestCase(PluginsTestBaseCase):
         self.assertEqual(response.status_code, 200)
         txt = Text.objects.all()[0]
         self.assertEqual('&lt;script&gt;var bar="hacked"&lt;/script&gt;', txt.body)
+
+    def test_copy_plugins_method(self):
+        """
+        Test that CMSPlugin copy does not have side effects
+        """
+        # create some objects
+        page_en = api.create_page("CopyPluginTestPage (EN)", "nav_playground.html", "en")
+        page_de = api.create_page("CopyPluginTestPage (DE)", "nav_playground.html", "de")
+        ph_en = page_en.placeholders.get(slot="body")
+        ph_de = page_de.placeholders.get(slot="body")
+
+        # add the text plugin
+        text_plugin_en = api.add_plugin(ph_en, "TextPlugin", "en", body="Hello World")
+        self.assertEqual(text_plugin_en.pk, CMSPlugin.objects.all()[0].pk)
+
+        # add a *nested* link plugin
+        link_plugin_en = api.add_plugin(ph_en, "LinkPlugin", "en", target=text_plugin_en,
+                                        name="A Link", url="https://www.django-cms.org")
+        #
+        text_plugin_en.body += plugin_to_tag(link_plugin_en)
+        text_plugin_en.save()
+
+        # the call above to add a child makes a plugin reload required here.
+        text_plugin_en = self.reload(text_plugin_en)
+
+        # setup the plugins to copy
+        plugins = [text_plugin_en, link_plugin_en]
+        # save the old ids for check
+        old_ids = [plugin.pk for plugin in plugins]
+        new_plugins = []
+        plugins_ziplist = []
+        old_parent_cache = {}
+
+        # This is a stripped down version of cms.copy_plugins.copy_plugins_to
+        # to low-level testing the copy process
+        for plugin in plugins:
+            new_plugins.append(plugin.copy_plugin(ph_de, 'de', old_parent_cache))
+            plugins_ziplist.append((new_plugins[-1], plugin))
+
+        for idx, plugin in enumerate(plugins):
+            inst, _ = new_plugins[idx].get_plugin_instance()
+            new_plugins[idx] = inst
+            new_plugins[idx].post_copy(plugin, plugins_ziplist)
+
+        for idx, plugin in enumerate(plugins):
+            # original plugin instance reference should stay unmodified
+            self.assertEqual(old_ids[idx], plugin.pk)
+            # new plugin instance should be different from the original
+            self.assertNotEqual(new_plugins[idx], plugin.pk)
+
+            # text plugins (both old and new) should contain a reference
+            # to the link plugins
+            if plugin.plugin_type == 'TextPlugin':
+                self.assertTrue('link.png' in plugin.body)
+                self.assertTrue('plugin_obj_%s' % plugin.get_children()[0].pk in plugin.body)
+                self.assertTrue('link.png' in new_plugins[idx].body)
+                self.assertTrue('plugin_obj_%s' % new_plugins[idx].get_children()[0].pk in new_plugins[idx].body)
 
     def test_copy_plugins(self):
         """

--- a/cms/utils/copy_plugins.py
+++ b/cms/utils/copy_plugins.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
 
-
-def copy_plugins_to(plugin_list, to_placeholder, to_language=None, parent_plugin_id=None, no_signals=False):
+def copy_plugins_to(plugin_list, to_placeholder, to_language=None, parent_plugin_id=None,
+                    no_signals=False):
     """
     Copies a list of plugins to a placeholder to a language.
     """
@@ -17,9 +17,10 @@ def copy_plugins_to(plugin_list, to_placeholder, to_language=None, parent_plugin
             plugin_language = to_language
         else:
             plugin_language = old_plugin.language
-            # do the simple copying
 
-        new_plugin = old_plugin.copy_plugin(to_placeholder, plugin_language, old_parent_cache, no_signals=no_signals)
+        # do the simple copying
+        new_plugin = old_plugin.copy_plugin(to_placeholder, plugin_language, old_parent_cache,
+                                            no_signals=no_signals)
         if first:
             first = False
             if parent_plugin_id:
@@ -28,11 +29,13 @@ def copy_plugins_to(plugin_list, to_placeholder, to_language=None, parent_plugin
                     new_plugin.move_to(target=CMSPlugin.objects.get(pk=parent_plugin_id))
                     new_plugin = CMSPlugin.objects.get(pk=new_plugin.pk)
         plugins_ziplist.append((new_plugin, old_plugin))
-        # this magic is needed for advanced plugins like Text Plugins that can have
+
+    # this magic is needed for advanced plugins like Text Plugins that can have
     # nested plugins and need to update their content based on the new plugins.
     for new_plugin, old_plugin in plugins_ziplist:
         new_instance = new_plugin.get_plugin_instance()[0]
         if new_instance:
             new_instance.post_copy(old_plugin, plugins_ziplist)
-        # returns information about originals and copies
+
+    # returns information about originals and copies
     return plugins_ziplist


### PR DESCRIPTION
the low level method `CMSPlugin.copy_plugin` messes up the reference to the old plugin changing it to the new one
This has no consequence if the old plugin instance is not "reused", but it may affect lower level use (like in blueprint)