### PR TITLE
Make PageField only list pages in the same language as the edited page

### DIFF
--- a/cms/forms/fields.py
+++ b/cms/forms/fields.py
@@ -49,6 +49,7 @@ class PageSelectFormField(forms.MultiValueField):
             LazyChoiceField(choices=site_choices, required=False, error_messages={'invalid': errors['invalid_site']}),
             LazyChoiceField(choices=page_choices, required=False, error_messages={'invalid': errors['invalid_page']}),
         )
+        kwargs['widget'] = self.widget(site_choices, page_choices)
         super(PageSelectFormField, self).__init__(fields, *args, **kwargs)
 
     def compress(self, data_list):

--- a/cms/forms/fields.py
+++ b/cms/forms/fields.py
@@ -10,11 +10,13 @@ from cms.forms.utils import get_site_choices, get_page_choices
 
 
 class SuperLazyIterator(object):
-    def __init__(self, func):
+    def __init__(self, func, func_args=None, func_kwargs=None):
         self.func = func
+        self.func_args = func_args or []
+        self.func_kwargs = func_kwargs or {}
 
     def __iter__(self):
-        return iter(self.func())
+        return iter(self.func(*self.func_args, **self.func_kwargs))
 
 
 class LazyChoiceField(forms.ChoiceField):
@@ -34,12 +36,13 @@ class PageSelectFormField(forms.MultiValueField):
 
     def __init__(self, queryset=None, empty_label=u"---------", cache_choices=False,
                  required=True, widget=None, to_field_name=None, limit_choices_to=None,
-                  *args, **kwargs):
+                 language=None, *args, **kwargs):
         errors = self.default_error_messages.copy()
         if 'error_messages' in kwargs:
             errors.update(kwargs['error_messages'])
         site_choices = SuperLazyIterator(get_site_choices)
