### PR TITLE
Fixed public page not appearing in menus.

### DIFF
--- a/cms/utils/permissions.py
+++ b/cms/utils/permissions.py
@@ -357,7 +357,7 @@ def load_view_restrictions(request, pages):
             page_id = page.pk if page.publisher_is_draft else page.publisher_public_id
             pages_by_id[page_id] = page
             cache[page_id] = []
-        page_permissions = PagePermission.objects.filter(page__in=pages_by_id).select_related('group__users')
+        page_permissions = PagePermission.objects.filter(page__in=pages_by_id, can_view=True).select_related('group__users')
         for perm in page_permissions:
             perm_page = pages_by_id[perm.page_id]
             # add the page itself


### PR DESCRIPTION
Possible regression in 2839478e71fd7683011dd12df85c8f90863eccc2.
Pages that have permissions but no view restrictions no longer appear in menus generated with the `{% show_menu %}` template tag after upgrading to 3.1.
`CMS_PUBLIC_FOR = 'all'`
Will look into adding a regression test if this indeed looks like a bug.