### PR TITLE
hide all submit-rows in cms.modal.js

### DIFF
--- a/cms/static/cms/js/modules/cms.modal.js
+++ b/cms/static/cms/js/modules/cms.modal.js
@@ -464,7 +464,8 @@ $(document).ready(function () {
 			} else {
 				row = iframe.contents().find('.save-box:eq(0)');
 			}
-			row.hide(); // hide submit-row
+			// hide all submit-rows
+			iframe.contents().find('.submit-row').hide();
 			var buttons = row.find('input, a, button');
 			var render = $('<span />'); // seriously jquery...
 


### PR DESCRIPTION
As buttons are added to the CMS interface, all submit-rows provided by the changeform should be hidden, not only the first one (e.g. when save-on-top is active).
I guess my proposal should be reviewed by someone familiar with django-suit.