### PR TITLE
Add render_model_add_block tag

### DIFF
--- a/cms/templates/cms/toolbar/plugin.html
+++ b/cms/templates/cms/toolbar/plugin.html
@@ -1,6 +1,6 @@
 {% spaceless %}{% load i18n l10n sekizai_tags static cms_tags %}
 
-<div class="cms_plugin cms_plugin-{% if generic %}{{ generic.app_label }}-{{ generic.module_name }}-{% if attribute_name %}{{ attribute_name|slugify }}-{% endif %}{% endif %}{{ instance.pk|unlocalize }}{% if render_model_icon %} cms_render_model_icon{% elif render_model %} cms_render_model{% elif render_model_block %} cms_render_model cms_render_model_block{% elif render_model_add %} cms_render_model_add{% endif %}">{% if render_model_icon %}<img src="{% static 'cms/img/toolbar/render_model_placeholder.png' %}">{% elif render_model_add %}<img src="{% static 'cms/img/toolbar/render_model_placeholder.png' %}">{% else %}{{ rendered_content }}{% endif %}</div>
+<div class="cms_plugin cms_plugin-{% if generic %}{{ generic.app_label }}-{{ generic.module_name }}-{% if attribute_name %}{{ attribute_name|slugify }}-{% endif %}{% endif %}{{ instance.pk|unlocalize }}{% if render_model_icon %} cms_render_model_icon{% elif render_model %} cms_render_model{% elif render_model_block %} cms_render_model cms_render_model_block{% elif render_model_add %} cms_render_model_add{% endif %}">{% if content %}{{ content }}{% elif render_model_icon %}<img src="{% static 'cms/img/toolbar/render_model_placeholder.png' %}">{% elif render_model_add %}<img src="{% static 'cms/img/toolbar/render_model_placeholder.png' %}">{% else %}{{ rendered_content }}{% endif %}</div>
 
 {% addtoblock "js" %}
 <script>

--- a/cms/tests/templatetags.py
+++ b/cms/tests/templatetags.py
@@ -382,3 +382,73 @@ class NoFixtureDatabaseTemplateTagTests(CMSTestCase):
         context = RequestContext(request)
         with self.assertNumQueries(4):
             template.render(context)
+
+    def test_render_model_add(self):
+        from django.core.cache import cache
+        from cms.test_utils.project.sampleapp.models import Category
+
+        cache.clear()
+        page = create_page('Test', 'col_two.html', 'en', published=True)
+        template = Template(
+            "{% load cms_tags %}{% render_model_add category %}")
+        user = self._create_user("admin", True, True)
+        request = RequestFactory().get('/')
+        request.user = user
+        request.current_page = page
+        request.session = {}
+        request.toolbar = CMSToolbar(request)
+        request.toolbar.edit_mode = True
+        request.toolbar.is_staff = True
+        context = RequestContext(request, {'category': Category()})
+        with self.assertNumQueries(0):
+            output = template.render(context)
+        expected = 'cms_plugin cms_plugin-sampleapp-category-add-None '
+        'cms_render_model_add'
+        self.assertIn(expected, output)
+
+        # Now test that it does NOT render when not in edit mode
+        request = RequestFactory().get('/')
+        request.user = user
+        request.current_page = page
+        request.session = {}
+        request.toolbar = CMSToolbar(request)
+        context = RequestContext(request, {'category': Category()})
+        with self.assertNumQueries(0):
+            output = template.render(context)
+        expected = ''
+        self.assertEqual(expected, output)
+
+    def test_render_model_add_block(self):
+        from django.core.cache import cache
+        from cms.test_utils.project.sampleapp.models import Category
+
+        cache.clear()
+        page = create_page('Test', 'col_two.html', 'en', published=True)
+        template = Template(
+            "{% load cms_tags %}{% render_model_add_block category %}wrapped{% endrender_model_add_block %}")
+        user = self._create_user("admin", True, True)
+        request = RequestFactory().get('/')
+        request.user = user
+        request.current_page = page
+        request.session = {}
+        request.toolbar = CMSToolbar(request)
+        request.toolbar.edit_mode = True
+        request.toolbar.is_staff = True
+        context = RequestContext(request, {'category': Category()})
+        with self.assertNumQueries(0):
+            output = template.render(context)
+        expected = 'cms_plugin cms_plugin-sampleapp-category-add-None '
+        'cms_render_model_add'
+        self.assertIn(expected, output)
+
+        # Now test that it does NOT render when not in edit mode
+        request = RequestFactory().get('/')
+        request.user = user
+        request.current_page = page
+        request.session = {}
+        request.toolbar = CMSToolbar(request)
+        context = RequestContext(request, {'category': Category()})
+        with self.assertNumQueries(0):
+            output = template.render(context)
+        expected = 'wrapped'
+        self.assertEqual(expected, output)

