### PR TITLE
preserve apphook view name (3.0.x branch)

### DIFF
--- a/cms/test_utils/project/sampleapp/urls.py
+++ b/cms/test_utils/project/sampleapp/urls.py
@@ -1,6 +1,8 @@
 from django.conf.urls import patterns, url, include
 from django.utils.translation import ugettext_lazy as _
 
+from cms.test_utils.project.sampleapp.views import ClassView, ClassBasedView
+
 """
 Also used in cms.tests.ApphooksTestCase
 """
@@ -15,5 +17,7 @@ urlpatterns = patterns('cms.test_utils.project.sampleapp.views',
     url(r'^category/(?P<id>[0-9]+)/$', 'category_view', name='category_view'),
     url(r'^notfound/$', 'notfound', name='notfound'),
     url(r'^extra_1/$', 'extra_view', {'message': 'test urlconf'}, name='extra_first'),
+    url(r'^class-view/$', ClassView(), name='sample-class-view'),
+    url(r'^class-based-view/$', ClassBasedView.as_view(), name='sample-class-based-view'),
     url(r'^', include('cms.test_utils.project.sampleapp.urls_extra'), {'opts': 'someopts'}),
 )

--- a/cms/test_utils/project/sampleapp/views.py
+++ b/cms/test_utils/project/sampleapp/views.py
@@ -1,12 +1,15 @@
 # Create your views here.
-from django.views.decorators.csrf import csrf_exempt
-from cms.utils.urlutils import admin_reverse
 from django.core.urlresolvers import resolve
 from django.http import Http404
 from django.shortcuts import render_to_response
 from django.template.context import RequestContext
-from cms.test_utils.project.sampleapp.models import Category
 from django.utils.translation import ugettext_lazy as _
+from django.views.decorators.csrf import csrf_exempt
+from django.views.generic.base import TemplateView
+
+from cms.test_utils.project.sampleapp.models import Category
+from cms.utils.urlutils import admin_reverse
+
 
 @csrf_exempt
 def exempt_view(request, **kw):
@@ -56,3 +59,13 @@ def plain_view(request):
 
 def notfound(request):
     raise Http404
+
+
+class ClassView(object):
+    def __call__(self, request, *args, **kwargs):
+        context = RequestContext(request, {'content': 'plain text'})
+        return render_to_response("sampleapp/plain.html", context)
+
+
+class ClassBasedView(TemplateView):
+    template_name = 'sampleapp/plain.html'

--- a/cms/tests/apphooks.py
+++ b/cms/tests/apphooks.py
@@ -6,7 +6,7 @@ from django.contrib.admin.models import CHANGE
 from django.contrib.admin.models import LogEntry
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
-from django.core.urlresolvers import clear_url_caches, reverse
+from django.core.urlresolvers import clear_url_caches, reverse, resolve
 from django.utils import six
 from django.utils.timezone import now
 
@@ -236,6 +236,15 @@ class ApphooksTestCase(CMSTestCase):
             response = self.client.get(path)
             self.assertEqual(response.status_code, 302)
             apphook_pool.clear()
+
+    def test_apphook_permissions_preserves_view_name(self):
+        with SettingsOverride(ROOT_URLCONF='cms.test_utils.project.second_urls_for_apphook_tests'):
+            self.create_base_structure(APP_NAME, ['en', 'de'])
+
+            with force_language("en"):
+                path = reverse('sample-settings')
+            match = resolve(path)
+            self.assertEqual(match.func.__name__, 'sample_view')
 
     def test_apphooks_with_excluded_permissions(self):
         with SettingsOverride(ROOT_URLCONF='cms.test_utils.project.second_urls_for_apphook_tests'):

--- a/cms/tests/apphooks.py
+++ b/cms/tests/apphooks.py
@@ -241,10 +241,17 @@ class ApphooksTestCase(CMSTestCase):
         with SettingsOverride(ROOT_URLCONF='cms.test_utils.project.second_urls_for_apphook_tests'):
             self.create_base_structure(APP_NAME, ['en', 'de'])
 
+            view_names = (
+                ('sample-settings', 'sample_view'),
+                ('sample-class-view', 'ClassView'),
+                ('sample-class-based-view', 'ClassBasedView'),
+            )
+
             with force_language("en"):
-                path = reverse('sample-settings')
-            match = resolve(path)
-            self.assertEqual(match.func.__name__, 'sample_view')
+                for url_name, view_name in view_names:
+                    path = reverse(url_name)
+                    match = resolve(path)
+                    self.assertEqual(match.func.__name__, view_name)
 
     def test_apphooks_with_excluded_permissions(self):
         with SettingsOverride(ROOT_URLCONF='cms.test_utils.project.second_urls_for_apphook_tests'):

--- a/cms/utils/decorators.py
+++ b/cms/utils/decorators.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from functools import wraps
 from cms.views import _handle_no_page
 from django.contrib.auth.views import redirect_to_login
 from django.utils.http import urlquote
@@ -6,6 +7,7 @@ from django.conf import settings
 
 
 def cms_perms(func):
+    @wraps(func)
     def inner(request, *args, **kwargs):
         page = request.current_page
         if page:

--- a/cms/utils/decorators.py
+++ b/cms/utils/decorators.py
@@ -1,13 +1,12 @@
 # -*- coding: utf-8 -*-
-from functools import wraps
-from cms.views import _handle_no_page
+from django.conf import settings
 from django.contrib.auth.views import redirect_to_login
 from django.utils.http import urlquote
-from django.conf import settings
+
+from cms.views import _handle_no_page
 
 
 def cms_perms(func):
-    @wraps(func)
     def inner(request, *args, **kwargs):
         page = request.current_page
         if page:
@@ -16,4 +15,10 @@ def cms_perms(func):
             if not page.has_view_permission(request):
                 return _handle_no_page(request, "$")
         return func(request, *args, **kwargs)
+    inner.__module__ = func.__module__
+    inner.__doc__ = func.__doc__
+    if hasattr(func, '__name__'):
+        inner.__name__ = func.__name__
+    elif hasattr(func, '__class__'):
+        inner.__name__ = func.__class__.__name__
     return inner


### PR DESCRIPTION
This replaces #4026. The original usage of `functool.wraps` turned out to have problem with "class" views that use the `__call__` pattern. Instead, in this branch we do the work manually and copy `__doc__`, `__module__` and `__name__` (for functions) or `__class__.__name__` (for classes) to the decorating function.