### PR TITLE
Add render_uncached_placeholder templatetag

### DIFF
--- a/cms/templatetags/cms_tags.py
+++ b/cms/templatetags/cms_tags.py
@@ -1176,6 +1176,20 @@ class RenderPlaceholder(AsTag):
 register.tag(RenderPlaceholder)
 
 
+class RenderPlaceholderUncached(RenderPlaceholder):
+    """
+    Uncached version of RenderPlaceholder
+    This templatetag will neither get the result from cache, nor will update
+    the cache value for the given placeholder
+    """
+    name = 'render_placeholder_uncached'
+
+    def _get_value(self, context, editable=True, **kwargs):
+        kwargs['nocache'] = True
+        return super(RenderPlaceholderUncached, self)._get_value(context, editable, **kwargs)
+
+register.tag(RenderPlaceholderUncached)
+
 NULL = object()
 
 

--- a/cms/templatetags/cms_tags.py
+++ b/cms/templatetags/cms_tags.py
@@ -1176,19 +1176,19 @@ class RenderPlaceholder(AsTag):
 register.tag(RenderPlaceholder)
 
 
-class RenderPlaceholderUncached(RenderPlaceholder):
+class RenderUncachedPlaceholder(RenderPlaceholder):
     """
     Uncached version of RenderPlaceholder
     This templatetag will neither get the result from cache, nor will update
     the cache value for the given placeholder
     """
-    name = 'render_placeholder_uncached'
+    name = 'render_uncached_placeholder'
 
     def _get_value(self, context, editable=True, **kwargs):
         kwargs['nocache'] = True
-        return super(RenderPlaceholderUncached, self)._get_value(context, editable, **kwargs)
+        return super(RenderUncachedPlaceholder, self)._get_value(context, editable, **kwargs)
 
-register.tag(RenderPlaceholderUncached)
+register.tag(RenderUncachedPlaceholder)
 
 NULL = object()
 

--- a/cms/tests/rendering.py
+++ b/cms/tests/rendering.py
@@ -246,6 +246,88 @@ class RenderingTestCase(CMSTestCase):
             r
         )
 
