### PR TITLE
Fix extensions copy

### DIFF
--- a/cms/extensions/extension_pool.py
+++ b/cms/extensions/extension_pool.py
@@ -63,20 +63,34 @@ class ExtensionPool(object):
             self._copy_page_extensions(draft_page, public_page, language)
             self._remove_orphaned_page_extensions()
         if self.title_extensions:
-            self._copy_title_extensions(draft_page, public_page, language)
+            self._copy_title_extensions(draft_page, None, language)
             self._remove_orphaned_title_extensions()
 
-    def _copy_page_extensions(self, draft_page, public_page, language):
-        for extension in self.page_extensions:
-            for instance in extension.objects.filter(extended_object=draft_page):
-                instance.copy_to_public(public_page, language)
+    def copy_extensions(self, source_page, target_page, languages=None):
+        if not languages:
+            languages = source_page.get_languages()
+        if self.page_extensions:
+            self._copy_page_extensions(source_page, target_page, None)
+            self._remove_orphaned_page_extensions()
+        for language in languages:
+            if self.title_extensions:
+                self._copy_title_extensions(source_page, target_page, language)
+                self._remove_orphaned_title_extensions()
 
-    def _copy_title_extensions(self, draft_page, public_page, language):
-        draft_title = draft_page.title_set.get(language=language)
-        public_title = draft_title.publisher_public
+    def _copy_page_extensions(self, source_page, target_page, language):
+        for extension in self.page_extensions:
+            for instance in extension.objects.filter(extended_object=source_page):
+                instance.copy_to_public(target_page, language)
+
+    def _copy_title_extensions(self, source_page, target_page, language):
+        source_title = source_page.title_set.get(language=language)
+        if target_page:
+            target_title = target_page.title_set.get(language=language)
+        else:
+            target_title = source_title.publisher_public
         for extension in self.title_extensions:
-            for instance in extension.objects.filter(extended_object=draft_title):
-                instance.copy_to_public(public_title, language)
+            for instance in extension.objects.filter(extended_object=source_title):
+                instance.copy_to_public(target_title, language)
 
     def _remove_orphaned_page_extensions(self):
         for extension in self.page_extensions:
@@ -92,6 +106,17 @@ class ExtensionPool(object):
                 draft_extension=None
             ).delete()
 
+    def get_page_extensions(self, page):
+        extensions = []
+        for extension in self.page_extensions:
+            extensions.extend(list(extension.objects.filter(extended_object=page)))
+        return extensions
+
+    def get_title_extensions(self, title):
+        extensions = []
+        for extension in self.title_extensions:
+            extensions.extend(list(extension.objects.filter(extended_object=title)))
+        return extensions
 
 extension_pool = ExtensionPool()
 

--- a/cms/extensions/extension_pool.py
+++ b/cms/extensions/extension_pool.py
@@ -66,17 +66,6 @@ class ExtensionPool(object):
             self._copy_title_extensions(draft_page, None, language)
             self._remove_orphaned_title_extensions()
 
-    def copy_extensions(self, source_page, target_page, languages=None):
-        if not languages:
-            languages = source_page.get_languages()
-        if self.page_extensions:
-            self._copy_page_extensions(source_page, target_page, None)
-            self._remove_orphaned_page_extensions()
-        for language in languages:
-            if self.title_extensions:
-                self._copy_title_extensions(source_page, target_page, language)
-                self._remove_orphaned_title_extensions()
-
     def _copy_page_extensions(self, source_page, target_page, language):
         for extension in self.page_extensions:
             for instance in extension.objects.filter(extended_object=source_page):
@@ -91,6 +80,17 @@ class ExtensionPool(object):
         for extension in self.title_extensions:
             for instance in extension.objects.filter(extended_object=source_title):
                 instance.copy_to_public(target_title, language)
+
+    def copy_extensions(self, source_page, target_page, languages=None):
+        if not languages:
+            languages = source_page.get_languages()
+        if self.page_extensions:
+            self._copy_page_extensions(source_page, target_page, None)
+            self._remove_orphaned_page_extensions()
+        for language in languages:
+            if self.title_extensions:
+                self._copy_title_extensions(source_page, target_page, language)
+                self._remove_orphaned_title_extensions()
 
     def _remove_orphaned_page_extensions(self):
         for extension in self.page_extensions:

--- a/cms/extensions/extension_pool.py
+++ b/cms/extensions/extension_pool.py
@@ -106,16 +106,22 @@ class ExtensionPool(object):
                 draft_extension=None
             ).delete()
 
