### PR TITLE
Emailuserapp shouldn't be in the list of apps

### DIFF
--- a/develop.py
+++ b/develop.py
@@ -191,7 +191,7 @@ def makemigrations(migrate_plugins=True, merge=False, squash=False):
         'cms', 'menus',
         # testing applications
         'meta', 'manytomany_rel', 'fileapp', 'placeholderapp', 'sampleapp', 'fakemlng', 'one_thing', 'extensionapp',
-        'objectpermissionsapp', 'bunch_of_plugins', 'emailuserapp'
+        'objectpermissionsapp', 'bunch_of_plugins',
     ]
     if migrate_plugins:
         applications.extend([

--- a/develop.py
+++ b/develop.py
@@ -193,6 +193,8 @@ def makemigrations(migrate_plugins=True, merge=False, squash=False):
         'meta', 'manytomany_rel', 'fileapp', 'placeholderapp', 'sampleapp', 'fakemlng', 'one_thing', 'extensionapp',
         'objectpermissionsapp', 'bunch_of_plugins',
     ]
+    if os.environ.get("AUTH_USER_MODEL") == "emailuserapp.EmailUser":
+        applications.append('emailuserapp')
     if migrate_plugins:
         applications.extend([
             # official plugins


### PR DESCRIPTION
If you want to run makemigrations for emailuserapp do this:

    AUTH_USER_MODEL='emailuserapp.EmailUser' python develop.py makemigrations