+    def test_render_uncached_placeholder_tag(self):
+        """
+        Tests the {% render_uncached_placeholder %} templatetag.
+        """
+        render_uncached_placeholder_body = "I'm the render uncached placeholder body"
+        ex1 = Example1(char_1="char_1", char_2="char_2", char_3="char_3",
+                       char_4="char_4")
+        ex1.save()
+
+        add_plugin(ex1.placeholder, u"TextPlugin", u"en", body=render_uncached_placeholder_body)
+
+        t = '''{% extends "base.html" %}
+{% load cms_tags %}
+
+{% block content %}
+<h1>{% render_uncached_placeholder ex1.placeholder %}</h1>
+<h2>{% render_uncached_placeholder ex1.placeholder as tempvar %}</h2>
+<h3>{{ tempvar }}</h3>
+{% endblock content %}
+'''
+        r = self.render(t, self.test_page, {'ex1': ex1})
+        self.assertIn(
+            '<h1>%s</h1>' % render_uncached_placeholder_body,
+            r
+        )
+
+        self.assertIn(
+            '<h2></h2>',
+            r
+        )
+
+        self.assertIn(
+            '<h3>%s</h3>' % render_uncached_placeholder_body,
+            r
+        )
+
+
+    def test_render_uncached_placeholder_tag_no_use_cache(self):
+        """
+        Tests that {% render_uncached_placeholder %} does not populate cache.
+        """
+        render_uncached_placeholder_body = "I'm the render uncached placeholder body"
+        ex1 = Example1(char_1="char_1", char_2="char_2", char_3="char_3",
+                       char_4="char_4")
+        ex1.save()
+
+        add_plugin(ex1.placeholder, u"TextPlugin", u"en", body=render_uncached_placeholder_body)
+
+        t = '{% load cms_tags %}<h1>{% render_uncached_placeholder ex1.placeholder %}</h1>'
+
+        cache_key = ex1.placeholder.get_cache_key(u"en")
+        cache_value_before = cache.get(cache_key)
+        r = self.render(t, self.test_page, {'ex1': ex1})
+        cache_value_after = cache.get(cache_key)
+
+        self.assertEqual(cache_value_before, cache_value_after)
+        self.assertIsNone(cache_value_after)
+
+
+    def test_render_placeholder_tag_use_cache(self):
+        """
+        Tests that {% render_placeholder %} populates cache.
+        """
+        render_placeholder_body = "I'm the render placeholder body"
+        ex1 = Example1(char_1="char_1", char_2="char_2", char_3="char_3",
+                       char_4="char_4")
+        ex1.save()
+
+        add_plugin(ex1.placeholder, u"TextPlugin", u"en", body=render_placeholder_body)
+
+        t = '{% load cms_tags %}<h1>{% render_placeholder ex1.placeholder %}</h1>'
+
+        cache_key = ex1.placeholder.get_cache_key(u"en")
+        cache_value_before = cache.get(cache_key)
+        r = self.render(t, self.test_page, {'ex1': ex1})
+        cache_value_after = cache.get(cache_key)
+
+        self.assertNotEqual(cache_value_before, cache_value_after)
+        self.assertIsNone(cache_value_before)
+        self.assertIsNotNone(cache_value_after)
+
+
     def test_show_placeholder(self):
         """
         Tests the {% show_placeholder %} templatetag, using lookup by pk/dict/reverse_id and passing a Page object.

--- a/cms/tests/rendering.py
+++ b/cms/tests/rendering.py
@@ -271,7 +271,6 @@ class RenderingTestCase(CMSTestCase):
             '<h1>%s</h1>' % render_uncached_placeholder_body,
             r
         )
-
         self.assertIn(
             '<h2></h2>',
             r
@@ -281,7 +280,6 @@ class RenderingTestCase(CMSTestCase):
             '<h3>%s</h3>' % render_uncached_placeholder_body,
             r
         )
-
 
     def test_render_uncached_placeholder_tag_no_use_cache(self):
         """
@@ -294,16 +292,15 @@ class RenderingTestCase(CMSTestCase):
 
         add_plugin(ex1.placeholder, u"TextPlugin", u"en", body=render_uncached_placeholder_body)
 
-        t = '{% load cms_tags %}<h1>{% render_uncached_placeholder ex1.placeholder %}</h1>'
+        template = '{% load cms_tags %}<h1>{% render_uncached_placeholder ex1.placeholder %}</h1>'
 
         cache_key = ex1.placeholder.get_cache_key(u"en")
         cache_value_before = cache.get(cache_key)
-        r = self.render(t, self.test_page, {'ex1': ex1})
+        self.render(template, self.test_page, {'ex1': ex1})
         cache_value_after = cache.get(cache_key)
 
         self.assertEqual(cache_value_before, cache_value_after)
         self.assertIsNone(cache_value_after)
-
 
     def test_render_placeholder_tag_use_cache(self):
         """
@@ -316,17 +313,16 @@ class RenderingTestCase(CMSTestCase):
 
         add_plugin(ex1.placeholder, u"TextPlugin", u"en", body=render_placeholder_body)
 
-        t = '{% load cms_tags %}<h1>{% render_placeholder ex1.placeholder %}</h1>'
+        template = '{% load cms_tags %}<h1>{% render_placeholder ex1.placeholder %}</h1>'
 
         cache_key = ex1.placeholder.get_cache_key(u"en")
         cache_value_before = cache.get(cache_key)
-        r = self.render(t, self.test_page, {'ex1': ex1})
+        self.render(template, self.test_page, {'ex1': ex1})
         cache_value_after = cache.get(cache_key)
 
         self.assertNotEqual(cache_value_before, cache_value_after)
         self.assertIsNone(cache_value_before)
         self.assertIsNotNone(cache_value_after)
-
 
     def test_show_placeholder(self):
         """

