### PR TITLE
Removed obsolete compatibility layer

### DIFF
--- a/cms/api.py
+++ b/cms/api.py
@@ -21,8 +21,9 @@ from cms.app_base import CMSApp
 from cms.apphook_pool import apphook_pool
 from cms.constants import TEMPLATE_INHERITANCE_MAGIC
 from cms.models.pagemodel import Page
-from cms.models.permissionmodels import (PageUser, PagePermission,
+from cms.models.permissionmodels import (PagePermission,
     GlobalPagePermission, ACCESS_PAGE_AND_DESCENDANTS)
+from cms.models.pageuserpermissions import PageUser
 from cms.models.placeholdermodel import Placeholder
 from cms.models.pluginmodel import CMSPlugin
 from cms.models.titlemodels import Title

--- a/cms/forms/widgets.py
+++ b/cms/forms/widgets.py
@@ -11,7 +11,7 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
 
 from cms.forms.utils import get_site_choices, get_page_choices
-from cms.models import Page, PageUser
+from cms.models import Page
 from cms.templatetags.cms_admin import CMS_ADMIN_ICON_BASE
 from cms.utils.compat.dj import force_unicode
 
@@ -212,6 +212,8 @@ class UserSelectAdminWidget(Select):
     attribute.
     """
     def render(self, name, value, attrs=None, choices=()):
+        from cms.models.pageuserpermissions import PageUser
+
         output = [super(UserSelectAdminWidget, self).render(name, value, attrs, choices)]    
         if hasattr(self, 'user') and (self.user.is_superuser or \
             self.user.has_perm(PageUser._meta.app_label + '.' + PageUser._meta.get_add_permission())):

--- a/cms/models/__init__.py
+++ b/cms/models/__init__.py
@@ -3,6 +3,7 @@ from .settingmodels import *  # nopyflakes
 from .pagemodel import *  # nopyflakes
 from .permissionmodels import *  # nopyflakes
 from .placeholdermodel import *  # nopyflakes
+from .pageuserpermissions import *  # nopyflakes
 from .pluginmodel import *  # nopyflakes
 from .titlemodels import *  # nopyflakes
 from .placeholderpluginmodel import *  # nopyflakes

--- a/cms/models/pageuserpermissions.py
+++ b/cms/models/pageuserpermissions.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-# -*- coding: utf-8 -*-
 from django.conf import settings
 from django.contrib.auth.models import Group
 from django.core.exceptions import ImproperlyConfigured

--- a/cms/models/pageuserpermissions.py
+++ b/cms/models/pageuserpermissions.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
+from django.conf import settings
+from django.contrib.auth.models import Group
+from django.core.exceptions import ImproperlyConfigured
+from django.utils.translation import ugettext_lazy as _
+from django.db import models
+
+
+def _get_user_model():
+    """
+    Returns the User model that is active in this project.
+    """
+    import importlib
+    from django.db.models import get_model
+
+    try:
+        app_label, model_name = settings.AUTH_USER_MODEL.split('.')
+    except ValueError:
+        raise ImproperlyConfigured("AUTH_USER_MODEL must be of the form 'app_label.model_name'")
+    user_model = get_model(app_label, model_name, only_installed=False)
+    if user_model is None:
+        module = importlib.import_module(app_label)
+        user_model = getattr(module, model_name)
+    return user_model
+
+
+class PageUser(_get_user_model()):
+    """CMS specific user data, required for permission system"""
+    created_by = models.ForeignKey(settings.AUTH_USER_MODEL, related_name="created_users")
+
+    class Meta:
+        verbose_name = _('User (page)')
+        verbose_name_plural = _('Users (page)')
+        app_label = 'cms'
+
+
+class PageUserGroup(Group):
+    """Cms specific group data, required for permission system
+    """
+    created_by = models.ForeignKey(settings.AUTH_USER_MODEL, related_name="created_usergroups")
+
+    class Meta:
+        verbose_name = _('User group (page)')
+        verbose_name_plural = _('User groups (page)')
+        app_label = 'cms'

--- a/cms/models/permissionmodels.py
+++ b/cms/models/permissionmodels.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from django.core.exceptions import ImproperlyConfigured
 from django.conf import settings
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
@@ -30,20 +29,6 @@ ACCESS_CHOICES = (
     (ACCESS_DESCENDANTS, _('Page descendants')),
     (ACCESS_PAGE_AND_DESCENDANTS, _('Page and descendants')),
 )
-
-
-def _get_user_model():
-    """
-    Returns the User model that is active in this project.
-    """
-    from django.db.models import get_model
-
-    try:
-        app_label, model_name = settings.AUTH_USER_MODEL.split('.')
-    except ValueError:
-        raise ImproperlyConfigured("AUTH_USER_MODEL must be of the form 'app_label.model_name'")
-    user_model = get_model(app_label, model_name, only_installed=False)
-    return user_model
 
 
 class AbstractPagePermission(models.Model):
@@ -116,27 +101,5 @@ class PagePermission(AbstractPagePermission):
     def __str__(self):
         page = self.page_id and force_unicode(self.page) or "None"
         return "%s :: %s has: %s" % (page, self.audience, force_unicode(dict(ACCESS_CHOICES)[self.grant_on]))
-
-
-class PageUser(_get_user_model()):
-    """CMS specific user data, required for permission system"""
-    created_by = models.ForeignKey(settings.AUTH_USER_MODEL, related_name="created_users")
-
-    class Meta:
-        verbose_name = _('User (page)')
-        verbose_name_plural = _('Users (page)')
-        app_label = 'cms'
-
-
-class PageUserGroup(Group):
-    """Cms specific group data, required for permission system
-    """
-    created_by = models.ForeignKey(settings.AUTH_USER_MODEL, related_name="created_usergroups")
-
-    class Meta:
-        verbose_name = _('User group (page)')
-        verbose_name_plural = _('User groups (page)')
-        app_label = 'cms'
-
 
 reversion_register(PagePermission)

--- a/cms/models/permissionmodels.py
+++ b/cms/models/permissionmodels.py
@@ -1,10 +1,14 @@
 # -*- coding: utf-8 -*-
+from django import VERSION as DJANGO_VERSION
 from django.conf import settings
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 from django.contrib.auth.models import Group
 from django.contrib.sites.models import Site
-from django.utils.encoding import force_unicode, python_2_unicode_compatible
+if DJANGO_VERSION[:2] >= (1, 6):
+    from django.utils.encoding import force_unicode, python_2_unicode_compatible
+else:
+    from cms.utils.compat.dj import force_unicode, python_2_unicode_compatible
 from cms.models import Page
 from cms.models.managers import PagePermissionManager, GlobalPagePermissionManager
 from cms.utils.helpers import reversion_register

--- a/cms/models/permissionmodels.py
+++ b/cms/models/permissionmodels.py
@@ -1,47 +1,14 @@
 # -*- coding: utf-8 -*-
 from django.conf import settings
 from django.db import models
-from django.utils import importlib
 from django.utils.translation import ugettext_lazy as _
-from django.core.exceptions import ImproperlyConfigured
 from django.contrib.auth.models import Group
 from django.contrib.sites.models import Site
 
 from cms.models import Page
-from cms.models.managers import (PagePermissionManager,
-                                 GlobalPagePermissionManager)
-from cms.utils.compat import DJANGO_1_6
-from cms.utils.compat.dj import (force_unicode, python_2_unicode_compatible,
-                                 is_user_swapped, user_model_label)
+from cms.models.managers import PagePermissionManager, GlobalPagePermissionManager
+from cms.utils.compat.dj import force_unicode, python_2_unicode_compatible, user_model_label
 from cms.utils.helpers import reversion_register
-
-# To avoid circular dependencies, don't use cms.compat.get_user_model, and
-# don't depend on the app registry, to get the custom user model if used
-if is_user_swapped:
-    user_app_name, user_model_name = user_model_label.rsplit('.', 1)
-    User = None
-    if DJANGO_1_6:
-        for app in settings.INSTALLED_APPS:
-            if app.endswith(user_app_name):
-                user_app_models = importlib.import_module(app + ".models")
-                User = getattr(user_app_models, user_model_name)
-                break
-    else:
-        # This is sort of a hack
-        # AppConfig is not ready yet, and we blindly check if the user model
-        # application has already been loaded
-        from django.apps import apps
-        try:
-            User = apps.all_models[user_app_name][user_model_name.lower()]
-        except KeyError:
-            pass
-    if User is None:
-        raise ImproperlyConfigured(
-            "You have defined a custom user model %s, but the app %s is not "
-            "in settings.INSTALLED_APPS" % (user_model_label, user_app_name)
-        )
-else:
-    from django.contrib.auth.models import User
 
 # NOTE: those are not just numbers!! we will do binary AND on them,
 # so pay attention when adding/changing them, or MASKs..
@@ -63,6 +30,7 @@ ACCESS_CHOICES = (
     (ACCESS_DESCENDANTS, _('Page descendants')),
     (ACCESS_PAGE_AND_DESCENDANTS, _('Page and descendants')),
 )
+
 
 class AbstractPagePermission(models.Model):
     """Abstract page permissions
@@ -136,9 +104,10 @@ class PagePermission(AbstractPagePermission):
         return "%s :: %s has: %s" % (page, self.audience, force_unicode(dict(ACCESS_CHOICES)[self.grant_on]))
 
 
-class PageUser(User):
+class PageUser(models.Model):
     """Cms specific user data, required for permission system
     """
+    user_ptr = models.OneToOneField(settings.AUTH_USER_MODEL, primary_key=True, parent_link=True)
     created_by = models.ForeignKey(user_model_label, related_name="created_users")
 
     class Meta:

--- a/test_requirements/requirements_base.txt
+++ b/test_requirements/requirements_base.txt
@@ -11,6 +11,7 @@ django-sekizai>=0.7
 argparse
 dj-database-url
 selenium
+six
 django-debug-toolbar
 -e git+git://github.com/divio/djangocms-admin-style.git#egg=djangocms-admin-style
 -e git+git://github.com/divio/djangocms-text-ckeditor.git#egg=djangocms-text-ckeditor


### PR DESCRIPTION
This compatibility layer added

* *“sort of a hack”* (citation @yakky )
* added non robust code ``importlib.import_module(app + ".models")`` – this caused issue #3973
* accessed private class members: ``User._meta.swapped``
* duplicated code, available since Django-1.4

I therefore would strongly suggest to do some code cleaning here
