### PR TITLE
Fixes #4005

### DIFF
--- a/cms/admin/useradmin.py
+++ b/cms/admin/useradmin.py
@@ -21,7 +21,7 @@ class PageUserAdmin(admin_class, GenericCmsPermissionAdmin):
     form = PageUserForm
     add_form = PageUserForm
     model = PageUser
-    
+
     def queryset(self, request):
         qs = super(PageUserAdmin, self).queryset(request)
         try:
@@ -30,15 +30,15 @@ class PageUserAdmin(admin_class, GenericCmsPermissionAdmin):
         except NoPermissionsException:
             return self.model.objects.get_empty_query_set()
 
-    
+
 class PageUserGroupAdmin(admin.ModelAdmin, GenericCmsPermissionAdmin):
     form = PageUserGroupForm
     list_display = ('name', 'created_by')
-    
+
     fieldsets = [
         (None, {'fields': ('name',)}),
     ]
-    
+
     def get_fieldsets(self, request, obj=None):
         return self.update_permission_fieldsets(request, obj)
 

--- a/cms/api.py
+++ b/cms/api.py
@@ -21,8 +21,9 @@ from cms.app_base import CMSApp
 from cms.apphook_pool import apphook_pool
 from cms.constants import TEMPLATE_INHERITANCE_MAGIC
 from cms.models.pagemodel import Page
-from cms.models.permissionmodels import (PageUser, PagePermission,
-    GlobalPagePermission, ACCESS_PAGE_AND_DESCENDANTS)
+from cms.models.permissionmodels import (PagePermission, GlobalPagePermission,
+                                         ACCESS_PAGE_AND_DESCENDANTS)
+from cms.models.pageuserpermissions import PageUser
 from cms.models.placeholdermodel import Placeholder
 from cms.models.pluginmodel import CMSPlugin
 from cms.models.titlemodels import Title

--- a/cms/forms/widgets.py
+++ b/cms/forms/widgets.py
@@ -11,7 +11,7 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
 
 from cms.forms.utils import get_site_choices, get_page_choices
-from cms.models import Page, PageUser
+from cms.models import Page
 from cms.templatetags.cms_admin import CMS_ADMIN_ICON_BASE
 from cms.utils.compat.dj import force_unicode
 
