### PR TITLE
Toolbar API update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ install:
 
 script: coverage run --rcfile=.coverage.rc develop.py test --migrate
 
-after_success: coveralls --config_file=.coverage.rc --coveralls_yaml=.coveralls.yml
+after_success: coveralls --config_file=.coverage.rc
 
 notifications:
   email:

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -351,4 +351,4 @@ Please see Install/2.4 release notes *before* attempting to upgrade to version 2
 - General code cleanup
 - Simplify loading of view restrictions in the menu
 - south is not marked as optional; to use south on Django 1.6 install django-cms[south]
-
+- Add system_plugin attribute to CMSPluginBase that allow the plugin to override any configuration

--- a/cms/cms_plugins.py
+++ b/cms/cms_plugins.py
@@ -19,6 +19,7 @@ class PlaceholderPlugin(CMSPluginBase):
     #require_parent = True
     render_plugin = False
     admin_preview = False
+    system = True
 
     model = PlaceholderReference
 
@@ -31,6 +32,7 @@ class AliasPlugin(CMSPluginBase):
     allow_children = False
     model = AliasPluginModel
     render_template = "cms/plugins/alias.html"
+    system = True
 
     def render(self, context, instance, placeholder):
         from cms.utils.plugins import downcast_plugins, build_plugin_tree

--- a/cms/cms_toolbar.py
+++ b/cms/cms_toolbar.py
@@ -98,17 +98,19 @@ class BasicToolbar(CMSToolbar):
     """
     Basic Toolbar for site and languages menu
     """
+    page = None
 
     def init_from_request(self):
         self.page = get_page_draft(self.request.current_page)
 
     def populate(self):
-        self.init_from_request()
+        if not self.page:
+            self.init_from_request()
 
-        self.add_admin_menu()
-        self.add_language_menu()
-        user_settings = self.request.toolbar.get_user_settings()
-        self.clipboard = user_settings.clipboard
+            self.add_admin_menu()
+            self.add_language_menu()
+            user_settings = self.request.toolbar.get_user_settings()
+            self.clipboard = user_settings.clipboard
 
     def add_admin_menu(self):
         admin_menu = self.toolbar.get_or_create_menu(ADMIN_MENU_IDENTIFIER, self.current_site.name)

--- a/cms/cms_toolbar.py
+++ b/cms/cms_toolbar.py
@@ -99,9 +99,6 @@ class BasicToolbar(CMSToolbar):
     Basic Toolbar for site and languages menu
     """
 
-    def __init__(self, request, toolbar, is_current_app, app_path):
-        super(BasicToolbar, self).__init__(request, toolbar, is_current_app, app_path)
-
     def init_from_request(self):
         self.page = get_page_draft(self.request.current_page)
 
@@ -110,6 +107,8 @@ class BasicToolbar(CMSToolbar):
 
         self.add_admin_menu()
         self.add_language_menu()
+        user_settings = self.request.toolbar.get_user_settings()
+        self.clipboard = user_settings.clipboard
 
     def add_admin_menu(self):
         admin_menu = self.toolbar.get_or_create_menu(ADMIN_MENU_IDENTIFIER, self.current_site.name)

--- a/cms/cms_toolbar.py
+++ b/cms/cms_toolbar.py
@@ -101,8 +101,6 @@ class BasicToolbar(CMSToolbar):
 
     def __init__(self, request, toolbar, is_current_app, app_path):
         super(BasicToolbar, self).__init__(request, toolbar, is_current_app, app_path)
-        user_settings = self.request.toolbar.get_user_settings()
-        self.clipboard = user_settings.clipboard
 
     def init_from_request(self):
         self.page = get_page_draft(self.request.current_page)

--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -157,6 +157,26 @@ class Page(six.with_metaclass(PageMetaClass, MP_Node)):
         path = self.get_path(language, fallback) or self.get_slug(language, fallback)
         return reverse('pages-details-by-slug', kwargs={"slug": path})
 
+    def get_public_url(self, language=None, fallback=True):
+        """
+        Returns the URL of the published version of the current page.
+        Returns empty string if the page is not published.
+        """
+        try:
+            return self.get_public_object().get_absolute_url(language, fallback)
+        except:
+            return ''
+
+    def get_draft_url(self, language=None, fallback=True):
+        """
+        Returns the URL of the draft version of the current page.
+        Returns empty string if the draft page is not available.
+        """
+        try:
+            return self.get_draft_object().get_absolute_url(language, fallback)
+        except:
+            return ''
+
     def move_page(self, target, position='first-child'):
         """
         Called from admin interface when page is moved. Should be used on

