### PR TITLE
Fix corner case with Django 1.7

### DIFF
--- a/cms/models/fields.py
+++ b/cms/models/fields.py
@@ -20,7 +20,7 @@ class PlaceholderField(models.ForeignKey):
             del(kwargs['to'])
         kwargs.update({'null': True})  # always allow Null
         kwargs.update({'editable': False}) # never allow edits in admin
-        super(PlaceholderField, self).__init__(Placeholder, **kwargs)
+        super(PlaceholderField, self).__init__('cms.Placeholder', **kwargs)
 
     def deconstruct(self):
         name, path, args, kwargs = super(PlaceholderField, self).deconstruct()

--- a/cms/tests/placeholder.py
+++ b/cms/tests/placeholder.py
@@ -39,6 +39,7 @@ from cms.test_utils.project.placeholderapp.models import (
     MultilingualExample1,
     TwoPlaceholderExample,
 )
+from cms.test_utils.project.sampleapp.models import Category
 from cms.test_utils.testcases import CMSTestCase
 from cms.test_utils.util.context_managers import (SettingsOverride, UserLoginContext)
 from cms.test_utils.util.mock import AttributeObject
@@ -305,6 +306,16 @@ class PlaceholderTestCase(CMSTestCase, UnittestCompatMixin):
 
     def test_placeholder_field_no_related_name(self):
         self.assertRaises(ValueError, PlaceholderField, 'placeholder', related_name='+')
+
+    def test_placeholder_field_db_table(self):
+        """
+        Test for #3891
+        """
+        example = Category.objects.create(
+            name='category',
+            parent=None
+        )
+        self.assertEqual(len(example.description._get_attached_fields()), 1)
 
     def test_placeholder_field_valid_slotname(self):
         self.assertRaises(ImproperlyConfigured, PlaceholderField, 10)

--- a/cms/tests/placeholder.py
+++ b/cms/tests/placeholder.py
@@ -309,12 +309,16 @@ class PlaceholderTestCase(CMSTestCase, UnittestCompatMixin):
 
     def test_placeholder_field_db_table(self):
         """
-        Test for #3891
+        Test for leaking Django 1.7 Model._meta.db_table monkeypatching
+        on sqlite See #3891
+        This test for a side-effect of the above which prevents placeholder
+        fields to return the 
         """
         example = Category.objects.create(
             name='category',
             parent=None
         )
+        self.assertEqual(example.description._get_attached_fields()[0].model, Category)
         self.assertEqual(len(example.description._get_attached_fields()), 1)
 
     def test_placeholder_field_valid_slotname(self):


### PR DESCRIPTION
Fix #3891

Apparently use of the model reference lead to the ``db_table`` issue documented above.
Passing it as string solves the issue.
The test checks a side effect of the above leak which leads to not returning attached fields for models with messed up ``db_table``