### PR TITLE
make shift tab work correctly in submenu

### DIFF
--- a/cms/static/cms/js/modules/cms.plugins.js
+++ b/cms/static/cms/js/modules/cms.plugins.js
@@ -567,8 +567,8 @@ $(document).ready(function () {
 					}
 				}
 
-				// bind arrow up keys
-				if(e.keyCode === 38) {
+				// bind arrow up and shift+tab keys
+				if(e.keyCode === 38 || (e.keyCode === 9 && e.shiftKey)) {
 					e.preventDefault();
 					if(anchors.is(':focus')) {
 						anchors.eq(index - 1).focus();


### PR DESCRIPTION
So currently when you click on the submenu in the placeholder or a plugin in structure mode and then start pressing tab the focus would go over menu items. However when you press shift+tab the expected behaviour would be to go to the previous item, which is not the case at the moment.

This PR fixes that.