### PR TITLE
Allow the migrate_use_structure migration to work with django 1.7

### DIFF
--- a/cms/migrations/0010_migrate_use_structure.py
+++ b/cms/migrations/0010_migrate_use_structure.py
@@ -11,11 +11,11 @@ def forwards(apps, schema_editor):
     ph_model = apps.get_model('cms', 'Placeholder')
     page_model = apps.get_model('cms', 'Page')
     try:
-        ph_ctype = ContentType.objects.get(app_label=ph_model._meta.app_label, model=ph_model._meta.model_name)
-        page_ctype = ContentType.objects.get(app_label=page_model._meta.app_label, model=page_model._meta.model_name)
+        ph_ctype = ContentType.objects.get_for_model(ph_model)
+        page_ctype = ContentType.objects.get_for_model(page_model)
         permission, _ = Permission.objects.get_or_create(
             codename='use_structure', content_type=ph_ctype, name=u"Can use Structure mode")
-        page_permission = Permission.objects.get(codename='change_page', content_type=page_ctype)
+        page_permission = Permission.objects.get_or_create(codename='change_page', content_type=page_ctype)
         for user in get_user_model().objects.filter(is_superuser=False, is_staff=True):
             if user.has_perm("cms.change_page"):
                 user.user_permissions.add(permission)


### PR DESCRIPTION
The ContentType can be gotten much more simply in django 1.7 and because of the ContentType error masks the rest of the code it was impossible to see the next error from the Permission get.

With this code the migration runs without the ContentType warning which happened every test run for our website.