### PR TITLE
ensure that apphooked views preserve their function name and docstrings

### DIFF
--- a/cms/tests/apphooks.py
+++ b/cms/tests/apphooks.py
@@ -4,7 +4,7 @@ import sys
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
-from django.core.urlresolvers import clear_url_caches, reverse
+from django.core.urlresolvers import clear_url_caches, reverse, resolve
 from django.test.utils import override_settings
 from django.utils import six
 from django.utils.timezone import now
@@ -213,6 +213,15 @@ class ApphooksTestCase(CMSTestCase):
         response = self.client.get(path)
         self.assertEqual(response.status_code, 302)
         apphook_pool.clear()
+
+    @override_settings(ROOT_URLCONF='cms.test_utils.project.second_urls_for_apphook_tests')
+    def test_apphook_permissions_preserves_view_name(self):
+        self.create_base_structure(APP_NAME, ['en', 'de'])
+
+        with force_language("en"):
+            path = reverse('sample-settings')
+        match = resolve(path)
+        self.assertEqual(match.func.__name__, 'sample_view')
 
     @override_settings(ROOT_URLCONF='cms.test_utils.project.second_urls_for_apphook_tests')
     def test_apphooks_with_excluded_permissions(self):

--- a/cms/utils/decorators.py
+++ b/cms/utils/decorators.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from functools import wraps
 from cms.views import _handle_no_page
 from django.contrib.auth.views import redirect_to_login
 from django.utils.http import urlquote
@@ -6,6 +7,7 @@ from django.conf import settings
 
 
 def cms_perms(func):
+    @wraps(func)
     def inner(request, *args, **kwargs):
         page = request.current_page
         if page:


### PR DESCRIPTION
Besides being a good citizen and preserving name and docstring of decorated view names, this also allows easier introspection of views for tools like the django debug toolbar or opbeat.