### PR TITLE
add a commercial support section to readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,7 +94,7 @@ to our `mailing list <https://groups.google.com/forum/#!forum/django-cms>`_.
 Commercial support
 ************
 
-Django CMS is sponsored by `Divio <https://divio.com/en/commercial-support>`_. If you need help implementing or hosting Django CMS, please contact us: info@divio.ch
+Django CMS is sponsored by `Divio <https://divio.ch>`_. If you need help implementing or hosting Django CMS, please contact us: sales@divio.ch
 
 *******
 Credits

--- a/README.rst
+++ b/README.rst
@@ -90,6 +90,12 @@ Getting Help
 Please head over to our IRC channel, #django-cms, on irc.freenode.net or write
 to our `mailing list <https://groups.google.com/forum/#!forum/django-cms>`_.
 
+************
+Commercial support
+************
+
+Django CMS is sponsored by `Divio <https://divio.com/en/commercial-support>`_. If you need help implementing or hosting Django CMS, please contact us: info@divio.ch
+
 *******
 Credits
 *******


### PR DESCRIPTION
**This pull request fixes the following issues**:

https://divio-ch.atlassian.net/browse/COM-35

adding a section of commercial support for django CMS to readme and link it with the associated page on divio.ch

**Additional information**:
- marketing section