--- a/cms/plugin_base.py
+++ b/cms/plugin_base.py
@@ -121,6 +121,7 @@ class CMSPluginBase(six.with_metaclass(CMSPluginBaseMetaclass, admin.ModelAdmin)
     disable_child_plugin = False
 
     cache = get_cms_setting('PLUGIN_CACHE')
+    system = False
 
     opts = {}
 

--- a/cms/plugin_pool.py
+++ b/cms/plugin_pool.py
@@ -208,5 +208,9 @@ class PluginPool(object):
 
         return url_patterns
 
+    def get_system_plugins(self):
+        self.discover_plugins()
+        self.set_plugin_meta()
+        return [plugin.name for plugin in self.plugins if plugin.system]
 
 plugin_pool = PluginPool()

--- a/cms/plugin_pool.py
+++ b/cms/plugin_pool.py
@@ -211,6 +211,6 @@ class PluginPool(object):
     def get_system_plugins(self):
         self.discover_plugins()
         self.set_plugin_meta()
-        return [plugin.name for plugin in self.plugins.values() if plugin.system]
+        return [plugin.__name__ for plugin in self.plugins.values() if plugin.system]
 
 plugin_pool = PluginPool()

--- a/cms/plugin_pool.py
+++ b/cms/plugin_pool.py
@@ -211,6 +211,6 @@ class PluginPool(object):
     def get_system_plugins(self):
         self.discover_plugins()
         self.set_plugin_meta()
-        return [plugin.name for plugin in self.plugins if plugin.system]
+        return [plugin.name for plugin in self.plugins.values() if plugin.system]
 
 plugin_pool = PluginPool()

--- a/cms/plugin_rendering.py
+++ b/cms/plugin_rendering.py
@@ -202,7 +202,7 @@ def render_placeholder_toolbar(placeholder, context, name_fallback, save_languag
     context.push()
 
     # to restrict child-only plugins from draggables..
-    context['allowed_plugins'] = [cls.__name__ for cls in plugin_pool.get_all_plugins(slot, page)]
+    context['allowed_plugins'] = [cls.__name__ for cls in plugin_pool.get_all_plugins(slot, page)] + plugin_pool.get_system_plugins()
     context['placeholder'] = placeholder
     context['language'] = save_language
     context['page'] = page

--- a/cms/templates/cms/toolbar/clipboard.html
+++ b/cms/templates/cms/toolbar/clipboard.html
@@ -2,22 +2,22 @@
 {% load url from future %}
 
 {% if request.toolbar.edit_mode or request.toolbar.build_mode %}
-{% if request.toolbar.get_clipboard_plugins %}
+{% if local_toolbar.get_clipboard_plugins %}
 {% with slot="clipboard" %}
 <div class="cms_clipboard">
 	<div class="cms_clipboard-triggers">
 		{# maximum of 5, delete link #}
-		{% for plugin in request.toolbar.get_clipboard_plugins %}
+		{% for plugin in local_toolbar.get_clipboard_plugins %}
 			{% if not plugin.parent_id %}
 			<div class="cms_clipboard-numbers"><a href="#">{{ forloop.index }}</a></div>
 			{% endif %}
 		{% endfor %}
 	</div>
-	{% for plugin in request.toolbar.get_clipboard_plugins %}
+	{% for plugin in local_toolbar.get_clipboard_plugins %}
 	<div class="cms_plugins">{% include "cms/toolbar/plugin.html" with instance=plugin %}</div>
 	{% endfor %}
 	<div class="cms_clipboard-containers cms_dragarea cms_draggables">
-		{% for plugin in request.toolbar.get_clipboard_plugins %}
+		{% for plugin in local_toolbar.get_clipboard_plugins %}
 			{% with show_language="true" %}{% include "cms/toolbar/dragitem.html" with plugin=plugin %}{% endwith %}
 		{% endfor %}
 	</div>

--- a/cms/templates/cms/toolbar/items/live_draft.html
+++ b/cms/templates/cms/toolbar/items/live_draft.html
@@ -1,11 +1,11 @@
 {% load i18n %}{% spaceless %}
 <div class="cms_toolbar-item cms_toolbar-item-buttons cms_toolbar-item_switch_save-edit">
     {% if request.toolbar.edit_mode %}
-    <a class="cms_btn cms_btn-switch-save" href="?{{ request.toolbar.edit_mode_url_off }}">
+    <a class="cms_btn cms_btn-switch-save" href="{{ request.toolbar.get_object_public_url }}?{{ request.toolbar.edit_mode_url_off }}">
         {% trans "Save and close" %}
     </a>
     {% else %}
-    <a class="cms_btn cms_btn-active cms_btn-switch-edit" href="?{{ request.toolbar.edit_mode_url_on }}">
+    <a class="cms_btn cms_btn-active cms_btn-switch-edit" href="{{ request.toolbar.get_object_draft_url }}?{{ request.toolbar.edit_mode_url_on }}">
         {% trans "Edit" %}
     </a>
     {% endif %}

--- a/cms/templates/cms/toolbar/toolbar.html
+++ b/cms/templates/cms/toolbar/toolbar.html
@@ -53,9 +53,9 @@
 	</div>
 	{# end: sidebar #}
 
-	{# start: clipboard #}
-	{{ clipboard }}
-	{# end: clipboard #}
+	{# start: addons #}
+	{{ addons }}
+	{# end: addons #}
 
 	{# start: modal #}
 	<div class="cms_modal">

--- a/cms/templatetags/cms_tags.py
+++ b/cms/templatetags/cms_tags.py
@@ -655,6 +655,7 @@ class CMSToolbar(RenderBlock):
         request = context.get('request', None)
         toolbar = getattr(request, 'toolbar', None)
         if toolbar:
+            toolbar.init_toolbar(request)
             toolbar.populate()
         if request and 'cms-toolbar-login-error' in request.GET:
             context['cms_toolbar_login_error'] = request.GET['cms-toolbar-login-error'] == '1'

--- a/cms/templatetags/cms_tags.py
+++ b/cms/templatetags/cms_tags.py
@@ -664,6 +664,7 @@ class CMSToolbar(RenderBlock):
             with force_language(language):
                 # needed to populate the context with sekizai content
                 render_to_string('cms/toolbar/toolbar_javascript.html', context)
+                context['addons'] = mark_safe(toolbar.render_addons(context))
         else:
             language = None
         # render everything below the tag
@@ -678,7 +679,6 @@ class CMSToolbar(RenderBlock):
         # render the toolbar content
         request.toolbar.post_template_populate()
         with force_language(language):
-            context['addons'] = toolbar.render_addons(context)
             content = render_to_string('cms/toolbar/toolbar.html', context)
         # return the toolbar content and the content below
         return '%s\n%s' % (content, rendered_contents)

--- a/cms/test_utils/project/placeholderapp/cms_toolbar.py
+++ b/cms/test_utils/project/placeholderapp/cms_toolbar.py
@@ -6,11 +6,15 @@ from cms.toolbar_pool import toolbar_pool
 from cms.utils.urlutils import admin_reverse
 from django.utils.translation import ugettext_lazy as _
 
+from .models import Example1
+
 SAMPLEAPP_BREAK = 'Example1 App Break'
 
 
 @toolbar_pool.register
 class Example1Toolbar(CMSToolbar):
+    watch_models = [Example1]
+
     def populate(self):
         admin_menu = self.toolbar.get_or_create_menu(ADMIN_MENU_IDENTIFIER)
         position = admin_menu.find_first(Break, identifier=ADMINISTRATION_BREAK)

--- a/cms/test_utils/project/placeholderapp/models.py
+++ b/cms/test_utils/project/placeholderapp/models.py
@@ -40,6 +40,12 @@ class Example1(models.Model):
     def get_absolute_url(self):
         return reverse("example_detail", args=(self.pk,))
 
+    def get_draft_url(self):
+        return self.get_absolute_url()
+
+    def get_public_url(self):
+        return '/public/view/'
+
     def set_static_url(self, request):
         language = get_language_from_request(request)
         if self.pk:

--- a/cms/test_utils/project/placeholderapp/views.py
+++ b/cms/test_utils/project/placeholderapp/views.py
@@ -20,6 +20,8 @@ def _base_detail(request, instance, template_name='detail.html',
     context['instance'] = instance
     context['instance_class'] = instance.__class__
     context['item_name'] = item_name
+    if hasattr(request, 'toolbar'):
+        request.toolbar.set_object(instance)
     if template_string:
         template = Template(template_string)
         return HttpResponse(template.render(context))

--- a/cms/test_utils/project/placeholderapp_urls.py
+++ b/cms/test_utils/project/placeholderapp_urls.py
@@ -18,6 +18,7 @@ urlpatterns = [
 
 urlpatterns += i18n_patterns('',
     url(r'^detail/(?P<id>[0-9]+)/$', 'cms.test_utils.project.placeholderapp.views.detail_view', name="detail"),
+    url(r'^detail/(?P<pk>[0-9]+)/$', 'cms.test_utils.project.placeholderapp.views.detail_view', name="example_detail"),
     url(r'^detail_multi/(?P<id>[0-9]+)/$', 'cms.test_utils.project.placeholderapp.views.detail_view_multi', name="detail_multi"),
     url(r'^', include('cms.urls')),
 )

--- a/cms/tests/admin.py
+++ b/cms/tests/admin.py
@@ -1176,13 +1176,13 @@ class PluginPermissionTests(AdminTestsBase):
         plugins = self._placeholder.get_plugins()
         self.assertEqual(plugins.count(), 4)
         self.assertEqual(CMSPlugin.objects.count(), 7)
-        self.assertEqual(Placeholder.objects.count(), 5)
+        self.assertEqual(Placeholder.objects.count(), 4)
         url = admin_reverse('cms_page_clear_placeholder', args=[clipboard.pk])
         with self.assertNumQueries(FuzzyInt(70, 80)):
             response = self.client.post(url, {'test': 0})
         self.assertEqual(response.status_code, 302)
         self.assertEqual(CMSPlugin.objects.count(), 4)
-        self.assertEqual(Placeholder.objects.count(), 4)
+        self.assertEqual(Placeholder.objects.count(), 3)
 
     def test_plugins_copy_language(self):
         """User tries to copy plugin but has no permissions. He can copy plugins after he got the permissions"""
@@ -1529,7 +1529,7 @@ class AdminFormsTests(AdminTestsBase):
             with self.assertNumQueries(FuzzyInt(40, 66)):
                 output = force_text(self.client.get('/en/?%s' % get_cms_setting('CMS_TOOLBAR_URL__EDIT_ON')).content)
             self.assertIn('<b>Test</b>', output)
-            self.assertEqual(Placeholder.objects.all().count(), 10)
+            self.assertEqual(Placeholder.objects.all().count(), 9)
             self.assertEqual(StaticPlaceholder.objects.count(), 2)
             for placeholder in Placeholder.objects.all():
                 add_plugin(placeholder, TextPlugin, 'en', body='<b>Test</b>')

--- a/cms/tests/admin.py
+++ b/cms/tests/admin.py
@@ -1176,13 +1176,13 @@ class PluginPermissionTests(AdminTestsBase):
         plugins = self._placeholder.get_plugins()
         self.assertEqual(plugins.count(), 4)
         self.assertEqual(CMSPlugin.objects.count(), 7)
-        self.assertEqual(Placeholder.objects.count(), 4)
+        self.assertEqual(Placeholder.objects.count(), 5)
         url = admin_reverse('cms_page_clear_placeholder', args=[clipboard.pk])
         with self.assertNumQueries(FuzzyInt(70, 80)):
             response = self.client.post(url, {'test': 0})
         self.assertEqual(response.status_code, 302)
         self.assertEqual(CMSPlugin.objects.count(), 4)
-        self.assertEqual(Placeholder.objects.count(), 3)
+        self.assertEqual(Placeholder.objects.count(), 4)
 
     def test_plugins_copy_language(self):
         """User tries to copy plugin but has no permissions. He can copy plugins after he got the permissions"""
@@ -1529,11 +1529,11 @@ class AdminFormsTests(AdminTestsBase):
             with self.assertNumQueries(FuzzyInt(40, 66)):
                 output = force_text(self.client.get('/en/?%s' % get_cms_setting('CMS_TOOLBAR_URL__EDIT_ON')).content)
             self.assertIn('<b>Test</b>', output)
-            self.assertEqual(Placeholder.objects.all().count(), 9)
+            self.assertEqual(Placeholder.objects.all().count(), 10)
             self.assertEqual(StaticPlaceholder.objects.count(), 2)
             for placeholder in Placeholder.objects.all():
                 add_plugin(placeholder, TextPlugin, 'en', body='<b>Test</b>')
-            with self.assertNumQueries(FuzzyInt(40, 60)):
+            with self.assertNumQueries(FuzzyInt(40, 72)):
                 output = force_text(self.client.get('/en/?%s' % get_cms_setting('CMS_TOOLBAR_URL__EDIT_ON')).content)
             self.assertIn('<b>Test</b>', output)
         with self.assertNumQueries(FuzzyInt(18, 45)):

--- a/cms/tests/nested_plugins.py
+++ b/cms/tests/nested_plugins.py
@@ -10,7 +10,6 @@ from cms.models import Page
 from cms.models.placeholdermodel import Placeholder
 from cms.models.pluginmodel import CMSPlugin
 from cms.tests.plugins import PluginsTestBaseCase
-from cms.test_utils.util.context_managers import SettingsOverride
 from cms.utils.compat.tests import UnittestCompatMixin
 from cms.utils.copy_plugins import copy_plugins_to
 

--- a/cms/tests/nested_plugins.py
+++ b/cms/tests/nested_plugins.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import with_statement
 import json
-from django.contrib.auth.models import AnonymousUser
 
 from djangocms_text_ckeditor.models import Text
 
@@ -12,10 +11,8 @@ from cms.models.placeholdermodel import Placeholder
 from cms.models.pluginmodel import CMSPlugin
 from cms.tests.plugins import PluginsTestBaseCase
 from cms.test_utils.util.context_managers import SettingsOverride
-from cms.utils import get_cms_setting
 from cms.utils.compat.tests import UnittestCompatMixin
 from cms.utils.copy_plugins import copy_plugins_to
-from cms.utils.plugins import downcast_plugins
 
 
 URL_CMS_MOVE_PLUGIN = u'/en/admin/cms/page/%d/move-plugin/'

--- a/cms/tests/nested_plugins.py
+++ b/cms/tests/nested_plugins.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import with_statement
 import json
+from django.contrib.auth.models import AnonymousUser
 
 from djangocms_text_ckeditor.models import Text
 
@@ -10,8 +11,11 @@ from cms.models import Page
 from cms.models.placeholdermodel import Placeholder
 from cms.models.pluginmodel import CMSPlugin
 from cms.tests.plugins import PluginsTestBaseCase
-from cms.utils.copy_plugins import copy_plugins_to
+from cms.test_utils.util.context_managers import SettingsOverride
+from cms.utils import get_cms_setting
 from cms.utils.compat.tests import UnittestCompatMixin
+from cms.utils.copy_plugins import copy_plugins_to
+from cms.utils.plugins import downcast_plugins
 
 
 URL_CMS_MOVE_PLUGIN = u'/en/admin/cms/page/%d/move-plugin/'

--- a/cms/tests/plugins.py
+++ b/cms/tests/plugins.py
@@ -1649,8 +1649,6 @@ class BrokenPluginTests(TestCase):
         with self.settings(INSTALLED_APPS=new_apps):
             plugin_pool.discovered = False
             self.assertRaises(ImportError, plugin_pool.discover_plugins)
-            apps.unset_installed_apps()
-
 
 class MTIPluginsTestCase(PluginsTestBaseCase):
     def test_add_edit_plugin(self):

--- a/cms/tests/plugins.py
+++ b/cms/tests/plugins.py
@@ -1405,7 +1405,6 @@ class PluginManyToManyTestCase(PluginsTestBaseCase):
         self.assertEqual(u'Articles Plugin 1', articles_plugin.title)
         self.assertEqual(self.section_count, articles_plugin.sections.count())
 
-
         # check publish box
         page = api.publish_page(page, self.super_user, 'en')
 
@@ -1416,7 +1415,6 @@ class PluginManyToManyTestCase(PluginsTestBaseCase):
         db_counts = [plugin.sections.count() for plugin in ArticlePluginModel.objects.all()]
         expected = [self.section_count for i in range(len(db_counts))]
         self.assertEqual(expected, db_counts)
-
 
     def test_copy_plugin_with_m2m(self):
         page = api.create_page("page", "nav_playground.html", "en")
@@ -1651,6 +1649,8 @@ class BrokenPluginTests(TestCase):
         with self.settings(INSTALLED_APPS=new_apps):
             plugin_pool.discovered = False
             self.assertRaises(ImportError, plugin_pool.discover_plugins)
+            apps.unset_installed_apps()
+
 
 class MTIPluginsTestCase(PluginsTestBaseCase):
     def test_add_edit_plugin(self):

--- a/cms/tests/reversion_tests.py
+++ b/cms/tests/reversion_tests.py
@@ -123,7 +123,7 @@ class ReversionTestCase(TransactionCMSTestCase):
             self.assertEqual(Title.objects.all().count(), 2)
             self.assertEqual(CMSPlugin.objects.all().count(), 2)
             self.assertEqual(Revision.objects.all().count(), 5)
-            self.assertEqual(Placeholder.objects.count(), 6)
+            self.assertEqual(Placeholder.objects.count(), 5)
 
             ctype = ContentType.objects.get_for_model(Page)
             revision = Revision.objects.all()[2]
@@ -168,7 +168,7 @@ class ReversionTestCase(TransactionCMSTestCase):
             self.client.post(undo_url)
             self.client.post(undo_url)
             self.assertEqual(2, CMSPlugin.objects.all().count())
-            self.assertEqual(Placeholder.objects.count(), 6)
+            self.assertEqual(Placeholder.objects.count(), 5)
 
     def test_undo_slug_collision(self):
         data1 = self.get_new_page_data()

--- a/cms/tests/reversion_tests.py
+++ b/cms/tests/reversion_tests.py
@@ -123,7 +123,7 @@ class ReversionTestCase(TransactionCMSTestCase):
             self.assertEqual(Title.objects.all().count(), 2)
             self.assertEqual(CMSPlugin.objects.all().count(), 2)
             self.assertEqual(Revision.objects.all().count(), 5)
-            self.assertEqual(Placeholder.objects.count(), 5)
+            self.assertEqual(Placeholder.objects.count(), 6)
 
             ctype = ContentType.objects.get_for_model(Page)
             revision = Revision.objects.all()[2]
@@ -168,7 +168,7 @@ class ReversionTestCase(TransactionCMSTestCase):
             self.client.post(undo_url)
             self.client.post(undo_url)
             self.assertEqual(2, CMSPlugin.objects.all().count())
-            self.assertEqual(Placeholder.objects.count(), 5)
+            self.assertEqual(Placeholder.objects.count(), 6)
 
     def test_undo_slug_collision(self):
         data1 = self.get_new_page_data()

--- a/cms/tests/toolbar.py
+++ b/cms/tests/toolbar.py
@@ -168,6 +168,62 @@ class ToolbarTests(ToolbarTestBase):
         self.assertContains(response,
                             '<div class="cms_submenu-item"><a href="/some/other/url/" data-rel="ajax_add"')
 
+    def test_markup_toolbar_url_page(self):
+        superuser = self.get_superuser()
+        page_1 = create_page("top-page", "col_two.html", "en", published=True)
+        page_2 = create_page("sec-page", "col_two.html", "en", published=True, parent=page_1)
+        page_3 = create_page("trd-page", "col_two.html", "en", published=False, parent=page_1)
+
+        # page with publish = draft
+        # check when in draft mode
+        with self.login_user_context(superuser):
+            response = self.client.get('%s?%s' % (
+                page_2.get_absolute_url(), get_cms_setting('CMS_TOOLBAR_URL__EDIT_ON')))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'href="%s?%s"' % (
+            page_2.get_public_url(), get_cms_setting('CMS_TOOLBAR_URL__EDIT_OFF')
+        ))
+        # check when in live mode
+        with self.login_user_context(superuser):
+            response = self.client.get('%s?%s' % (
+                page_2.get_absolute_url(), get_cms_setting('CMS_TOOLBAR_URL__EDIT_OFF')))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'href="%s?%s"' % (
+            page_2.get_draft_url(), get_cms_setting('CMS_TOOLBAR_URL__EDIT_ON')
+        ))
+        self.assertEqual(page_2.get_draft_url(), page_2.get_public_url())
+
+        # page with publish != draft
+        page_2.get_title_obj().slug = 'mod-page'
+        page_2.get_title_obj().save()
+        # check when in draft mode
+        with self.login_user_context(superuser):
+            response = self.client.get('%s?%s' % (
+                page_2.get_absolute_url(), get_cms_setting('CMS_TOOLBAR_URL__EDIT_ON')))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'href="%s?%s"' % (
+            page_2.get_public_url(), get_cms_setting('CMS_TOOLBAR_URL__EDIT_OFF')
+        ))
+        # check when in live mode
+        with self.login_user_context(superuser):
+            response = self.client.get('%s?%s' % (
+                page_2.get_public_url(), get_cms_setting('CMS_TOOLBAR_URL__EDIT_OFF')))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'href="%s?%s"' % (
+            page_2.get_draft_url(), get_cms_setting('CMS_TOOLBAR_URL__EDIT_ON')
+        ))
+        self.assertNotEqual(page_2.get_draft_url(), page_2.get_public_url())
+
+        # not published page
+        # check when in draft mode
+        with self.login_user_context(superuser):
+            response = self.client.get('%s?%s' % (
+                page_3.get_absolute_url(), get_cms_setting('CMS_TOOLBAR_URL__EDIT_ON')))
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, 'cms_toolbar-item_switch')
+        self.assertEqual(page_3.get_public_url(), '')
+        self.assertNotEqual(page_3.get_draft_url(), page_3.get_public_url())
+
     def test_markup_plugin_template(self):
         page = create_page("toolbar-page-1", "col_two.html", "en", published=True)
         plugin_1 = add_plugin(page.placeholders.get(slot='col_left'), language='en',

--- a/cms/tests/toolbar.py
+++ b/cms/tests/toolbar.py
@@ -607,6 +607,29 @@ class EditModelTemplateTagTest(ToolbarTestBase):
         MultilingualExample1.objects.all().delete()
         super(EditModelTemplateTagTest, self).tearDown()
 
+    def test_markup_toolbar_url_model(self):
+        superuser = self.get_superuser()
+        page = create_page('Test', 'col_two.html', 'en', published=True)
+        ex1 = Example1(char_1="char_1", char_2="char_2", char_3="char_3",
+                       char_4="char_4")
+        ex1.save()
+        # object
+        # check when in draft mode
+        request = self.get_page_request(page, superuser, edit=True)
+        response = detail_view(request, ex1.pk)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'href="%s?%s"' % (
+            ex1.get_public_url(), get_cms_setting('CMS_TOOLBAR_URL__EDIT_OFF')
+        ))
+        # check when in live mode
+        request = self.get_page_request(page, superuser, edit=False)
+        response = detail_view(request, ex1.pk)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'href="%s?%s"' % (
+            ex1.get_draft_url(), get_cms_setting('CMS_TOOLBAR_URL__EDIT_ON')
+        ))
+        self.assertNotEqual(ex1.get_draft_url(), ex1.get_public_url())
+
     def test_anon(self):
         user = self.get_anon()
         page = create_page('Test', 'col_two.html', 'en', published=True)

--- a/cms/toolbar/toolbar.py
+++ b/cms/toolbar/toolbar.py
@@ -17,7 +17,6 @@ from django.http import HttpResponseRedirect, HttpResponse
 from django.middleware.csrf import get_token
 from django.utils.translation import ugettext_lazy as _
 from django.utils.datastructures import SortedDict
-from cms.utils.plugins import downcast_plugins
 
 
 class CMSToolbarLoginForm(AuthenticationForm):
@@ -63,12 +62,14 @@ class CMSToolbar(ToolbarAPIMixin):
         self.toolbar_language = self.language
 
         user_settings = self.get_user_settings()
-        if (settings.USE_I18N and user_settings.language in dict(settings.LANGUAGES)) or (
-                not settings.USE_I18N and user_settings.language == settings.LANGUAGE_CODE):
-            self.toolbar_language = user_settings.language
-        else:
-            user_settings.language = self.language
-            user_settings.save()
+        if user_settings:
+            if (settings.USE_I18N and user_settings.language in dict(settings.LANGUAGES)) or (
+                    not settings.USE_I18N and user_settings.language == settings.LANGUAGE_CODE):
+                self.toolbar_language = user_settings.language
+            else:
+                user_settings.language = self.language
+                user_settings.save()
+            self.clipboard = user_settings.clipboard
 
         with force_language(self.language):
             try:

--- a/cms/toolbar/toolbar.py
+++ b/cms/toolbar/toolbar.py
@@ -31,6 +31,7 @@ class CMSToolbar(ToolbarAPIMixin):
     """
     The default CMS Toolbar
     """
+    watch_models = []
 
     def __init__(self, request):
         super(CMSToolbar, self).__init__()
@@ -213,6 +214,25 @@ class CMSToolbar(ToolbarAPIMixin):
     def get_object_pk(self):
         if self.obj:
             return self.obj.pk
+        return ''
+
+    def get_object_public_url(self):
+        if self.obj:
+            try:
+                return self.obj.get_public_url()
+            except:
+                pass
+        return ''
+
+    def get_object_draft_url(self):
+        if self.obj:
+            try:
+                return self.obj.get_draft_url()
+            except:
+                try:
+                    return self.obj.get_absolute_url()
+                except:
+                    pass
         return ''
 
     # Internal API

--- a/cms/toolbar_base.py
+++ b/cms/toolbar_base.py
@@ -38,3 +38,6 @@ class CMSToolbar(object):
             if app_name and local_app and app_name.startswith(local_app):
                 return True
         return False
+
+    def render_addons(self, context):
+        return []

--- a/docs/how_to/toolbar.rst
+++ b/docs/how_to/toolbar.rst
@@ -285,6 +285,7 @@ selected poll and its sub-methods::
 
         return render(request, 'polls/detail.html', {'poll': poll})
 
+.. _url_changes:
 
 ---------------------
 Detecting url changes
@@ -320,7 +321,9 @@ Example::
             ...
 
 After you add this every change to an instance of ``Poll`` via sideframe or modal window will trigger a redirect to
-the ``get_absolute_url()`` of the poll instance that was edited.
+the URL of the poll instance that was edited, according to the toolbar status: if in *draft* mode
+the ``get_draft_url()`` is returned (or ``get_absolute_url()`` if the former does not exists),
+if in *live* mode and the method exists ``get_public_url()`` is returned;
 
 
 ********

--- a/docs/reference/api_references.rst
+++ b/docs/reference/api_references.rst
@@ -376,6 +376,11 @@ cms.toolbar.toolbar
 
         Language used by the toolbar.
 
+    .. attribute:: watch_models
+
+        A list of model this toolbar works on; used for redirections after editing
+        (:ref:`url_changes`).
+
     .. method:: add_item(item, position=None)
 
         Low level API to add items.

--- a/docs/reference/plugins.rst
+++ b/docs/reference/plugins.rst
@@ -182,6 +182,16 @@ Can the plugin be inserted inside the text plugin?  If this is ``True`` then
 
 See also: `icon_src`_, `icon_alt`_
 
+.. _system_plugin:
+
+system
+------
+
+Default: ``False``
+
+Plugins with this attribute set to True can be dropped in any placeholder, overriding
+any placeholder configuration in :setting:`CMS_PLACEHOLDER_CONF`.
+
 
 Methods
 =======

--- a/docs/reference/plugins.rst
+++ b/docs/reference/plugins.rst
@@ -182,16 +182,6 @@ Can the plugin be inserted inside the text plugin?  If this is ``True`` then
 
 See also: `icon_src`_, `icon_alt`_
 
-.. _system_plugin:
-
-system
-------
-
-Default: ``False``
-
-Plugins with this attribute set to True can be dropped in any placeholder, overriding
-any placeholder configuration in :setting:`CMS_PLACEHOLDER_CONF`.
-
 
 Methods
 =======

--- a/docs/upgrade/3.1.rst
+++ b/docs/upgrade/3.1.rst
@@ -24,6 +24,13 @@ Before upgrading
 Be sure to run ``manage.py cms fix-mptt`` before you upgrade.
 
 
+System plugin attribute
+=======================
+
+:ref:`system_plugin` attribute has been added to :class:`CMSPluginBase`, it allows plugin
+to be added to any placeholder, overriding any placeholder configuration.
+
+
 Dropped support for Django 1.4 and 1.5
 ======================================
 

--- a/docs/upgrade/3.1.rst
+++ b/docs/upgrade/3.1.rst
@@ -24,13 +24,6 @@ Before upgrading
 Be sure to run ``manage.py cms fix-mptt`` before you upgrade.
 
 
-System plugin attribute
-=======================
-
-:ref:`system_plugin` attribute has been added to :class:`CMSPluginBase`, it allows plugin
-to be added to any placeholder, overriding any placeholder configuration.
-
-
 Dropped support for Django 1.4 and 1.5
 ======================================
 


### PR DESCRIPTION
Extends the Toolbar API, adding a few features:

 * system plugins: plugins marked with this attribute skip the placeholder configuration checks;
 * add "addons" concept which allows to render extra content from the toolbar (like clipboard plugins, but it's rather generic);
 * add the ``get_public_url`` / ``get_draft_url`` which allows to implement proper redirection when switching draft / live mode; this requires changes to the existing models to support this semantic; extended documentation for this feature must be implemented as part of #3889 

This also adds the system flag to PlaceholderPlugin and AliasPlugin

Fix #3384