### PR TITLE
Fixes #3784 -- adds notes on ordering in INSTALLED_APPS

### DIFF
--- a/docs/how_to/integrate.rst
+++ b/docs/how_to/integrate.rst
@@ -303,9 +303,8 @@ To make your life easier, add the following at the top of the file::
     BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 
 
-Add the following apps to your :setting:`django:INSTALLED_APPS`.
-This includes django CMS itself as well as its dependenices and
-other highly recommended applications/libraries::
+Add the following apps to your :setting:`django:INSTALLED_APPS`. This includes django CMS itself as
+well as its dependencies and other highly recommended applications/libraries::
 
     'cms',  # django CMS itself
     'mptt',  # utilities for implementing a tree
@@ -315,8 +314,8 @@ other highly recommended applications/libraries::
     'djangocms_admin_style',  # for the admin skin. You **must** add 'djangocms_admin_style' in the list **before** 'django.contrib.admin'.
     'django.contrib.messages',  # to enable messages framework (see :ref:`Enable messages <enable-messages>`)
 
-
-Also add any (or all) of the following plugins, depending on your needs::
+Also add any (or all) of the following plugins, depending on your needs (see the note in
+:ref:`installed_apps` about ordering)::
 
     'djangocms_file',
     'djangocms_flash',
@@ -327,7 +326,7 @@ Also add any (or all) of the following plugins, depending on your needs::
     'djangocms_video',
     'djangocms_link',
     'djangocms_snippet',
-    'djangocms_text_ckeditor',  # note this needs to be above the 'cms' entry
+
 
 .. note::
 

--- a/docs/how_to/sitemap.rst
+++ b/docs/how_to/sitemap.rst
@@ -18,11 +18,11 @@ your CMS
 Configuration
 *************
 
- * Add :mod:`django.contrib.sitemaps` to your project's :setting:`django:INSTALLED_APPS`
-   setting.
- * Add ``from cms.sitemaps import CMSSitemap`` to the top of your main ``urls.py``.
- * Add ``url(r'^sitemap\.xml$', 'django.contrib.sitemaps.views.sitemap', {'sitemaps': {'cmspages': CMSSitemap}}),``
-   to your urlpatterns.
+ * add :mod:`django.contrib.sitemaps` to your project's :setting:`django:INSTALLED_APPS`
+   setting
+ * add ``from cms.sitemaps import CMSSitemap`` to the top of your main ``urls.py``
+ * add ``url(r'^sitemap\.xml$', 'django.contrib.sitemaps.views.sitemap', {'sitemaps': {'cmspages': CMSSitemap}}),``
+   to your urlpatterns
 
 
 ***********************
@@ -32,4 +32,4 @@ django.contrib.sitemaps
 More information about :mod:`django.contrib.sitemaps` can be found in the official
 `Django documentation <http://docs.djangoproject.com/en/dev/ref/contrib/sitemaps/>`_.
 
- 
+

--- a/docs/introduction/plugins.rst
+++ b/docs/introduction/plugins.rst
@@ -26,8 +26,8 @@ You should end up with a folder structure similar to this::
                     urls.py
                     views.py
 
-Let's add it this application to our project. Add ``'polls'`` to the end
-of `INSTALLED_APPS` in your project's `settings.py`.
+Let's add it this application to our project. Add ``'polls'`` to the end of ``INSTALLED_APPS`` in
+your project's `settings.py` (see the note on :ref:`installed_apps` about ordering ).
 
 Add the following line to ``urlpatterns`` in the project's ``urls.py``::
 

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -7,6 +7,15 @@ Configuration
 django CMS has a number of settings to configure its behaviour. These should
 be available in your ``settings.py`` file.
 
+.. _installed_apps:
+
+******************************
+The ``INSTALLED_APPS`` setting
+******************************
+
+The ordering of items in ``INSTALLED_APPS`` matters. Entries for applications with plugins
+should come *after* ``cms``.
+
 ************************
 Custom User Requirements
 ************************
@@ -25,9 +34,12 @@ Additionally, the application in which the model is defined **must** be loaded b
 
 .. note::
 
-    In most cases, it is better to create a UserProfile model with a one to one relationship to auth.User rather than creating a custom user model.  Custom user models are only necessary if you intended to alter the default behavior of the User model, not simply extend it.
+    In most cases, it is better to create a UserProfile model with a one to one relationship to
+    auth.User rather than creating a custom user model. Custom user models are only necessary if
+    you intended to alter the default behavior of the User model, not simply extend it.
 
-    Additionally, if you do intend to use a custom user model, it is generally advisable to do so only at the beginning of a project, before the database is created.
+    Additionally, if you do intend to use a custom user model, it is generally advisable to do so
+    only at the beginning of a project, before the database is created.
 
 *****************
 Required Settings

--- a/docs/topics/commonly_used_plugins.rst
+++ b/docs/topics/commonly_used_plugins.rst
@@ -14,6 +14,9 @@ These are the recommended plugins to use with django CMS.
 
 .. :class:: djangocms_file.cms_plugins.FilePlugin
 
+.. important::
+    See the note on :ref:`installed_apps` about ordering.
+
 ****
 File
 ****


### PR DESCRIPTION
`cms` should come before applications with plugins. Notes added to
several pages within the documentation.