@@ -212,6 +212,8 @@ class UserSelectAdminWidget(Select):
     attribute.
     """
     def render(self, name, value, attrs=None, choices=()):
+        from cms.models.pageuserpermissions import PageUser
+
         output = [super(UserSelectAdminWidget, self).render(name, value, attrs, choices)]    
         if hasattr(self, 'user') and (self.user.is_superuser or \
             self.user.has_perm(PageUser._meta.app_label + '.' + PageUser._meta.get_add_permission())):

--- a/cms/middleware/toolbar.py
+++ b/cms/middleware/toolbar.py
@@ -21,6 +21,7 @@ def toolbar_plugin_processor(instance, placeholder, rendered_content, original_c
     if plugin_class.allow_children:
         inst, plugin = instance.get_plugin_instance()
         page = original_context['request'].current_page
+        plugin.cms_plugin_instance = inst
         children = [plugin_pool.get_plugin(cls) for cls in plugin.get_child_classes(placeholder, page)]
         # Builds the list of dictionaries containing module, name and value for the plugin dropdowns
         child_plugin_classes = get_toolbar_plugin_struct(children, placeholder.slot, placeholder.page,

--- a/cms/models/__init__.py
+++ b/cms/models/__init__.py
@@ -3,6 +3,7 @@ from .settingmodels import *  # nopyflakes
 from .pagemodel import *  # nopyflakes
 from .permissionmodels import *  # nopyflakes
 from .placeholdermodel import *  # nopyflakes
+from .pageuserpermissions import *  # nopyflakes
 from .pluginmodel import *  # nopyflakes
 from .titlemodels import *  # nopyflakes
 from .placeholderpluginmodel import *  # nopyflakes

--- a/cms/models/pageuserpermissions.py
+++ b/cms/models/pageuserpermissions.py
@@ -53,7 +53,7 @@ class PageUser(_get_user_model()):
     """
     CMS specific user data, required for permission system
     """
-    created_by = models.ForeignKey(settings.AUTH_USER_MODEL, related_name="created_users")
+    created_by = models.ForeignKey(getattr(settings, 'AUTH_USER_MODEL', 'auth.User'), related_name="created_users")
 
     class Meta:
         verbose_name = _('User (page)')

--- a/cms/models/pageuserpermissions.py
+++ b/cms/models/pageuserpermissions.py
@@ -11,7 +11,25 @@ def _get_user_model():
     """
     Returns the User model that is active in this project.
     """
-    if DJANGO_VERSION[:2] >= (1, 6):
+    if DJANGO_VERSION[:2] >= (1, 7):
+        from django.apps import apps
+        from django.contrib.auth.models import User
+
+        if settings.AUTH_USER_MODEL == 'auth.User':
+            user_model = User
+        else:
+            # This is sort of a hack
+            # AppConfig is not ready yet, and we blindly check if the user model
+            # application has already been loaded
+            user_app_name, user_model_name = settings.AUTH_USER_MODEL.rsplit('.', 1)
+            try:
+                user_model = apps.all_models[user_app_name][user_model_name.lower()]
+            except KeyError:
+                raise ImproperlyConfigured(
+                    "You have defined a custom user model %s, but the app %s is not "
+                    "in settings.INSTALLED_APPS" % (settings.AUTH_USER_MODEL, user_app_name)
+                )
+    elif DJANGO_VERSION[:2] == (1, 6):
         import importlib
         from django.db.models import get_model
 

--- a/cms/models/pageuserpermissions.py
+++ b/cms/models/pageuserpermissions.py
@@ -23,28 +23,11 @@ def _get_user_model():
         if user_model is None:
             module = importlib.import_module(app_label)
             user_model = getattr(module, model_name)
-    else:  # Django-1.4, Django-1.5
-        from cms.utils.compat.dj import is_user_swapped, user_model_label
+    else:
         from django.contrib.auth.models import User
 
-        # To avoid circular dependencies, don't use cms.compat.get_user_model, and
-        # don't depend on the app registry, to get the custom user model if used
+        # In Django-1.4 and Django-1.5 AUTH_USER_MODEL can not be overridden
         user_model = User
-        if is_user_swapped:
-            user_app_name, user_model_name = user_model_label.rsplit('.', 1)
-            # This is sort of a hack
-            # AppConfig is not ready yet, and we blindly check if the user model
-            # application has already been loaded
-            from django.apps import apps
-            try:
-                user_model = apps.all_models[user_app_name][user_model_name.lower()]
-            except KeyError:
-                user_model = None
-            if user_model is None:
-                raise ImproperlyConfigured(
-                    "You have defined a custom user model %s, but the app %s is not "
-                    "in settings.INSTALLED_APPS" % (user_model_label, user_app_name)
-                )
     return user_model
 
 

--- a/cms/models/pageuserpermissions.py
+++ b/cms/models/pageuserpermissions.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+from django import VERSION as DJANGO_VERSION
+from django.conf import settings
+from django.contrib.auth.models import Group
+from django.core.exceptions import ImproperlyConfigured
+from django.utils.translation import ugettext_lazy as _
+from django.db import models
+
+
+def _get_user_model():
+    """
+    Returns the User model that is active in this project.
+    """
+    if DJANGO_VERSION[:2] >= (1, 6):
+        import importlib
+        from django.db.models import get_model
+
+        try:
+            app_label, model_name = settings.AUTH_USER_MODEL.split('.')
+        except ValueError:
+            raise ImproperlyConfigured("AUTH_USER_MODEL must be of the form 'app_label.model_name'")
+        user_model = get_model(app_label, model_name, only_installed=False)
+        if user_model is None:
+            module = importlib.import_module(app_label)
+            user_model = getattr(module, model_name)
+    else:  # Django-1.4, Django-1.5
+        from cms.utils.compat.dj import is_user_swapped, user_model_label
+
+        # To avoid circular dependencies, don't use cms.compat.get_user_model, and
+        # don't depend on the app registry, to get the custom user model if used
+        if is_user_swapped:
+            user_app_name, user_model_name = user_model_label.rsplit('.', 1)
+            # This is sort of a hack
+            # AppConfig is not ready yet, and we blindly check if the user model
+            # application has already been loaded
+            from django.apps import apps
+            try:
+                user_model = apps.all_models[user_app_name][user_model_name.lower()]
+            except KeyError:
+                user_model = None
+            if user_model is None:
+                raise ImproperlyConfigured(
+                    "You have defined a custom user model %s, but the app %s is not "
+                    "in settings.INSTALLED_APPS" % (user_model_label, user_app_name)
+                )
+    return user_model
+
+
+class PageUser(_get_user_model()):
+    """
+    CMS specific user data, required for permission system
+    """
+    created_by = models.ForeignKey(settings.AUTH_USER_MODEL, related_name="created_users")
+
+    class Meta:
+        verbose_name = _('User (page)')
+        verbose_name_plural = _('Users (page)')
+        app_label = 'cms'
+
+
+class PageUserGroup(Group):
+    """
+    Cms specific group data, required for permission system
+    """
+    created_by = models.ForeignKey(settings.AUTH_USER_MODEL, related_name="created_usergroups")
+
+    class Meta:
+        verbose_name = _('User group (page)')
+        verbose_name_plural = _('User groups (page)')
+        app_label = 'cms'

--- a/cms/models/pageuserpermissions.py
+++ b/cms/models/pageuserpermissions.py
@@ -25,9 +25,11 @@ def _get_user_model():
             user_model = getattr(module, model_name)
     else:  # Django-1.4, Django-1.5
         from cms.utils.compat.dj import is_user_swapped, user_model_label
+        from django.contrib.auth.models import User
 
         # To avoid circular dependencies, don't use cms.compat.get_user_model, and
         # don't depend on the app registry, to get the custom user model if used
+        user_model = User
         if is_user_swapped:
             user_app_name, user_model_name = user_model_label.rsplit('.', 1)
             # This is sort of a hack

--- a/cms/models/pageuserpermissions.py
+++ b/cms/models/pageuserpermissions.py
@@ -19,7 +19,7 @@ def _get_user_model():
             app_label, model_name = settings.AUTH_USER_MODEL.split('.')
         except ValueError:
             raise ImproperlyConfigured("AUTH_USER_MODEL must be of the form 'app_label.model_name'")
-        user_model = get_model(app_label, model_name, only_installed=False)
+        user_model = get_model(app_label, model_name)
         if user_model is None:
             module = importlib.import_module(app_label)
             user_model = getattr(module, model_name)

--- a/cms/models/permissionmodels.py
+++ b/cms/models/permissionmodels.py
@@ -1,47 +1,21 @@
 # -*- coding: utf-8 -*-
+from django import VERSION as DJANGO_VERSION
 from django.conf import settings
 from django.db import models
-from django.utils import importlib
 from django.utils.translation import ugettext_lazy as _
-from django.core.exceptions import ImproperlyConfigured
 from django.contrib.auth.models import Group
 from django.contrib.sites.models import Site
 
 from cms.models import Page
-from cms.models.managers import (PagePermissionManager,
-                                 GlobalPagePermissionManager)
-from cms.utils.compat import DJANGO_1_6
-from cms.utils.compat.dj import (force_unicode, python_2_unicode_compatible,
-                                 is_user_swapped, user_model_label)
+from cms.models.managers import PagePermissionManager, GlobalPagePermissionManager
 from cms.utils.helpers import reversion_register
 
-# To avoid circular dependencies, don't use cms.compat.get_user_model, and
-# don't depend on the app registry, to get the custom user model if used
-if is_user_swapped:
-    user_app_name, user_model_name = user_model_label.rsplit('.', 1)
-    User = None
-    if DJANGO_1_6:
-        for app in settings.INSTALLED_APPS:
-            if app.endswith(user_app_name):
-                user_app_models = importlib.import_module(app + ".models")
-                User = getattr(user_app_models, user_model_name)
-                break
-    else:
-        # This is sort of a hack
-        # AppConfig is not ready yet, and we blindly check if the user model
-        # application has already been loaded
-        from django.apps import apps
-        try:
-            User = apps.all_models[user_app_name][user_model_name.lower()]
-        except KeyError:
-            pass
-    if User is None:
-        raise ImproperlyConfigured(
-            "You have defined a custom user model %s, but the app %s is not "
-            "in settings.INSTALLED_APPS" % (user_model_label, user_app_name)
-        )
+if DJANGO_VERSION[:2] >= (1, 6):
+    from django.utils.encoding import force_text, python_2_unicode_compatible
+    user_model_label = settings.AUTH_USER_MODEL
 else:
-    from django.contrib.auth.models import User
+    from cms.utils.compat.dj import force_unicode as force_text
+    from cms.utils.compat.dj import python_2_unicode_compatible, user_model_label
 
 # NOTE: those are not just numbers!! we will do binary AND on them,
 # so pay attention when adding/changing them, or MASKs..
@@ -90,7 +64,7 @@ class AbstractPagePermission(models.Model):
         """Return audience by priority, so: All or User, Group
         """
         targets = filter(lambda item: item, (self.user, self.group,))
-        return ", ".join([force_unicode(t) for t in targets]) or 'No one'
+        return ", ".join([force_text(t) for t in targets]) or 'No one'
 
     def save(self, *args, **kwargs):
         if not self.user and not self.group:
@@ -132,30 +106,7 @@ class PagePermission(AbstractPagePermission):
         app_label = 'cms'
 
     def __str__(self):
-        page = self.page_id and force_unicode(self.page) or "None"
-        return "%s :: %s has: %s" % (page, self.audience, force_unicode(dict(ACCESS_CHOICES)[self.grant_on]))
-
-
-class PageUser(User):
-    """Cms specific user data, required for permission system
-    """
-    created_by = models.ForeignKey(user_model_label, related_name="created_users")
-
-    class Meta:
-        verbose_name = _('User (page)')
-        verbose_name_plural = _('Users (page)')
-        app_label = 'cms'
-
-
-class PageUserGroup(Group):
-    """Cms specific group data, required for permission system
-    """
-    created_by = models.ForeignKey(user_model_label, related_name="created_usergroups")
-
-    class Meta:
-        verbose_name = _('User group (page)')
-        verbose_name_plural = _('User groups (page)')
-        app_label = 'cms'
-
+        page = self.page_id and force_text(self.page) or "None"
+        return "%s :: %s has: %s" % (page, self.audience, force_text(dict(ACCESS_CHOICES)[self.grant_on]))
 
 reversion_register(PagePermission)

--- a/cms/models/pluginmodel.py
+++ b/cms/models/pluginmodel.py
@@ -188,6 +188,7 @@ class CMSPlugin(with_metaclass(PluginModelBase, MPTTModel)):
             page = None
             if request:
                 page = request.current_page
+            plugin.cms_plugin_instance = instance
             context['allowed_child_classes'] = plugin.get_child_classes(placeholder_slot, page)
             if plugin.render_plugin:
                 template = plugin._get_render_template(context, instance, placeholder)

--- a/cms/templatetags/cms_tags.py
+++ b/cms/templatetags/cms_tags.py
@@ -400,6 +400,7 @@ class PluginChildClasses(InclusionTag):
             plugin_class = plugin.get_plugin_class()
             if plugin_class.allow_children:
                 instance, plugin = plugin.get_plugin_instance()
+                plugin.cms_plugin_instance = instance
                 childs = [plugin_pool.get_plugin(cls) for cls in plugin.get_child_classes(slot, page)]
                 # Builds the list of dictionaries containing module, name and value for the plugin dropdowns
                 child_plugin_classes = get_toolbar_plugin_struct(childs, slot, page, parent=plugin_class)


### PR DESCRIPTION
Fixes #4005 by moving potential circular dependencies into the calling functions.

This PR adds less magicness to ``permissionmodels.py``.

Renamed ``force_unicode`` -> ``force_text``, since thats the correct name.

Obsoletes PR #3975.