### PR TITLE
Allow SITE_ID to be an integer-valued object.

### DIFF
--- a/cms/utils/conf.py
+++ b/cms/utils/conf.py
@@ -158,7 +158,7 @@ def _ensure_languages_settings_new(languages):
             defaults[key] = True
 
     for site, language_list in languages.items():
-        if not isinstance(site, six.integer_types):
+        if site != hash(site):
             raise ImproperlyConfigured(
                 "CMS_LANGUAGES can only be filled with integers (site IDs) and 'default'"
                 " for default values. %s is not a valid key." % site)
@@ -248,7 +248,7 @@ def _ensure_languages_settings(languages):
 
 
 def get_languages():
-    if not isinstance(settings.SITE_ID, six.integer_types):
+    if settings.SITE_ID != hash(settings.SITE_ID):
         raise ImproperlyConfigured(
             "SITE_ID must be an integer"
         )


### PR DESCRIPTION
This allows for the use of dynamic site mechanisms like django-multisite.  I think it's actually a better test, since you want to use the site id in a hash, and this tests that directly.  Fails for None and succeeds for True/False, same as the current test.