--- a/docs/reference/templatetags.rst
+++ b/docs/reference/templatetags.rst
@@ -631,8 +631,6 @@ It will render to something like:
 
 .. _django-hvad: https://github.com/kristianoellegaard/django-hvad
 
-    {% endblock %}
-
 
 render_model_add_block
 ======================

--- a/docs/reference/templatetags.rst
+++ b/docs/reference/templatetags.rst
@@ -633,6 +633,57 @@ It will render to something like:
 
     {% endblock %}
 
+
+render_model_add_block
+======================
+
+``render_model_add_block`` is similar to ``render_model_add`` but instead of
+emitting an icon that is linked to the add model form in a modal dialog, it
+wraps arbitrary markup with the same "link". This allows the developer to create
+front-end editing experiences better suited to the project.
+
+All arguments are identical to ``render_model_add``, but the templatetag is used
+in two parts to wrap the markup that should be wrapped.
+
+.. code-block:: html+django
+
+    {% render_model_add_block my_model_instance %}<div>New Object</div>{% endrender_model_add_block %}
+
+
+It will render to something like:
+
+.. code-block:: html+django
+
+    <div class="cms_plugin cms_plugin-myapp-mymodel-1 cms_render_model_add">
+      <div>New Object</div>
+    </div>
+
+
+.. warning::
+
+    You **must** pass an *instance* of your model as instance parameter. The
+    instance passed could be an existing models instance, or one newly created
+    in your view/plugin. It does not even have to be saved, it is introspected
+    by the templatetag to determine the desired model class.
+
+
+**Arguments:**
+
+* ``instance``: instance of your model in the template
+* ``edit_fields`` (optional): a comma separated list of fields editable in the
+  popup editor;
+* ``language`` (optional): the admin language tab to be linked. Useful only for
+  `django-hvad`_ enabled models.
+* ``view_url`` (optional): the name of a url that will be reversed using the
+  instance ``pk`` and the ``language`` as arguments;
+* ``view_method`` (optional): a method name that will return a URL to a view;
+  the method must accept ``request`` as first parameter.
+* ``varname`` (optional): the templatetag output can be saved as a context
+  variable for later use.
+
+.. _django-hvad: https://github.com/kristianoellegaard/django-hvad
+
+
 .. templatetag:: page_language_url
 
 

--- a/docs/reference/templatetags.rst
+++ b/docs/reference/templatetags.rst
@@ -609,12 +609,9 @@ It will render to something like:
         Icon and position can be customized via CSS by setting a background
         to the ``.cms_render_model_add img`` selector.
 
-.. warning::
+..warning::
 
-    You **must** pass an *instance* of your model as instance parameter. The
-    instance passed could be an existing models instance, or one newly created
-    in your view/plugin. It does not even have to be saved, it is introspected
-    by the templatetag to determine the desired model class.
+    You **must** pass an instance of your model as instance parameter.
 
 **Arguments:**
 
@@ -634,55 +631,9 @@ It will render to something like:
 
 .. _django-hvad: https://github.com/kristianoellegaard/django-hvad
 
+    {% endblock %}
 
