### PR TITLE
Added page attribute to page navigation node

### DIFF
--- a/cms/menu.py
+++ b/cms/menu.py
@@ -105,7 +105,8 @@ def page_to_node(page, home, cut):
     """
     # Theses are simple to port over, since they are not calculated.
     # Other attributes will be added conditionnally later.
-    attr = {'soft_root': page.soft_root,
+    attr = {'page': page,
+            'soft_root': page.soft_root,
             'auth_required': page.login_required,
             'reverse_id': page.reverse_id, }
 


### PR DESCRIPTION
Maybe it's worth keeping 'page' in NavigationNode.attrs? It used to be there and our code depends on it for creating custom menus using navigation modifiers.

I see that it was removed in https://github.com/divio/django-cms/pull/1558, but maybe keeping a reference to a page shouldn't effect performance that much.