### PR TITLE
delay importing models in commands to prevent circular imports

### DIFF
--- a/cms/management/commands/subcommands/check.py
+++ b/cms/management/commands/subcommands/check.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from cms.utils.check import FileOutputWrapper, check
 from django.core.management.base import NoArgsCommand, CommandError
 
 
@@ -7,5 +6,6 @@ class CheckInstallation(NoArgsCommand):
     help = 'Checks your settings and environment'
 
     def handle_noargs(self, **options):
+        from cms.utils.check import FileOutputWrapper, check
         if not check(FileOutputWrapper(self.stdout, self.stderr)):
             raise CommandError()

--- a/cms/management/commands/subcommands/copy_lang.py
+++ b/cms/management/commands/subcommands/copy_lang.py
@@ -3,8 +3,6 @@ from django.conf import settings
 
 from django.core.management.base import BaseCommand, CommandError
 
-from cms.api import copy_plugins_to_language
-from cms.models import Page, StaticPlaceholder, EmptyTitle
 from cms.utils.copy_plugins import copy_plugins_to
 from cms.utils.i18n import get_language_list
 
@@ -14,6 +12,8 @@ class CopyLangCommand(BaseCommand):
     help = u'duplicate the cms content from one lang to another (to boot a new lang) using draft pages'
 
     def handle(self, *args, **kwargs):
+        from cms.api import copy_plugins_to_language
+        from cms.models import Page, StaticPlaceholder, EmptyTitle
         verbose = 'verbose' in args
         only_empty = 'force-copy' not in args
         site = [arg.split("=")[1] for arg in args if arg.startswith("site")]

--- a/cms/management/commands/subcommands/list.py
+++ b/cms/management/commands/subcommands/list.py
@@ -1,14 +1,12 @@
 # -*- coding: utf-8 -*-
 from cms.management.commands.subcommands.base import SubcommandsCommand
-from cms.models import Page
-from cms.models.pluginmodel import CMSPlugin
-from cms.plugin_pool import plugin_pool
 from django.core.management.base import NoArgsCommand
 
 class ListApphooksCommand(NoArgsCommand):
     
     help = 'Lists all apphooks in pages'
     def handle_noargs(self, **options):
+        from cms.models import Page
         urls = Page.objects.filter(application_urls__gt='').values_list("application_urls", flat=True)
         for url in urls:
             self.stdout.write(u'%s\n' % url)
@@ -23,6 +21,8 @@ def plugin_report():
     #         'unsaved_instances': those with no corresponding model instance,
     #     },
     # ]
+    from cms.plugin_pool import plugin_pool
+    from cms.models.pluginmodel import CMSPlugin
     plugin_report = []
     all_plugins = CMSPlugin.objects.order_by("plugin_type")
     plugin_types = list(set(all_plugins.values_list("plugin_type", flat=True)))
@@ -56,6 +56,7 @@ class ListPluginsCommand(NoArgsCommand):
 
     help = 'Lists all plugins in CMSPlugin'
     def handle_noargs(self, **options):
+        from cms.models.pluginmodel import CMSPlugin
         self.stdout.write(u"==== Plugin report ==== \n\n")
         self.stdout.write(u"There are %s plugin types in your database \n" % len(plugin_report()))
         for plugin in plugin_report():   

--- a/cms/management/commands/subcommands/moderator.py
+++ b/cms/management/commands/subcommands/moderator.py
@@ -2,8 +2,6 @@
 from logging import getLogger
 
 from cms.management.commands.subcommands.base import SubcommandsCommand
-from cms.models import CMSPlugin, Title
-from cms.models.pagemodel import Page
 from django.core.management.base import NoArgsCommand
 
 
@@ -25,6 +23,8 @@ class ModeratorOnCommand(NoArgsCommand):
         have the same plugins listed. If both versions exist and have content,
         the public page has precedence. Otherwise, the draft version is used.
         """
+        from cms.models import CMSPlugin, Title
+        from cms.models.pagemodel import Page
         log.info('Reverting drafts to public versions')
         for page in Page.objects.public():
             for language in page.get_languages():

--- a/cms/management/commands/subcommands/mptt.py
+++ b/cms/management/commands/subcommands/mptt.py
@@ -1,4 +1,3 @@
-from cms.models import Page, CMSPlugin
 from django.core.management.base import NoArgsCommand
 
 
@@ -9,6 +8,7 @@ class FixMPTTCommand(NoArgsCommand):
         """
         Repairs the MPTT tree
         """
+        from cms.models import Page, CMSPlugin
         self.stdout.write(u"fixing mptt page tree")
         Page._tree_manager.rebuild()
         last = None

--- a/cms/management/commands/subcommands/uninstall.py
+++ b/cms/management/commands/subcommands/uninstall.py
@@ -3,9 +3,6 @@ from django.core.management.base import LabelCommand
 from django.utils.six.moves import input
 
 from cms.management.commands.subcommands.base import SubcommandsCommand
-from cms.models import Page
-from cms.models.pluginmodel import CMSPlugin
-from cms.plugin_pool import plugin_pool
 
 
 class UninstallApphooksCommand(LabelCommand):
@@ -14,6 +11,7 @@ class UninstallApphooksCommand(LabelCommand):
     help = 'Uninstalls (sets to null) specified apphooks for all pages'
 
     def handle_label(self, label, **options):
+        from cms.models import Page
         queryset = Page.objects.filter(application_urls=label)
         number_of_apphooks = queryset.count()
 
@@ -38,6 +36,8 @@ class UninstallPluginsCommand(LabelCommand):
     help = 'Uninstalls (deletes) specified plugins from the CMSPlugin model'
 
     def handle_label(self, label, **options):
+        from cms.models.pluginmodel import CMSPlugin
+        from cms.plugin_pool import plugin_pool
         plugin_pool.get_all_plugins()
         queryset = CMSPlugin.objects.filter(plugin_type=label)
         number_of_plugins = queryset.count()


### PR DESCRIPTION
A combination of a custom user model and https://github.com/justquick/django-activity-stream (with django-activity-stream used in the ``models.py`` which defines the custom user model) appears to cause circular imports when hitting cms commands. As a hotfix, this PR delays all model imports in cms commands until as late as possible.

This appears to be triggered by bugs in 3rd party libraries, but since it can be hotfixed in our codebase, it should until a solution can be found.