### PR TITLE
Fixed #3572

### DIFF
--- a/cms/migrations_django/0001_initial.py
+++ b/cms/migrations_django/0001_initial.py
@@ -26,7 +26,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(primary_key=True, verbose_name='ID', auto_created=True, serialize=False)),
                 ('position', models.PositiveSmallIntegerField(null=True, editable=False, blank=True, verbose_name='position')),
                 ('language', models.CharField(db_index=True, max_length=15, verbose_name="language", editable=False)),
-                ('plugin_type', models.CharField(verbose_name='plugin name', max_length=50, editable=False, db_index=True)),
+                ('plugin_type', models.CharField(verbose_name='plugin_name', max_length=50, editable=False, db_index=True)),
                 ('creation_date', models.DateTimeField(default=django.utils.timezone.now, verbose_name='creation date', editable=False)),
                 ('changed_date', models.DateTimeField(auto_now=True)),
                 ('level', models.PositiveIntegerField(db_index=True, editable=False)),

--- a/cms/migrations_django/0002_auto_20140816_1918.py
+++ b/cms/migrations_django/0002_auto_20140816_1918.py
@@ -125,7 +125,7 @@ class Migration(migrations.Migration):
                 ('meta_description', models.TextField(max_length=155, null=True, help_text='The text displayed in search engines.', blank=True, verbose_name='description')),
                 ('slug', models.SlugField(max_length=255, verbose_name='slug')),
                 ('path', models.CharField(db_index=True, max_length=255, verbose_name='Path')),
-                ('has_url_overwrite', models.BooleanField(default=False, verbose_name='has URL overwrite', db_index=True, editable=False)),
+                ('has_url_overwrite', models.BooleanField(default=False, verbose_name='has url overwrite', db_index=True, editable=False)),
                 ('redirect', models.CharField(max_length=255, null=True, blank=True, verbose_name='redirect')),
                 ('creation_date', models.DateTimeField(default=django.utils.timezone.now, verbose_name='creation date', editable=False)),
                 ('published', models.BooleanField(default=False, verbose_name='is published')),


### PR DESCRIPTION
Verbose names in migrations now match models. This also brings 3.0.x branch to match models/migrations in `develop` branch.