### PR TITLE
Fix title reversion

### DIFF
--- a/cms/models/titlemodels.py
+++ b/cms/models/titlemodels.py
@@ -131,4 +131,13 @@ class EmptyTitle(object):
         return None
 
 
-reversion_register(Title)
+def _reversion():
+    exclude_fields = ['publisher_is_draft', 'publisher_public', 'publisher_state']
+
+    reversion_register(
+        Title,
+        exclude_fields=exclude_fields
+    )
+
+
+_reversion()


### PR DESCRIPTION
Publisher attributes must not be included in reversion data
Fix #3823