### PR TITLE
resolve divio/django-cms#3725: move load jstree *after* cms js libs

### DIFF
--- a/cms/templates/admin/cms/page/tree/base.html
+++ b/cms/templates/admin/cms/page/tree/base.html
@@ -29,13 +29,13 @@
 {{ block.super }}
 {% block jquery %}<script src="{% static "cms/js/libs/jquery.min.js" %}" type="text/javascript"></script>{% endblock jquery %}
 <script src="{% static "cms/js/libs/class.min.js" %}" type="text/javascript"></script>
-<!-- load jstree -->
-<script src="{% static "cms/js/jstree/_lib/_all.js" %}" type="text/javascript"></script>
-<script src="{% static "cms/js/jstree/tree_component.js" %}" type="text/javascript"></script>
 <!-- load changelist -->
 <script src="{% static "cms/js/modules/jquery.ui.custom.js" %}" type="text/javascript"></script>
 <script src="{% static "cms/js/modules/cms.base.js" %}" type="text/javascript"></script>
 <script src="{% static "cms/js/modules/cms.changelist.js" %}" type="text/javascript"></script>
+<!-- load jstree -->
+<script src="{% static "cms/js/jstree/_lib/_all.js" %}" type="text/javascript"></script>
+<script src="{% static "cms/js/jstree/tree_component.js" %}" type="text/javascript"></script>
 <script>
 (function($) {
 // CMS.$ will be passed for $


### PR DESCRIPTION
resolve divio/django-cms#3725: move load jstree *after* cms js libs to fix jQuery undefined issue with 3rd party packages.