### PR TITLE
Removed deprecated method on CMSToolbarLoginForm.

### DIFF
--- a/cms/toolbar/toolbar.py
+++ b/cms/toolbar/toolbar.py
@@ -26,8 +26,6 @@ class CMSToolbarLoginForm(AuthenticationForm):
         kwargs['prefix'] = kwargs.get('prefix', 'cms')
         super(CMSToolbarLoginForm, self).__init__(*args, **kwargs)
 
-    def check_for_test_cookie(self): pass  # for some reason this test fails in our case. but login works.
-
 
 class CMSToolbar(ToolbarAPIMixin):
     """
@@ -292,4 +290,3 @@ class CMSToolbar(ToolbarAPIMixin):
                 result = getattr(toolbar, func_name)()
                 if isinstance(result, HttpResponse):
                     return result
-


### PR DESCRIPTION
This method is a no-op in Django 1.6 and removed in 1.7.