### PR TITLE
Fix permission detection on placeholders

### DIFF
--- a/cms/plugin_rendering.py
+++ b/cms/plugin_rendering.py
@@ -105,7 +105,8 @@ def render_placeholder(placeholder, context_to_copy,
     request = context['request']
     if not hasattr(request, 'placeholders'):
         request.placeholders = []
-    request.placeholders.append(placeholder)
+    if placeholder.has_change_permission(request):
+        request.placeholders.append(placeholder)
     if hasattr(placeholder, 'content_cache'):
         return mark_safe(placeholder.content_cache)
     page = placeholder.page if placeholder else None

--- a/cms/templatetags/cms_tags.py
+++ b/cms/templatetags/cms_tags.py
@@ -1124,7 +1124,8 @@ class RenderPlaceholder(AsTag):
             return ''
         if not hasattr(request, 'placeholders'):
             request.placeholders = []
-        request.placeholders.append(placeholder)
+        if placeholder.has_change_permission(request):
+            request.placeholders.append(placeholder)
         return safe(placeholder.render(context, width, lang=language, editable=editable))
 
     def get_value_for_context(self, context, **kwargs):

--- a/cms/tests/admin.py
+++ b/cms/tests/admin.py
@@ -1426,7 +1426,7 @@ class AdminFormsTests(AdminTestsBase):
             with self.assertNumQueries(FuzzyInt(40, 60)):
                 output = force_unicode(self.client.get('/en/?%s' % get_cms_setting('CMS_TOOLBAR_URL__EDIT_ON')).content)
             self.assertIn('<b>Test</b>', output)
-        with self.assertNumQueries(FuzzyInt(18, 46)):
+        with self.assertNumQueries(FuzzyInt(18, 48)):
             force_unicode(self.client.get('/en/?%s' % get_cms_setting('CMS_TOOLBAR_URL__EDIT_ON')).content)
         with self.assertNumQueries(FuzzyInt(12, 30)):
             force_unicode(self.client.get('/en/').content)

--- a/cms/tests/admin.py
+++ b/cms/tests/admin.py
@@ -1426,9 +1426,9 @@ class AdminFormsTests(AdminTestsBase):
             with self.assertNumQueries(FuzzyInt(40, 60)):
                 output = force_unicode(self.client.get('/en/?%s' % get_cms_setting('CMS_TOOLBAR_URL__EDIT_ON')).content)
             self.assertIn('<b>Test</b>', output)
-        with self.assertNumQueries(FuzzyInt(18, 34)):
+        with self.assertNumQueries(FuzzyInt(18, 46)):
             force_unicode(self.client.get('/en/?%s' % get_cms_setting('CMS_TOOLBAR_URL__EDIT_ON')).content)
-        with self.assertNumQueries(FuzzyInt(12, 14)):
+        with self.assertNumQueries(FuzzyInt(12, 30)):
             force_unicode(self.client.get('/en/').content)
 
     def test_tree_view_queries(self):

--- a/cms/tests/cache.py
+++ b/cms/tests/cache.py
@@ -112,9 +112,10 @@ class CacheTestCase(CMSTestCase):
         rctx = RequestContext(request)
         with self.assertNumQueries(4):
             render2 = template.render(rctx)
-        with self.assertNumQueries(FuzzyInt(9, 13)):
-            response = self.client.get('/en/')
-            resp2 = response.content.decode('utf8').split("$$$")[1]
+        with self.settings(CMS_PAGE_CACHE=False):
+            with self.assertNumQueries(FuzzyInt(9, 13)):
+                response = self.client.get('/en/')
+                resp2 = response.content.decode('utf8').split("$$$")[1]
         self.assertNotEqual(render, render2)
         self.assertNotEqual(resp1, resp2)
 

--- a/cms/tests/placeholder.py
+++ b/cms/tests/placeholder.py
@@ -822,6 +822,121 @@ class PlaceholderModelTests(CMSTestCase):
         result = force_unicode(ph)
         self.assertEqual(result, u'test')
 
+    def test_request_placeholders_permission_check_model(self):
+        # Setup instance
+        ex = Example1(
+            char_1='one',
+            char_2='two',
+            char_3='tree',
+            char_4='four'
+        )
+        ex.save()
+        page_en = create_page('page_en', 'col_two.html', 'en')
+
+        class NoPushPopContext(SekizaiContext):
+            def push(self):
+                pass
+
+            pop = push
+
+        context_en = NoPushPopContext()
+
+        # request.placeholders is populated for superuser
+        context_en['request'] = self.get_request(language="en", page=page_en)
+        context_en['request'].user = self.get_superuser()
+        render_placeholder(ex.placeholder, context_en)
+        self.assertEqual(len(context_en['request'].placeholders), 1)
+        self.assertIn(ex.placeholder, context_en['request'].placeholders)
+
+        # request.placeholders is not populated for staff user with no permission
+        user = self.get_staff_user_with_no_permissions()
+        context_en['request'] = self.get_request(language="en", page=page_en)
+        context_en['request'].user = user
+        render_placeholder(ex.placeholder, context_en)
+        self.assertEqual(len(context_en['request'].placeholders), 0)
+        self.assertNotIn(ex.placeholder, context_en['request'].placeholders)
+
+        # request.placeholders is populated for staff user with permission on the model
+        user.user_permissions.add(Permission.objects.get(codename='change_example1'))
+        context_en['request'] = self.get_request(language="en", page=page_en)
+        context_en['request'].user = get_user_model().objects.get(pk=user.pk)
+        render_placeholder(ex.placeholder, context_en)
+        self.assertEqual(len(context_en['request'].placeholders), 1)
+        self.assertIn(ex.placeholder, context_en['request'].placeholders)
+
+    def test_request_placeholders_permission_check_page(self):
+        page_en = create_page('page_en', 'col_two.html', 'en')
+        placeholder_en = page_en.placeholders.get(slot='col_left')
+
+        class NoPushPopContext(SekizaiContext):
+            def push(self):
+                pass
+
+            pop = push
+
+        context_en = NoPushPopContext()
+
+        # request.placeholders is populated for superuser
+        context_en['request'] = self.get_request(language="en", page=page_en)
+        context_en['request'].user = self.get_superuser()
+        render_placeholder(placeholder_en, context_en)
+        self.assertEqual(len(context_en['request'].placeholders), 1)
+        self.assertIn(placeholder_en, context_en['request'].placeholders)
+
+        # request.placeholders is not populated for staff user with no permission
+        user = self.get_staff_user_with_no_permissions()
+        context_en['request'] = self.get_request(language="en", page=page_en)
+        context_en['request'].user = user
+        render_placeholder(placeholder_en, context_en)
+        self.assertEqual(len(context_en['request'].placeholders), 0)
+        self.assertNotIn(placeholder_en, context_en['request'].placeholders)
+
+        # request.placeholders is populated for staff user with permission on the model
+        user.user_permissions.add(Permission.objects.get(codename='change_page'))
+        context_en['request'] = self.get_request(language="en", page=page_en)
+        context_en['request'].user = get_user_model().objects.get(pk=user.pk)
+        render_placeholder(placeholder_en, context_en)
+        self.assertEqual(len(context_en['request'].placeholders), 1)
+        self.assertIn(placeholder_en, context_en['request'].placeholders)
+
+    def test_request_placeholders_permission_check_templatetag(self):
+        """
+        Tests that {% render_placeholder %} templatetag check for placeholder permission
+        """
+        page_en = create_page('page_en', 'col_two.html', 'en')
+        ex1 = Example1(char_1="char_1", char_2="char_2", char_3="char_3",
+                       char_4="char_4")
+        ex1.save()
+        template = '{% load cms_tags %}{% render_placeholder ex1.placeholder %}'
+
+        context = RequestContext(self.get_request(language="en", page=page_en), {'ex1': ex1})
+
+        # request.placeholders is populated for superuser
+        context['request'] = self.get_request(language="en", page=page_en)
+        context['request'].user = self.get_superuser()
+        template_obj = Template(template)
+        template_obj.render(context)
+        self.assertEqual(len(context['request'].placeholders), 2)
+        self.assertIn(ex1.placeholder, context['request'].placeholders)
+
+        # request.placeholders is not populated for staff user with no permission
+        user = self.get_staff_user_with_no_permissions()
+        context['request'] = self.get_request(language="en", page=page_en)
+        context['request'].user = user
+        template_obj = Template(template)
+        template_obj.render(context)
+        self.assertEqual(len(context['request'].placeholders), 0)
+        self.assertNotIn(ex1.placeholder, context['request'].placeholders)
+
+        # request.placeholders is populated for staff user with permission on the model
+        user.user_permissions.add(Permission.objects.get(codename='change_example1'))
+        context['request'] = self.get_request(language="en", page=page_en)
+        context['request'].user = get_user_model().objects.get(pk=user.pk)
+        template_obj = Template(template)
+        template_obj.render(context)
+        self.assertEqual(len(context['request'].placeholders), 2)
+        self.assertIn(ex1.placeholder, context['request'].placeholders)
+
     def test_excercise_get_attached_model(self):
         ph = Placeholder.objects.create(slot='test', default_width=300)
         result = ph._get_attached_model()

--- a/cms/tests/templatetags.py
+++ b/cms/tests/templatetags.py
@@ -243,15 +243,13 @@ class NoFixtureDatabaseTemplateTagTests(CMSTestCase):
         cache.clear()
         from cms.test_utils import project
 
-        User = get_user_model()
-
         template_dir = os.path.join(os.path.dirname(project.__file__), 'templates', 'alt_plugin_templates',
                                     'show_placeholder')
         page = create_page('Test', 'col_two.html', 'en')
         placeholder = page.placeholders.all()[0]
         add_plugin(placeholder, TextPlugin, 'en', body='HIDDEN')
         request = RequestFactory().get('/')
-        request.user = User()
+        request.user = self.get_staff_user_with_no_permissions()
         request.current_page = page
         with SettingsOverride(TEMPLATE_DIRS=[template_dir]):
             template = Template(


### PR DESCRIPTION
Currently placeholders in model is pushed to ``request.placeholders`` disregarding actual user permission on them; the user can't add content to them anyway as permission is enforced upon plugin insertion, but this can be confusing for users.
This PR check for user permissions on placeholders when populating ``request.placeholders`` ensuring that the users can only see the placeholders they have rights on.