### PR TITLE
Fix a js error in advanced settings

### DIFF
--- a/cms/static/cms/js/modules/cms.app_hook_select.js
+++ b/cms/static/cms/js/modules/cms.app_hook_select.js
@@ -18,7 +18,7 @@ $(document).ready(function () {
 	appHooks.setupNamespaces = function() {
 		var opt = $(this).find('option:selected');
 
-		if(apphooks_configuration[opt.val()]){
+		if($(appCfgs).length > 0 && apphooks_configuration[opt.val()]){
 			for(var i=0; i < apphooks_configuration[opt.val()].length; i++) {
 				selectedCfgs = '';
 				if(apphooks_configuration[opt.val()][i][0] == apphooks_configuration_value) {


### PR DESCRIPTION
Fix a js error in advanced settings when no apphook-config application exists