### PR TITLE
Fix #4023: Update language middleware for Django 1.8.

### DIFF
--- a/cms/middleware/language.py
+++ b/cms/middleware/language.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import datetime
 
-from django.utils.translation import get_language
+from django.utils.translation import (get_language, LANGUAGE_SESSION_KEY)
 from django.conf import settings
 
 
@@ -9,9 +9,9 @@ class LanguageCookieMiddleware(object):
     def process_response(self, request, response):
         language = get_language()
         if hasattr(request, 'session'):
-            session_language = request.session.get('django_language', None)
+            session_language = request.session.get(LANGUAGE_SESSION_KEY, None)
             if session_language and not session_language == language:
-                request.session['django_language'] = language
+                request.session[LANGUAGE_SESSION_KEY] = language
                 request.session.save()
         if settings.LANGUAGE_COOKIE_NAME in request.COOKIES and \
                         request.COOKIES[settings.LANGUAGE_COOKIE_NAME] == language:

--- a/cms/tests/i18n.py
+++ b/cms/tests/i18n.py
@@ -6,6 +6,7 @@ from cms.utils.i18n import get_fallback_languages
 from django.conf import settings
 from django.test.utils import override_settings
 from django.utils.importlib import import_module
+from django.utils.translation import LANGUAGE_SESSION_KEY
 
 
 @override_settings(
@@ -360,13 +361,13 @@ class TestLanguageFallbacks(CMSTestCase):
 
         #   ugly and long set of session
         session = self.client.session
-        session['django_language'] = 'fr'
+        session[LANGUAGE_SESSION_KEY] = 'fr'
         session.save()
         response = self.client.get('/')
         self.assertEqual(response.status_code, 302)
         self.assertRedirects(response, '/fr/')
         self.client.get('/en/')
-        self.assertEqual(self.client.session['django_language'], 'en')
+        self.assertEqual(self.client.session[LANGUAGE_SESSION_KEY], 'en')
         response = self.client.get('/')
         self.assertEqual(response.status_code, 302)
         self.assertRedirects(response, '/en/')

--- a/docs/topics/multiple_languages.rst
+++ b/docs/topics/multiple_languages.rst
@@ -18,7 +18,7 @@ django CMS determines the user's language the same way Django does it.
 
 * the language code prefix in the URL
 * the language set in the session
-* the language in the `django_language` cookie
+* the language in the language cookie
 * the language that the browser says its user prefers
 
 It uses the django built in capabilities for this.
@@ -41,4 +41,3 @@ What django CMS shows in your menus
 
 If :setting:`hide_untranslated` is ``True`` (the default) then pages that
 aren't translated into the desired language will not appear in the menu.
-


### PR DESCRIPTION
I ran the tests, and 9 failed.
However, none are related to the committed changes, I believe, since I also ran the tests for the `develop` branch and got the same 9 errors.

````txt
======================================================================
ERROR: test_po_sanity (cms.tests.po.PoTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ldgarcia/Documents/github/django-cms/cms/tests/po.py", line 57, in test_po_sanity
    ok, stderr = compile_messages()
  File "/home/ldgarcia/Documents/github/django-cms/cms/tests/po.py", line 44, in compile_messages
    pipe = subprocess.Popen(bits, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
  File "/usr/lib/python2.7/subprocess.py", line 710, in __init__
    errread, errwrite)
  File "/usr/lib/python2.7/subprocess.py", line 1335, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory

======================================================================
ERROR: test_publish_limits (cms.tests.reversion_tests.ReversionTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/test/testcases.py", line 189, in __call__
    self._post_teardown()
  File "/home/ldgarcia/Documents/github/django-cms/cms/test_utils/testcases.py", line 98, in _post_teardown
    super(BaseCMSTestCase, self)._post_teardown()
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/test/testcases.py", line 816, in _post_teardown
    self._fixture_teardown()
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/test/testcases.py", line 843, in _fixture_teardown
    inhibit_post_migrate=self.available_apps is not None)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 115, in call_command
    return klass.execute(*args, **defaults)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/base.py", line 338, in execute
    output = self.handle(*args, **options)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/base.py", line 533, in handle
    return self.handle_noargs(**options)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/commands/flush.py", line 93, in handle_noargs
    call_command('loaddata', 'initial_data', **app_options)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 115, in call_command
    return klass.execute(*args, **defaults)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/base.py", line 338, in execute
    output = self.handle(*args, **options)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/commands/loaddata.py", line 61, in handle
    self.loaddata(fixture_labels)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/commands/loaddata.py", line 91, in loaddata
    self.load_label(fixture_label)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/commands/loaddata.py", line 127, in load_label
    for fixture_file, fixture_dir, fixture_name in self.find_fixtures(fixture_label):
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/utils/lru_cache.py", line 101, in wrapper
    result = user_function(*args, **kwds)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/commands/loaddata.py", line 192, in find_fixtures
    fixture_dirs = self.fixture_dirs
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/utils/functional.py", line 55, in __get__
    res = instance.__dict__[self.func.__name__] = self.func(instance)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/commands/loaddata.py", line 253, in fixture_dirs
    dirs = [upath(os.path.abspath(os.path.realpath(d))) for d in dirs]
  File "/home/ldgarcia/venv/dcms/lib/python2.7/posixpath.py", line 383, in realpath
    return abspath(path)
  File "/home/ldgarcia/venv/dcms/lib/python2.7/posixpath.py", line 371, in abspath
    cwd = os.getcwd()
OSError: [Errno 2] No such file or directory

======================================================================
ERROR: test_recover (cms.tests.reversion_tests.ReversionTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/test/testcases.py", line 189, in __call__
    self._post_teardown()
  File "/home/ldgarcia/Documents/github/django-cms/cms/test_utils/testcases.py", line 98, in _post_teardown
    super(BaseCMSTestCase, self)._post_teardown()
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/test/testcases.py", line 816, in _post_teardown
    self._fixture_teardown()
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/test/testcases.py", line 843, in _fixture_teardown
    inhibit_post_migrate=self.available_apps is not None)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 115, in call_command
    return klass.execute(*args, **defaults)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/base.py", line 338, in execute
    output = self.handle(*args, **options)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/base.py", line 533, in handle
    return self.handle_noargs(**options)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/commands/flush.py", line 93, in handle_noargs
    call_command('loaddata', 'initial_data', **app_options)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 115, in call_command
    return klass.execute(*args, **defaults)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/base.py", line 338, in execute
    output = self.handle(*args, **options)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/commands/loaddata.py", line 61, in handle
    self.loaddata(fixture_labels)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/commands/loaddata.py", line 91, in loaddata
    self.load_label(fixture_label)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/commands/loaddata.py", line 127, in load_label
    for fixture_file, fixture_dir, fixture_name in self.find_fixtures(fixture_label):
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/utils/lru_cache.py", line 101, in wrapper
    result = user_function(*args, **kwds)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/commands/loaddata.py", line 192, in find_fixtures
    fixture_dirs = self.fixture_dirs
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/utils/functional.py", line 55, in __get__
    res = instance.__dict__[self.func.__name__] = self.func(instance)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/commands/loaddata.py", line 253, in fixture_dirs
    dirs = [upath(os.path.abspath(os.path.realpath(d))) for d in dirs]
  File "/home/ldgarcia/venv/dcms/lib/python2.7/posixpath.py", line 383, in realpath
    return abspath(path)
  File "/home/ldgarcia/venv/dcms/lib/python2.7/posixpath.py", line 371, in abspath
    cwd = os.getcwd()
OSError: [Errno 2] No such file or directory

======================================================================
ERROR: test_recover_path_collision (cms.tests.reversion_tests.ReversionTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/test/testcases.py", line 189, in __call__
    self._post_teardown()
  File "/home/ldgarcia/Documents/github/django-cms/cms/test_utils/testcases.py", line 98, in _post_teardown
    super(BaseCMSTestCase, self)._post_teardown()
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/test/testcases.py", line 816, in _post_teardown
    self._fixture_teardown()
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/test/testcases.py", line 843, in _fixture_teardown
    inhibit_post_migrate=self.available_apps is not None)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 115, in call_command
    return klass.execute(*args, **defaults)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/base.py", line 338, in execute
    output = self.handle(*args, **options)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/base.py", line 533, in handle
    return self.handle_noargs(**options)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/commands/flush.py", line 93, in handle_noargs
    call_command('loaddata', 'initial_data', **app_options)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 115, in call_command
    return klass.execute(*args, **defaults)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/base.py", line 338, in execute
    output = self.handle(*args, **options)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/commands/loaddata.py", line 61, in handle
    self.loaddata(fixture_labels)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/commands/loaddata.py", line 91, in loaddata
    self.load_label(fixture_label)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/commands/loaddata.py", line 127, in load_label
    for fixture_file, fixture_dir, fixture_name in self.find_fixtures(fixture_label):
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/utils/lru_cache.py", line 101, in wrapper
    result = user_function(*args, **kwds)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/commands/loaddata.py", line 192, in find_fixtures
    fixture_dirs = self.fixture_dirs
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/utils/functional.py", line 55, in __get__
    res = instance.__dict__[self.func.__name__] = self.func(instance)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/commands/loaddata.py", line 253, in fixture_dirs
    dirs = [upath(os.path.abspath(os.path.realpath(d))) for d in dirs]
  File "/home/ldgarcia/venv/dcms/lib/python2.7/posixpath.py", line 383, in realpath
    return abspath(path)
  File "/home/ldgarcia/venv/dcms/lib/python2.7/posixpath.py", line 371, in abspath
    cwd = os.getcwd()
OSError: [Errno 2] No such file or directory

======================================================================
ERROR: test_revert (cms.tests.reversion_tests.ReversionTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/test/testcases.py", line 189, in __call__
    self._post_teardown()
  File "/home/ldgarcia/Documents/github/django-cms/cms/test_utils/testcases.py", line 98, in _post_teardown
    super(BaseCMSTestCase, self)._post_teardown()
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/test/testcases.py", line 816, in _post_teardown
    self._fixture_teardown()
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/test/testcases.py", line 843, in _fixture_teardown
    inhibit_post_migrate=self.available_apps is not None)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 115, in call_command
    return klass.execute(*args, **defaults)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/base.py", line 338, in execute
    output = self.handle(*args, **options)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/base.py", line 533, in handle
    return self.handle_noargs(**options)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/commands/flush.py", line 93, in handle_noargs
    call_command('loaddata', 'initial_data', **app_options)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 115, in call_command
    return klass.execute(*args, **defaults)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/base.py", line 338, in execute
    output = self.handle(*args, **options)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/commands/loaddata.py", line 61, in handle
    self.loaddata(fixture_labels)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/commands/loaddata.py", line 91, in loaddata
    self.load_label(fixture_label)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/commands/loaddata.py", line 127, in load_label
    for fixture_file, fixture_dir, fixture_name in self.find_fixtures(fixture_label):
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/utils/lru_cache.py", line 101, in wrapper
    result = user_function(*args, **kwds)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/commands/loaddata.py", line 192, in find_fixtures
    fixture_dirs = self.fixture_dirs
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/utils/functional.py", line 55, in __get__
    res = instance.__dict__[self.func.__name__] = self.func(instance)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/commands/loaddata.py", line 253, in fixture_dirs
    dirs = [upath(os.path.abspath(os.path.realpath(d))) for d in dirs]
  File "/home/ldgarcia/venv/dcms/lib/python2.7/posixpath.py", line 383, in realpath
    return abspath(path)
  File "/home/ldgarcia/venv/dcms/lib/python2.7/posixpath.py", line 371, in abspath
    cwd = os.getcwd()
OSError: [Errno 2] No such file or directory

======================================================================
ERROR: test_undo_redo (cms.tests.reversion_tests.ReversionTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/test/testcases.py", line 189, in __call__
    self._post_teardown()
  File "/home/ldgarcia/Documents/github/django-cms/cms/test_utils/testcases.py", line 98, in _post_teardown
    super(BaseCMSTestCase, self)._post_teardown()
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/test/testcases.py", line 816, in _post_teardown
    self._fixture_teardown()
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/test/testcases.py", line 843, in _fixture_teardown
    inhibit_post_migrate=self.available_apps is not None)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 115, in call_command
    return klass.execute(*args, **defaults)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/base.py", line 338, in execute
    output = self.handle(*args, **options)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/base.py", line 533, in handle
    return self.handle_noargs(**options)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/commands/flush.py", line 93, in handle_noargs
    call_command('loaddata', 'initial_data', **app_options)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 115, in call_command
    return klass.execute(*args, **defaults)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/base.py", line 338, in execute
    output = self.handle(*args, **options)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/commands/loaddata.py", line 61, in handle
    self.loaddata(fixture_labels)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/commands/loaddata.py", line 91, in loaddata
    self.load_label(fixture_label)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/commands/loaddata.py", line 127, in load_label
    for fixture_file, fixture_dir, fixture_name in self.find_fixtures(fixture_label):
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/utils/lru_cache.py", line 101, in wrapper
    result = user_function(*args, **kwds)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/commands/loaddata.py", line 192, in find_fixtures
    fixture_dirs = self.fixture_dirs
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/utils/functional.py", line 55, in __get__
    res = instance.__dict__[self.func.__name__] = self.func(instance)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/commands/loaddata.py", line 253, in fixture_dirs
    dirs = [upath(os.path.abspath(os.path.realpath(d))) for d in dirs]
  File "/home/ldgarcia/venv/dcms/lib/python2.7/posixpath.py", line 383, in realpath
    return abspath(path)
  File "/home/ldgarcia/venv/dcms/lib/python2.7/posixpath.py", line 371, in abspath
    cwd = os.getcwd()
OSError: [Errno 2] No such file or directory

======================================================================
ERROR: test_undo_slug_collision (cms.tests.reversion_tests.ReversionTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/test/testcases.py", line 189, in __call__
    self._post_teardown()
  File "/home/ldgarcia/Documents/github/django-cms/cms/test_utils/testcases.py", line 98, in _post_teardown
    super(BaseCMSTestCase, self)._post_teardown()
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/test/testcases.py", line 816, in _post_teardown
    self._fixture_teardown()
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/test/testcases.py", line 843, in _fixture_teardown
    inhibit_post_migrate=self.available_apps is not None)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 115, in call_command
    return klass.execute(*args, **defaults)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/base.py", line 338, in execute
    output = self.handle(*args, **options)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/base.py", line 533, in handle
    return self.handle_noargs(**options)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/commands/flush.py", line 93, in handle_noargs
    call_command('loaddata', 'initial_data', **app_options)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 115, in call_command
    return klass.execute(*args, **defaults)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/base.py", line 338, in execute
    output = self.handle(*args, **options)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/commands/loaddata.py", line 61, in handle
    self.loaddata(fixture_labels)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/commands/loaddata.py", line 91, in loaddata
    self.load_label(fixture_label)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/commands/loaddata.py", line 127, in load_label
    for fixture_file, fixture_dir, fixture_name in self.find_fixtures(fixture_label):
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/utils/lru_cache.py", line 101, in wrapper
    result = user_function(*args, **kwds)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/commands/loaddata.py", line 192, in find_fixtures
    fixture_dirs = self.fixture_dirs
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/utils/functional.py", line 55, in __get__
    res = instance.__dict__[self.func.__name__] = self.func(instance)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/django/core/management/commands/loaddata.py", line 253, in fixture_dirs
    dirs = [upath(os.path.abspath(os.path.realpath(d))) for d in dirs]
  File "/home/ldgarcia/venv/dcms/lib/python2.7/posixpath.py", line 383, in realpath
    return abspath(path)
  File "/home/ldgarcia/venv/dcms/lib/python2.7/posixpath.py", line 371, in abspath
    cwd = os.getcwd()
OSError: [Errno 2] No such file or directory

======================================================================
ERROR: setUpClass (cms.tests.frontend.StaticPlaceholderPermissionTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ldgarcia/Documents/github/django-cms/cms/tests/frontend.py", line 60, in setUpClass
    cls.driver = webdriver.Firefox()
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/selenium/webdriver/firefox/webdriver.py", line 59, in __init__
    self.binary, timeout),
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/selenium/webdriver/firefox/extension_connection.py", line 47, in __init__
    self.binary.launch_browser(self.profile)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/selenium/webdriver/firefox/firefox_binary.py", line 66, in launch_browser
    self._wait_until_connectable()
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/selenium/webdriver/firefox/firefox_binary.py", line 100, in _wait_until_connectable
    raise WebDriverException("The browser appears to have exited "
WebDriverException: Message: The browser appears to have exited before we could connect. If you specified a log_file in the FirefoxBinary constructor, check it for details.


======================================================================
ERROR: setUpClass (cms.tests.frontend.ToolbarBasicTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ldgarcia/Documents/github/django-cms/cms/tests/frontend.py", line 60, in setUpClass
    cls.driver = webdriver.Firefox()
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/selenium/webdriver/firefox/webdriver.py", line 59, in __init__
    self.binary, timeout),
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/selenium/webdriver/firefox/extension_connection.py", line 47, in __init__
    self.binary.launch_browser(self.profile)
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/selenium/webdriver/firefox/firefox_binary.py", line 66, in launch_browser
    self._wait_until_connectable()
  File "/home/ldgarcia/venv/dcms/local/lib/python2.7/site-packages/selenium/webdriver/firefox/firefox_binary.py", line 100, in _wait_until_connectable
    raise WebDriverException("The browser appears to have exited "
WebDriverException: Message: The browser appears to have exited before we could connect. If you specified a log_file in the FirefoxBinary constructor, check it for details.


----------------------------------------------------------------------
Ran 779 tests in 323.829s

FAILED (errors=9)

````

