### PR TITLE
Fix cache placeholder

### DIFF
--- a/cms/plugin_rendering.py
+++ b/cms/plugin_rendering.py
@@ -106,7 +106,7 @@ def render_placeholder(placeholder, context_to_copy,
     request = context['request']
     if not hasattr(request, 'placeholders'):
         request.placeholders = []
-    if placeholder.has_change_permission(request):
+    if placeholder.has_change_permission(request) or not placeholder.cache_placeholder:
         request.placeholders.append(placeholder)
     if hasattr(placeholder, 'content_cache'):
         return mark_safe(placeholder.content_cache)

--- a/cms/views.py
+++ b/cms/views.py
@@ -231,11 +231,10 @@ def _cache_page(response):
         return response
     request = response._request
     save_cache = True
-    if hasattr(request, 'placeholders'):
-        for placeholder in request.placeholders:
-            if not placeholder.cache_placeholder:
-                save_cache = False
-                break
+    for placeholder in getattr(request, 'placeholders', []):
+        if not placeholder.cache_placeholder:
+            save_cache = False
+            break
     if hasattr(request, 'toolbar'):
         if request.toolbar.edit_mode or request.toolbar.show_toolbar:
             save_cache = False


### PR DESCRIPTION
If a placeholder or one of its child plugins is marked as non-cachable, this information is not propagated down to the caching middleware and thus in https://github.com/divio/django-cms/blob/support/3.0.x/cms/views.py#L245  ``add_never_cache_headers(response)`` is not set, hence these pages are cached upstream, while they shouldn't.
