### PR TITLE
added fix for show_menu_below_id and soft_root

### DIFF
--- a/cms/tests/menu.py
+++ b/cms/tests/menu.py
@@ -990,6 +990,107 @@ class ShowMenuBelowIdTests(BaseMenuTest):
         node = nodes[0]
         self.assertEqual(node.id, b.publisher_public.id)
 
+    def test_menu_beyond_soft_root(self):
+        """
+        Test for issue 4107
+
+        Build the following tree:
+
+            A
+            |-B (soft_root)
+              |-C
+        """
+        stdkwargs = {
+            'template': 'nav_playground.html',
+            'language': 'en',
+            'published': True,
+            'in_navigation': True,
+        }
+        a = create_page('A', reverse_id='a', **stdkwargs)
+        b = create_page('B', parent=a, soft_root=True, **stdkwargs)
+        c = create_page('C', parent=b, **stdkwargs)
+
+        context = self.get_context(a.get_absolute_url())
+        tpl = Template("{% load menu_tags %}{% show_menu 0 100 100 100 %}")
+        tpl.render(context)
+        nodes = context['children']
+        # check whole menu
+        self.assertEqual(len(nodes), 1)
+        a_node = nodes[0]
+        self.assertEqual(a_node.id, a.publisher_public.pk)  # On A, show from A
+        self.assertEqual(len(a_node.children), 1)
+        b_node = a_node.children[0]
+        self.assertEqual(b_node.id, b.publisher_public.pk)
+        self.assertEqual(len(b_node.children), 1)
+        c_node = b_node.children[0]
+        self.assertEqual(c_node.id, c.publisher_public.pk)
+        self.assertEqual(len(c_node.children), 0)
+
+        context = self.get_context(b.get_absolute_url())
+        tpl = Template("{% load menu_tags %}{% show_menu 0 100 100 100 %}")
+        tpl.render(context)
+        nodes = context['children']
+        # check whole menu
+        self.assertEqual(len(nodes), 1)
+        b_node = nodes[0]
+        self.assertEqual(b_node.id, b.publisher_public.pk)  # On B, show from B
+        self.assertEqual(len(b_node.children), 1)
+        c_node = b_node.children[0]
+        self.assertEqual(c_node.id, c.publisher_public.pk)
+        self.assertEqual(len(c_node.children), 0)
+
+        context = self.get_context(c.get_absolute_url())
+        tpl = Template("{% load menu_tags %}{% show_menu 0 100 100 100 %}")
+        tpl.render(context)
+        nodes = context['children']
+        # check whole menu
+        self.assertEqual(len(nodes), 1)
+        b_node = nodes[0]
+        self.assertEqual(b_node.id, b.publisher_public.pk)  # On C, show from B
+        self.assertEqual(len(b_node.children), 1)
+        c_node = b_node.children[0]
+        self.assertEqual(c_node.id, c.publisher_public.pk)
+        self.assertEqual(len(c_node.children), 0)
+
+        context = self.get_context(a.get_absolute_url())
+        tpl = Template("{% load menu_tags %}{% show_menu_below_id 'a' 0 100 100 100 %}")
+        tpl.render(context)
+        nodes = context['children']
+        # check whole menu
+        self.assertEqual(len(nodes), 1)
+        b_node = nodes[0]
+        self.assertEqual(b_node.id, b.publisher_public.pk)  # On A, show from B (since below A)
+        self.assertEqual(len(b_node.children), 1)
+        c_node = b_node.children[0]
+        self.assertEqual(c_node.id, c.publisher_public.pk)
+        self.assertEqual(len(c_node.children), 0)
+
+        context = self.get_context(b.get_absolute_url())
+        tpl = Template("{% load menu_tags %}{% show_menu_below_id 'a' 0 100 100 100 %}")
+        tpl.render(context)
+        nodes = context['children']
+        # check whole menu
+        self.assertEqual(len(nodes), 1)
+        b_node = nodes[0]
+        self.assertEqual(b_node.id, b.publisher_public.pk)  # On B, show from B (since below A)
+        self.assertEqual(len(b_node.children), 1)
+        c_node = b_node.children[0]
+        self.assertEqual(c_node.id, c.publisher_public.pk)
+        self.assertEqual(len(c_node.children), 0)
+
+        context = self.get_context(c.get_absolute_url())
+        tpl = Template("{% load menu_tags %}{% show_menu_below_id 'a' 0 100 100 100 %}")
+        tpl.render(context)
+        nodes = context['children']
+        # check whole menu
+        self.assertEqual(len(nodes), 1)
+        b_node = nodes[0]
+        self.assertEqual(b_node.id, b.publisher_public.pk)  # On C, show from B (since below A)
+        self.assertEqual(len(b_node.children), 1)
+        c_node = b_node.children[0]
+        self.assertEqual(c_node.id, c.publisher_public.pk)
+        self.assertEqual(len(c_node.children), 0)
+
 
 @override_settings(
     CMS_PERMISSION=True,


### PR DESCRIPTION
When using show_menu_below_id you want to get past soft_root, as mentioned in the documentation.

http://docs.django-cms.org/en/latest/reference/navigation.html#show-menu-below-id
"Note that soft roots will not affect the menu when using show_menu_below_id."