### PR TITLE
Fix UnboundLocalError in cms_tags

### DIFF
--- a/cms/templatetags/cms_tags.py
+++ b/cms/templatetags/cms_tags.py
@@ -303,6 +303,7 @@ class Placeholder(Tag):
             if nodelist:
                 return nodelist.render(context)
             return ''
+        content = ''
         try:
             content = get_placeholder_content(context, request, page, name, inherit, nodelist)
         except PlaceholderNotFound:


### PR DESCRIPTION
`content` is used in line 311 without being defined first.