-    def get_page_extensions(self, page):
+    def get_page_extensions(self, page=None):
         extensions = []
         for extension in self.page_extensions:
-            extensions.extend(list(extension.objects.filter(extended_object=page)))
+            if page:
+                extensions.extend(list(extension.objects.filter(extended_object=page)))
+            else:
+                extensions.extend(list(extension.objects.all()))
         return extensions
 
-    def get_title_extensions(self, title):
+    def get_title_extensions(self, title=None):
         extensions = []
         for extension in self.title_extensions:
-            extensions.extend(list(extension.objects.filter(extended_object=title)))
+            if title:
+                extensions.extend(list(extension.objects.filter(extended_object=title)))
+            else:
+                extensions.extend(list(extension.objects.all()))
         return extensions
 
 extension_pool = ExtensionPool()

--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -328,6 +328,7 @@ class Page(with_metaclass(PageMetaClass, MPTTModel)):
             tree[0].old_pk = tree[0].pk
 
         first = True
+        first_page = None
         # loop over all affected pages (self is included in descendants)
         for page in pages:
             titles = list(page.title_set.all())
@@ -353,6 +354,7 @@ class Page(with_metaclass(PageMetaClass, MPTTModel)):
                 else:
                     page.parent = None
                 page.insert_at(target, position)
+                first_page = page
             else:
                 count = 1
                 found = False
@@ -419,7 +421,7 @@ class Page(with_metaclass(PageMetaClass, MPTTModel)):
             extension_pool.copy_extensions(Page.objects.get(pk=origin_id), page)
         # invalidate the menu for this site
         menu_pool.clear(site_id=site.pk)
-        return page
+        return first_page
 
     def save(self, no_signals=False, commit=True, **kwargs):
         """

--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -309,6 +309,7 @@ class Page(with_metaclass(PageMetaClass, MPTTModel)):
         Note for issue #1166: when copying pages there is no need to check for
         conflicting URLs as pages are copied unpublished.
         """
+        from cms.extensions import extension_pool
         pages = [self] + list(self.get_descendants().order_by('-rght'))
 
         site_reverse_ids = Page.objects.filter(site=site, reverse_id__isnull=False).values_list('reverse_id', flat=True)
@@ -415,8 +416,10 @@ class Page(with_metaclass(PageMetaClass, MPTTModel)):
                     page.placeholders.add(ph)
                 if plugins:
                     copy_plugins_to(plugins, ph)
+            extension_pool.copy_extensions(Page.objects.get(pk=origin_id), page)
         # invalidate the menu for this site
         menu_pool.clear(site_id=site.pk)
+        return page
 
     def save(self, no_signals=False, commit=True, **kwargs):
         """

--- a/cms/tests/extensions.py
+++ b/cms/tests/extensions.py
@@ -91,6 +91,29 @@ class ExtensionsTestCase(TestCase):
 
         return TestNoneExtension
 
+    def test_copy_extensions(self):
+        root = create_page('Root', "nav_playground.html", "en", published=True)
+        page = create_page('Test Page Extension', "nav_playground.html", "en",
+                           parent=root.get_draft_object())
+        page_extension = MyPageExtension(extended_object=page, extra='page extension 1')
+        page_extension.save()
+        page.mypageextension = page_extension
+        title = page.get_title_obj()
+        title_extension = MyTitleExtension(extended_object=title, extra_title='title extension 1')
+        title_extension.save()
+        page.mytitleextension = title_extension
+
+        copied_page = page.copy_page(root.get_draft_object(), page.site, position='last-child')
+        copied_title = copied_page.title_set.get(language='en')
+
+        self.assertEqual(len(extension_pool.get_page_extensions(copied_page)), 1)
+        self.assertEqual(len(extension_pool.get_title_extensions(copied_title)), 1)
+
+        self.assertEqual(extension_pool.get_page_extensions(copied_page)[0].extra,
+                         page_extension.extra)
+        self.assertEqual(extension_pool.get_title_extensions(copied_title)[0].extra_title,
+                         title_extension.extra_title)
+
     def test_publish_page_extension(self):
         page = create_page('Test Page Extension', "nav_playground.html", "en")
         page_extension = MyPageExtension(extended_object=page, extra='page extension 1')


### PR DESCRIPTION
Add page/title extensions copy logic into ``Page.copy_page`` method
Fix #3551