### PR TITLE
don't install django 1.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     platforms=['OS Independent'],
     classifiers=CLASSIFIERS,
     install_requires=[
-        'Django>=1.4',
+        'Django>=1.4,<1.8',
         'django-classy-tags>=0.5',
         'south>=0.7.2',
         'html5lib',


### PR DESCRIPTION
If somebody runs "pip install --upgrade django-cms" on current 3.0.x branch, it will run into a unusable environment, because django 1.8 will be installed :(