--- a/docs/reference/templatetags.rst
+++ b/docs/reference/templatetags.rst
@@ -157,7 +157,7 @@ render_uncached_placeholder
 ===========================
 
 The same as :ttag:`render_placeholder`, but the placeholder contents will not be
-cached taken from the cache.
+cached or taken from the cache.
 
 Arguments:
 

--- a/docs/reference/templatetags.rst
+++ b/docs/reference/templatetags.rst
@@ -110,7 +110,7 @@ Example::
     {% static_placeholder "footer" site or %}There is no content.{% endstatic_placeholder %}
 
 
-.. templatetag:: show_placeholder
+.. templatetag:: render_placeholder
 
 render_placeholder
 ==================
@@ -124,6 +124,10 @@ The :ttag:`render_placeholder` tag takes the following parameters:
 * ``width`` parameter for context sensitive plugins (optional)
 * ``language`` keyword plus ``language-code`` string to render content in the
   specified language (optional)
+* ``language`` keyword plus ``language-code`` string to render content in the
+  specified language (optional)
+* ``as`` keyword followed by ``varname`` (optional): the templatetag output can
+  be saved as a context variable for later use.
 
 
 The following example renders the my_placeholder field from the mymodel_instance and will render
@@ -147,7 +151,29 @@ only the english plugins:
     When used in this manner, the placeholder will not be displayed for
     editing when the CMS is in edit mode.
 
+.. templatetag:: render_uncached_placeholder
 
+render_uncached_placeholder
+===========================
+
+The same as :ttag:`render_placeholder`, but the placeholder contents will not be
+cached taken from the cache.
+
+Arguments:
+
+* :class:`~cms.models.fields.PlaceholderField` instance
+* ``width`` parameter for context sensitive plugins (optional)
+* ``language`` keyword plus ``language-code`` string to render content in the
+  specified language (optional)
+* ``as`` keyword followed by ``varname`` (optional): the templatetag output can
+  be saved as a context variable for later use.
+
+Example::
+
+    {% render_uncached_placeholder mymodel_instance.my_placeholder language 'en' %}
+
+
+.. templatetag:: show_placeholder
 
 show_placeholder
 ================
@@ -168,6 +194,29 @@ Examples::
     {% show_placeholder "footer" "footer_container_page" %}
     {% show_placeholder "content" request.current_page.parent_id %}
     {% show_placeholder "teaser" request.current_page.get_root %}
+
+
+.. templatetag:: show_uncached_placeholder
+
+show_uncached_placeholder
+=========================
+
+The same as :ttag:`show_placeholder`, but the placeholder contents will not be
+cached or taken from the cache.
+
+Arguments:
+
+- ``placeholder_name``
+- ``page_lookup`` (see `page_lookup`_ for more information)
+- ``language`` (optional)
+- ``site`` (optional)
+
+Example::
+
+    {% show_uncached_placeholder "footer" "footer_container_page" %}
+
+
+.. templatetag:: page_lookup
 
 page_lookup
 ===========
@@ -208,25 +257,6 @@ inherit the content of its root-level ancestor::
         {% show_placeholder "teaser" request.current_page.get_root %}
     {% endplaceholder %}
 
-
-.. templatetag:: show_uncached_placeholder
-
-show_uncached_placeholder
-=========================
-
-The same as :ttag:`show_placeholder`, but the placeholder contents will not be
-cached.
-
-Arguments:
-
-- ``placeholder_name``
-- ``page_lookup`` (see `page_lookup`_ for more information)
-- ``language`` (optional)
-- ``site`` (optional)
-
-Example::
-
-    {% show_uncached_placeholder "footer" "footer_container_page" %}
 
 .. templatetag:: page_url
 


### PR DESCRIPTION
This templatetag is a version of `render_placeholder` which does not use cache, in a similar way to `show_placeholder`, `show_uncached_placeholder`