-        page_choices = SuperLazyIterator(get_page_choices)
+        page_choices = SuperLazyIterator(get_page_choices,
+                                         func_kwargs={'lang': language})
         self.limit_choices_to = limit_choices_to
         kwargs['required'] = required
         fields = (

--- a/cms/forms/widgets.py
+++ b/cms/forms/widgets.py
@@ -11,7 +11,6 @@ from django.utils.encoding import force_text
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
 
-from cms.forms.utils import get_site_choices, get_page_choices
 from cms.models import Page, PageUser
 from cms.templatetags.cms_admin import CMS_ADMIN_ICON_BASE
 
@@ -25,7 +24,8 @@ class PageSelectWidget(MultiWidget):
             self.attrs = attrs.copy()
         else:
             self.attrs = {}
-        self.choices = []
+        self.site_choices = site_choices or []
+        self.choices = page_choices or []
         super(PageSelectWidget, self).__init__((Select, Select, Select), attrs)
 
     def decompress(self, value):
@@ -69,11 +69,7 @@ class PageSelectWidget(MultiWidget):
         # value is a list of values, each corresponding to a widget
         # in self.widgets.
 
-        site_choices = get_site_choices()
-        page_choices = get_page_choices()
-        self.site_choices = site_choices
-        self.choices = page_choices
-        self.widgets = (Select(choices=site_choices ),
+        self.widgets = (Select(choices=self.site_choices ),
                    Select(choices=[('', '----')]),
                    Select(choices=self.choices, attrs={'style': "display:none;"} ),
         )

--- a/cms/plugin_base.py
+++ b/cms/plugin_base.py
@@ -361,6 +361,15 @@ class CMSPluginBase(six.with_metaclass(CMSPluginBaseMetaclass, admin.ModelAdmin)
         )
 
 
+class CMSPagePluginBase(CMSPluginBase):
+    def formfield_for_dbfield(self, db_field, **kwargs):
+        from cms.models import fields
+        if isinstance(db_field, fields.PageField):
+            kwargs['language'] = self.cms_plugin_instance.language
+
+        return super(CMSPagePluginBase, self).formfield_for_dbfield(db_field, **kwargs)
+
+
 class PluginMenuItem(object):
     def __init__(self, name, url, data, question=None, action='ajax'):
         """

--- a/cms/test_utils/project/sampleapp/cms_plugins.py
+++ b/cms/test_utils/project/sampleapp/cms_plugins.py
@@ -1,0 +1,16 @@
+from cms.plugin_base import CMSPagePluginBase
+from cms.plugin_pool import plugin_pool
+from .models import LinkModel
+
+
+class PageFieldTestPlugin(CMSPagePluginBase):
+    model = LinkModel
+    name = "Dumb Test Plugin. It does nothing."
+    render_template = ""
+    admin_preview = False
+    render_plugin = False
+
+    def render(self, context, instance, placeholder):
+        return context
+
+plugin_pool.register_plugin(PageFieldTestPlugin)

--- a/cms/test_utils/project/sampleapp/migrations/0003_linkmodel.py
+++ b/cms/test_utils/project/sampleapp/migrations/0003_linkmodel.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import cms.models.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('cms', '0011_auto_20150419_1006'),
+        ('sampleapp', '0002_auto_20141015_1057'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='LinkModel',
+            fields=[
+                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin')),
+                ('link', cms.models.fields.PageField(related_name='plugin_link_link', to='cms.Page')),
+            ],
+            options={
+                'abstract': False,
+            },
+            bases=('cms.cmsplugin',),
+        ),
+    ]

--- a/cms/test_utils/project/sampleapp/models.py
+++ b/cms/test_utils/project/sampleapp/models.py
@@ -1,8 +1,10 @@
-from cms.models.fields import PlaceholderField
+from cms.models.fields import PageField, PlaceholderField
 from django.core.urlresolvers import reverse
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
 from treebeard.mp_tree import MP_Node
+
+from cms.models.pluginmodel import CMSPlugin
 
 
 @python_2_unicode_compatible
@@ -24,3 +26,7 @@ class Category(MP_Node):
 class Picture(models.Model):
     image = models.ImageField(upload_to="pictures")
     category = models.ForeignKey(Category)
+
+
+class LinkModel(CMSPlugin):
+    link = PageField(related_name='plugin_link_link')

--- a/cms/tests/plugins.py
+++ b/cms/tests/plugins.py
@@ -15,6 +15,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.management import call_command
 from django.forms.widgets import Media
 from django.test.testcases import TestCase
+from django.test.utils import override_settings
 from django.utils import timezone
 
 from cms import api
@@ -1235,6 +1236,51 @@ class PluginsTestCase(PluginsTestBaseCase):
             render_plugin = False
             name = "Test Plugin"
         self.assertIsNotNone(DecoratorTestPlugin)
+
+    @override_settings(CMS_LANGUAGES={
+        'default': {
+            'public': True,
+            'hide_untranslated': True,
+            'redirect_on_fallback': False,
+        },
+        1: [
+            {
+                'code': 'de',
+                'name': 'de',
+                'fallbacks': [],
+            },
+            {
+                'code': 'en',
+                'name': 'en',
+                'fallbacks': [],
+                'public': True,
+            },
+        ],
+    })
+    def test_page_field_lists_pages_with_same_language(self):
+        """
+        Test that the PageField only lists pages in the same language as the
+        current page if hide_untranslated is set to true.
+        """
+        page_data = [self.get_new_page_data() for __ in range(0, 3)]
+        page_data[0]['language'] = 'de'
+        page_data[0]['title'] = 'DE page 1'
+        page_data[1]['language'] = 'de'
+        page_data[1]['title'] = 'DE page 2'
+        for page in page_data:
+            self.client.post(URL_CMS_PAGE_ADD, page)
+        page = Page.objects.all()[0]
+        plugin_data = {
+            'plugin_type': "PageFieldTestPlugin",
+            'plugin_language': 'de',
+            'placeholder_id': page.placeholders.get(slot="body").pk,
+            'plugin_parent': '',
+        }
+        response = self.client.post(URL_CMS_PLUGIN_ADD, plugin_data)
+        url = json.loads(response.content)['url']
+        response = self.client.get(url)
+        self.assertIn('DE page 1', response.content)
+        self.assertIn('DE page 2', response.content)
 
 
 class FileSystemPluginTests(PluginsTestBaseCase):


### PR DESCRIPTION
This is a workaround for #3981. It introduces a new `CMSPluginBase` derived class named `CMSPagePluginBase`, that, if inherited, will make `PageField` fields only list pages in the same language as the edited page. I think it would be better if it could be included in `CMSPluginBase` since `PageField` is still a core feature.

If we leave it as `CMSPagePluginBase`, then this should be documented somewhere.