### PR TITLE
Fix command block in plugins.html

### DIFF
--- a/docs/introduction/plugins.rst
+++ b/docs/introduction/plugins.rst
@@ -183,7 +183,7 @@ something like this::
         <input type="submit" value="Vote" />
     </form>
 
-Now add ``djangocms_polls`` to ``INSTALLED_APPS`` and create a database migration to add the plugin table (using South):
+Now add ``djangocms_polls`` to ``INSTALLED_APPS`` and create a database migration to add the plugin table (using South)::
 
     python manage.py schemamigration polls_plugin --init
     python manage.py migrate polls_plugin


### PR DESCRIPTION
Without the second ':' both lines appear as one, and '--init' as '-init' which can cause confusion because passing '-init' will result in an error message.