### PR TITLE
Fixes #3931 -- Installation documentation is confusing

### DIFF
--- a/docs/how_to/index.rst
+++ b/docs/how_to/index.rst
@@ -8,7 +8,7 @@ the same territory as the :doc:`/introduction/index`, but in more detail.
 .. toctree::
     :maxdepth: 2
 
-    integrate
+    install
     custom_plugins
     menus
     apphooks

--- a/docs/how_to/install.rst
+++ b/docs/how_to/install.rst
@@ -1,6 +1,15 @@
-#############################################
-Integrate django CMS into an existing project
-#############################################
+#############################
+Installing django CMS by hand
+#############################
+
+This is how to install django CMS 'the hard way' (it's not really that hard, but there is an easier
+way).
+
+It's suitable if you want to dive in to integrating django CMS into an existing project, are already
+experienced at setting up Django projects or indeed like to do things the hard way.
+
+If you prefer an easier way using an automated configuration tool - definitely recommended for new
+users - see :doc:`/introduction/install`, which is part of a complete introductory tutorial.
 
 This document assumes you are familiar with Python and Django. After you've
 integrated django CMS into your project, you should be able to follow the
@@ -270,15 +279,15 @@ To use django CMS efficiently, we recommend:
 Configuration and setup
 ***********************
 
-
 Preparing the environment
 =========================
 
-The following assumes your Django project is in ``~/workspace/myproject``.
+The following steps assume your Django project will be - or already is - in
+``~/workspace/myproject``, and that you'll be using a virtualenv.
 
-After completing the OS-specific installation instructions above as well as a pip
-requirements.txt file, you should now be able to create a virtual environment for
-your project and install the requirements:
+If you already have a virtualenv with a project in it, activate it and move on to :ref:`configure-django-cms`.
+
+Otherwise:
 
 .. code-block:: bash
 
@@ -288,12 +297,22 @@ your project and install the requirements:
     pip install -r requirements.txt
 
 
+Create a new Django project
+===========================
+
+::
+
+    django-admin.py startproject myproject
+
+If this is new to you, you ought to read the `official Django tutorial
+<https://docs.djangoproject.com/en/dev/intro/tutorial01/>`_, which covers starting a new project.
+
 .. _configure-django-cms:
 
-Installing and configuring django CMS in your Django project
-============================================================
+Configuring your project for django CMS
+=======================================
 
-Open the file ``~/workspace/myproject/myproject/settings.py``.
+Open the ``settings.py`` file in your project.
 
 To make your life easier, add the following at the top of the file::
 

--- a/docs/introduction/index.rst
+++ b/docs/introduction/index.rst
@@ -17,13 +17,14 @@ Once you're familiar with the basics presented in these tutorials, you'll find
 the more in-depth coverage of the same topics in the :doc:`How-to
 </how_to/index>` section.
 
-The tutorials follow a logical progession and build on each other, so it's
-recommended to work through them in the order presented here.
+The tutorials follow a logical progession, starting from installation of django CMS and the
+creation of a brand new project, and build on each other, so it's recommended to work through them
+in the order presented here.
 
 .. toctree::
     :maxdepth: 1
 
-    install_from_scratch
+    install
     templates_placeholders
     plugins
     apphooks
@@ -31,8 +32,9 @@ recommended to work through them in the order presented here.
     toolbar
     menu
 
-If you prefer, rather than installing django CMS from scratch, you can
-:doc:`/how_to/integrate` and then follow the rest of the tutorials.
+If you want to install django CMS into an existing project, or prefer to configure django CMS by
+hand, rather than using the automated installer, see :doc:`/how_to/install` and then follow the
+rest of the tutorials.
 
 Either way, you'll be able to find support and help from the numerous friendly
 members of the django CMS community, either on our `mailinglist`_ or IRC

--- a/docs/introduction/install.rst
+++ b/docs/introduction/install.rst
@@ -1,6 +1,6 @@
-##################################
-Installing django CMS from scratch
-##################################
+#####################
+Installing django CMS
+#####################
 
 We'll get started by setting up our environment.
 
@@ -41,8 +41,7 @@ Create a new directory to work in, and cd into it::
     mkdir tutorial-project
     cd tutorial-project
 
-Run it to create a new
-Django project called ``mysite``::
+Run it to create a new Django project called ``mysite``::
 
     djangocms -p . mysite
 


### PR DESCRIPTION
This patch retitles the two installation documents (one for automated, one for manual, installation)
and clarifies their purpose.