-render_model_add_block
-======================
-
-``render_model_add_block`` is similar to ``render_model_add`` but instead of
-emitting an icon that is linked to the add model form in a modal dialog, it
-wraps arbitrary markup with the same "link". This allows the developer to create
-front-end editing experiences better suited to the project.
-
-All arguments are identical to ``render_model_add``, but the templatetag is used
-in two parts to wrap the markup that should be wrapped.
-
-.. code-block:: html+django
-
-    {% render_model_add_block my_model_instance %}<div>New Object</div>{% endrender_model_add_block %}
-
-
-It will render to something like:
-
-.. code-block:: html+django
-
-    <div class="cms_plugin cms_plugin-myapp-mymodel-1 cms_render_model_add">
-      <div>New Object</div>
-    </div>
-
-
-.. warning::
-
-    You **must** pass an *instance* of your model as instance parameter. The
-    instance passed could be an existing models instance, or one newly created
-    in your view/plugin. It does not even have to be saved, it is introspected
-    by the templatetag to determine the desired model class.
-
-
-**Arguments:**
-
-* ``instance``: instance of your model in the template
-* ``edit_fields`` (optional): a comma separated list of fields editable in the
-  popup editor;
-* ``language`` (optional): the admin language tab to be linked. Useful only for
-  `django-hvad`_ enabled models.
-* ``view_url`` (optional): the name of a url that will be reversed using the
-  instance ``pk`` and the ``language`` as arguments;
-* ``view_method`` (optional): a method name that will return a URL to a view;
-  the method must accept ``request`` as first parameter.
-* ``varname`` (optional): the templatetag output can be saved as a context
-  variable for later use.
-
-.. _django-hvad: https://github.com/kristianoellegaard/django-hvad
+.. templatetag:: page_language_url
 
 
 page_language_url

--- a/docs/reference/templatetags.rst
+++ b/docs/reference/templatetags.rst
@@ -609,9 +609,12 @@ It will render to something like:
         Icon and position can be customized via CSS by setting a background
         to the ``.cms_render_model_add img`` selector.
 
-..warning::
+.. warning::
 
-    You **must** pass an instance of your model as instance parameter.
+    You **must** pass an *instance* of your model as instance parameter. The
+    instance passed could be an existing models instance, or one newly created
+    in your view/plugin. It does not even have to be saved, it is introspected
+    by the templatetag to determine the desired model class.
 
 **Arguments:**
 
@@ -631,9 +634,55 @@ It will render to something like:
 
 .. _django-hvad: https://github.com/kristianoellegaard/django-hvad
 
-    {% endblock %}
 
-.. templatetag:: page_language_url
+render_model_add_block
+======================
+
+``render_model_add_block`` is similar to ``render_model_add`` but instead of
+emitting an icon that is linked to the add model form in a modal dialog, it
+wraps arbitrary markup with the same "link". This allows the developer to create
+front-end editing experiences better suited to the project.
+
+All arguments are identical to ``render_model_add``, but the templatetag is used
+in two parts to wrap the markup that should be wrapped.
+
+.. code-block:: html+django
+
+    {% render_model_add_block my_model_instance %}<div>New Object</div>{% endrender_model_add_block %}
+
+
+It will render to something like:
+
+.. code-block:: html+django
+
+    <div class="cms_plugin cms_plugin-myapp-mymodel-1 cms_render_model_add">
+      <div>New Object</div>
+    </div>
+
+
+.. warning::
+
+    You **must** pass an *instance* of your model as instance parameter. The
+    instance passed could be an existing models instance, or one newly created
+    in your view/plugin. It does not even have to be saved, it is introspected
+    by the templatetag to determine the desired model class.
+
+
+**Arguments:**
+
+* ``instance``: instance of your model in the template
+* ``edit_fields`` (optional): a comma separated list of fields editable in the
+  popup editor;
+* ``language`` (optional): the admin language tab to be linked. Useful only for
+  `django-hvad`_ enabled models.
+* ``view_url`` (optional): the name of a url that will be reversed using the
+  instance ``pk`` and the ``language`` as arguments;
+* ``view_method`` (optional): a method name that will return a URL to a view;
+  the method must accept ``request`` as first parameter.
+* ``varname`` (optional): the templatetag output can be saved as a context
+  variable for later use.
+
+.. _django-hvad: https://github.com/kristianoellegaard/django-hvad
 
 
 page_language_url


### PR DESCRIPTION
OK, this works nicely to satisfy #3873, but would be even better if ClassyTags would let me declare the nodelist block "argument" as, optional. Anyone know if this is possible?