### PR TITLE
plugin: add text_editor_button_icon method

### DIFF
--- a/docs/reference/plugins.rst
+++ b/docs/reference/plugins.rst
@@ -276,6 +276,28 @@ The default implementation is as follows::
 
 See also: `text_enabled`_, `icon_src`_
 
+text_editor_button_icon
+-----------------------
+
+When `text_enabled`_ is ``True``, this plugin can be added in a text editor and
+there might be an icon button for that purpose. This method allows to override
+this icon.
+
+By default, it returns ``None`` and each text editor plugin may have its own
+fallback icon.
+
+:meth:`text_editor_button_icon` takes 2 arguments:
+
+* ``editor_name``: The plugin name of the text editor
+* ``icon_context``: A dictionary containing information about the needed icon
+  like `width`, `height`, `theme`, etc
+
+Usualy this method should return the icon url. But, it may depends on the text
+editor because what is needed may differ. Please consult the documentation of
+your text editor plugin.
+
+See also: `text_enabled`_
+
 .. _get_extra_placeholder_menu_items:
 
 get_extra_placeholder_menu_items


### PR DESCRIPTION
This pull request follows divio/djangocms-text-ckeditor#197 .

It defines a way for a text enabled plugin to provide an button icon for text editors. If the idea is ok, I'll finish the pull request divio/djangocms-text-ckeditor#197 and add required code in django-cms.