### PR TITLE
Fix order of which application urls are injected into urlpatterns

### DIFF
--- a/cms/appresolver.py
+++ b/cms/appresolver.py
@@ -1,6 +1,12 @@
 # -*- coding: utf-8 -*-
 from __future__ import with_statement
 
+try:
+    from collections import OrderedDict
+except ImportError:
+    # Python < 2.7
+    from django.utils.datastructures import SortedDict as OrderedDict
+
 from django.conf import settings
 from django.conf.urls import patterns
 from django.contrib.sites.models import Site
@@ -199,10 +205,11 @@ def get_app_patterns():
 
     title_qs = Title.objects.public().filter(page__site=current_site)
 
-    hooked_applications = {}
+    hooked_applications = OrderedDict()
 
     # Loop over all titles with an application hooked to them
-    for title in title_qs.exclude(page__application_urls=None).exclude(page__application_urls='').select_related():
+    # TODO: Need to be fixed for django-treebeard when forward ported to 3.1
+    for title in title_qs.exclude(page__application_urls=None).exclude(page__application_urls='').order_by('-page__level').select_related():
         path = title.path
         mix_id = "%s:%s:%s" % (path + "/", title.page.application_urls, title.language)
         if mix_id in included:

--- a/cms/test_utils/project/sampleapp/cms_app.py
+++ b/cms/test_utils/project/sampleapp/cms_app.py
@@ -41,3 +41,17 @@ class NamespacedApp(CMSApp):
     app_name = 'namespaced_app_ns'
 
 apphook_pool.register(NamespacedApp)
+
+
+class ParentApp(CMSApp):
+    name = _("Parent app")
+    urls = ["cms.test_utils.project.sampleapp.urls_parentapp"]
+
+apphook_pool.register(ParentApp)
+
+
+class ChildApp(CMSApp):
+    name = _("Child app")
+    urls = ["cms.test_utils.project.sampleapp.urls_childapp"]
+
+apphook_pool.register(ChildApp)

--- a/cms/test_utils/project/sampleapp/urls_childapp.py
+++ b/cms/test_utils/project/sampleapp/urls_childapp.py
@@ -1,0 +1,7 @@
+from django.conf.urls import url
+
+from cms.test_utils.project.sampleapp import views
+
+urlpatterns = [
+    url(r'^(?P<path>.+)$', views.childapp_view, name='childapp_view'),
+]

--- a/cms/test_utils/project/sampleapp/urls_parentapp.py
+++ b/cms/test_utils/project/sampleapp/urls_parentapp.py
@@ -1,0 +1,7 @@
+from django.conf.urls import url
+
+from cms.test_utils.project.sampleapp import views
+
+urlpatterns = [
+    url(r'^(?P<path>.+)$', views.parentapp_view, name='parentapp_view'),
+]

--- a/cms/test_utils/project/sampleapp/views.py
+++ b/cms/test_utils/project/sampleapp/views.py
@@ -56,3 +56,13 @@ def plain_view(request):
 
 def notfound(request):
     raise Http404
+
+
+def parentapp_view(request, path):
+    context = RequestContext(request, {'content': 'parent app content'})
+    return render_to_response("sampleapp/plain.html", context)
+
+
+def childapp_view(request, path):
+    context = RequestContext(request, {'content': 'child app content'})
+    return render_to_response("sampleapp/plain.html", context)

--- a/cms/tests/apphooks.py
+++ b/cms/tests/apphooks.py
@@ -142,7 +142,7 @@ class ApphooksTestCase(CMSTestCase):
             apphook_pool.clear()
             hooks = apphook_pool.get_apphooks()
             app_names = [hook[0] for hook in hooks]
-            self.assertEqual(len(hooks), 4)
+            self.assertEqual(len(hooks), 6)
             self.assertIn(NS_APP_NAME, app_names)
             self.assertIn(APP_NAME, app_names)
             apphook_pool.clear()
@@ -647,6 +647,34 @@ class ApphooksTestCase(CMSTestCase):
                 # parameters - non page object
                 response = self.client.post(url, {'pk': ex1.pk, 'model': 'placeholderapp.example1'})
                 self.assertEqual(response.content.decode('utf-8'), ex1.get_absolute_url())
+
+    def test_nested_apphooks_urls(self):
+        # make sure that urlparams actually reach the apphook views
+        with SettingsOverride(ROOT_URLCONF='cms.test_utils.project.urls'):
+            apphook_pool.clear()
+
+            superuser = get_user_model().objects.create_superuser('admin', 'admin@admin.com', 'admin')
+            create_page("home", "nav_playground.html", "en", created_by=superuser, published=True, )
+            parent_page = create_page("parent-apphook-page", "nav_playground.html", "en",
+                                      created_by=superuser, published=True, apphook="ParentApp")
+            create_page("child-apphook-page", "nav_playground.html", "en", parent=parent_page,
+                        created_by=superuser, published=True, apphook="ChildApp")
+
+            parent_app_path = reverse('parentapp_view', kwargs={'path': 'parent/path/'})
+            child_app_path = reverse('childapp_view', kwargs={'path': 'child-path/'})
+
+            # Ensure the page structure is ok before getting responses
+            self.assertEqual(parent_app_path, '/en/parent-apphook-page/parent/path/')
+            self.assertEqual(child_app_path, '/en/parent-apphook-page/child-apphook-page/child-path/')
+
+            # Get responses for both paths and ensure that the right view will answer
+            response = self.client.get(parent_app_path)
+            self.assertContains(response, 'parent app content', status_code=200)
+
+            response = self.client.get(child_app_path)
+            self.assertContains(response, 'child app content', status_code=200)
+
+            apphook_pool.clear()
 
 
 class ApphooksPageLanguageUrlTestCase(SettingsOverrideTestCase):


### PR DESCRIPTION
This will fix problem when there are nested apphooks and urls of top level apphook are more greedy.

This fix is for Django CMS 3.0.x. I know that 3.1 but fix for it will be little different because of django-treebeard and we are not currently upgraded to 3.1.

I'm planning to add tests for that but first I need your opinion about the solutions of the problem.