### PR TITLE
Non serializable objects shall be handled by `default()` function

### DIFF
--- a/cms/utils/encoder.py
+++ b/cms/utils/encoder.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 from django.utils.html import conditional_escape
+from django.utils.encoding import force_text
+from django.utils.functional import Promise
 from django.core.serializers.json import DjangoJSONEncoder
 
 
@@ -12,8 +14,13 @@ class SafeJSONEncoder(DjangoJSONEncoder):
         try:
             return type(o)(esc(o))
         except ValueError:
-            return esc(o)
+            return self.default(o)
 
     def encode(self, o):
         value = self._recursive_escape(o)
         return super(SafeJSONEncoder, self).encode(value)
+
+    def default(self, o):
+        if isinstance(o, Promise):
+            return force_text(o)
+        return super(SafeJSONEncoder, self).default(o)


### PR DESCRIPTION
The Django docs state: https://docs.djangoproject.com/en/1.7/topics/serialization/#serialization-formats-json

REST framework does it as well: https://github.com/tomchristie/django-rest-framework/blob/4248a8d3fc725d9ae3fe7aaaad7ee12479ab07ab/rest_framework/utils/encoders.py#L21

we could even consider to support more types inside that ``default()`` method.