### PR TITLE
Fix copy page when permission is disabled

### DIFF
--- a/cms/templates/admin/cms/page/tree/base.html
+++ b/cms/templates/admin/cms/page/tree/base.html
@@ -46,9 +46,9 @@ $(document).ready(function () {
 	// initialize tree
 	new CMS.TreeManager({
 		'settings': {
-			'permission': {{ CMS_PERMISSION|json }},
-			'debug': {{ DEBUG|json }},
-			'filtered': {% if cl.is_filtered %}true{% else %}false{% endif %}
+			'permission': {{ CMS_PERMISSION|bool }},
+			'debug': {{ DEBUG|bool }},
+			'filtered': {{ cl.is_filtered|bool }}
 		},
 		'lang': {
 			'success': '{% filter escapejs %}{% trans "Successfully moved" %}{% endfilter %}',

--- a/cms/tests/templatetags.py
+++ b/cms/tests/templatetags.py
@@ -12,6 +12,7 @@ from django.template import RequestContext, Context
 from django.test import RequestFactory, TestCase
 from django.template.base import Template
 from django.utils.html import escape
+from django.utils.timezone import now
 from djangocms_text_ckeditor.cms_plugins import TextPlugin
 
 from cms.api import create_page, create_title, add_plugin
@@ -20,6 +21,7 @@ from cms.models.pagemodel import Page, Placeholder
 from cms.templatetags.cms_tags import (_get_page_by_untyped_arg,
                                        _show_placeholder_for_page,
                                        _get_placeholder, RenderPlugin)
+from cms.templatetags.cms_js_tags import json_filter
 from cms.test_utils.fixtures.templatetags import TwoPagesFixture
 from cms.test_utils.testcases import SettingsOverrideTestCase, CMSTestCase
 from cms.test_utils.util.context_managers import SettingsOverride
@@ -70,6 +72,17 @@ class TemplatetagTests(TestCase):
         output = template.render(context)
         self.assertNotEqual(script, output)
         self.assertEqual(escape(script), output)
+
+    def test_json_encoder(self):
+        self.assertEqual(json_filter(True), 'true')
+        self.assertEqual(json_filter(False), 'false')
+        self.assertEqual(json_filter([1, 2, 3]), '[1, 2, 3]')
+        self.assertEqual(json_filter((1, 2, 3)), '[1, 2, 3]')
+        filtered_dict = json_filter({'item1': 1, 'item2': 2, 'item3': 3})
+        self.assertTrue('"item1": 1' in filtered_dict)
+        self.assertTrue('"item2": 2' in filtered_dict)
+        self.assertTrue('"item3": 3' in filtered_dict)
+        self.assertEqual('"%s"' % now().today().isoformat()[:-3], json_filter(now().today()))
 
 
 class TemplatetagDatabaseTests(TwoPagesFixture, SettingsOverrideTestCase):

--- a/cms/utils/encoder.py
+++ b/cms/utils/encoder.py
@@ -3,12 +3,13 @@ from django.utils.html import conditional_escape
 from django.utils.encoding import force_text
 from django.utils.functional import Promise
 from django.core.serializers.json import DjangoJSONEncoder
+from django.utils.six import iteritems
 
 
 class SafeJSONEncoder(DjangoJSONEncoder):
     def _recursive_escape(self, o, esc=conditional_escape):
         if isinstance(o, dict):
-            return type(o)((esc(k), self._recursive_escape(v)) for (k, v) in o.iteritems())
+            return type(o)((esc(k), self._recursive_escape(v)) for (k, v) in iteritems(o))
         if isinstance(o, (list, tuple)):
             return type(o)(self._recursive_escape(v) for v in o)
         if type(o) is bool:

--- a/cms/utils/encoder.py
+++ b/cms/utils/encoder.py
@@ -15,7 +15,7 @@ class SafeJSONEncoder(DjangoJSONEncoder):
             return o
         try:
             return type(o)(esc(o))
-        except ValueError:
+        except (ValueError, TypeError):
             return self.default(o)
 
     def encode(self, o):

--- a/cms/utils/encoder.py
+++ b/cms/utils/encoder.py
@@ -9,6 +9,8 @@ class SafeJSONEncoder(DjangoJSONEncoder):
             return type(o)((esc(k), self._recursive_escape(v)) for (k, v) in o.iteritems())
         if isinstance(o, (list, tuple)):
             return type(o)(self._recursive_escape(v) for v in o)
+        if type(o) is bool:
+            return o
         try:
             return type(o)(esc(o))
         except ValueError:


### PR DESCRIPTION
Due to a bug in ``SafeJSONEncoder`` boolean ``False`` was rendered as js value ``true`` disabling copy when permissions is disabled