### PR TITLE
Fix cache invalidation

### DIFF
--- a/cms/cache/__init__.py
+++ b/cms/cache/__init__.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+import re
+from cms.utils import get_cms_setting
+
+CMS_PAGE_CACHE_VERSION_KEY = get_cms_setting("CACHE_PREFIX") + 'CMS_PAGE_CACHE_VERSION'
+
+
+def _get_cache_version():
+    """
+    Returns the current page cache version, explicitly setting one if not
+    defined.
+    """
+    from django.core.cache import cache
+
+    version = cache.get(CMS_PAGE_CACHE_VERSION_KEY)
+
+    if version:
+        return version
+    else:
+        _set_cache_version(1)
+        return 1
+
+
+def _set_cache_version(version):
+    """
+    Set the cache version to the specified value.
+    """
+    from django.core.cache import cache
+
+    cache.set(
+        CMS_PAGE_CACHE_VERSION_KEY,
+        version,
+        get_cms_setting('CACHE_DURATIONS')['content']
+    )
+
+
+def invalidate_cms_page_cache():
+    """
+    Invalidates the CMS PAGE CACHE.
+    """
+
+    #
+    # NOTE: We're using a cache versioning strategy for invalidating the page
+    # cache when necessary. Instead of wiping all the old entries, we simply
+    # increment the version number rendering all previous entries
+    # inaccessible and left to expire naturally.
+    #
+    # ALSO NOTE: According to the Django documentation, a timeout value of
+    # `None' (in version 1.6+) is supposed to mean "cache forever", however,
+    # this is actually only implemented as only slightly less than 30 days in
+    # some backends (memcached, in particular). In older Djangos, `None' means
+    # "use default value".  To avoid issues arising from different Django
+    # versions and cache backend implementations, we will explicitly set the
+    # lifespan of the CMS_PAGE_CACHE_VERSION entry to whatever is set in
+    # settings.CACHE_DURATIONS['content']. This allows users to adjust as
+    # necessary for their backend.
+    #
+    # To prevent writing cache entries that will live longer than our version
+    # key, we will always re-write the current version number into the cache
+    # just after we write any new cache entries, thus ensuring that the
+    # version number will always outlive any entries written against that
+    # version. This is a cheap operation.
+    #
+    # If there are no new cache writes before the version key expires, its
+    # perfectly OK, since any previous entries cached against that version
+    # will have also expired, so, it'd be pointless to try to access them
+    # anyway.
+    #
+    version = _get_cache_version()
+    _set_cache_version(version + 1)
+
+
+CLEAN_KEY_PATTERN = re.compile(r'[^a-zA-Z0-9_-]')
+
+
+def _clean_key(key):
+    return CLEAN_KEY_PATTERN.sub('-', key)
+
+
+def _get_cache_key(name, page_lookup, lang, site_id):
+    from cms.models import Page
+    if isinstance(page_lookup, Page):
+        page_key = str(page_lookup.pk)
+    else:
+        page_key = str(page_lookup)
+    page_key = _clean_key(page_key)
+    return get_cms_setting('CACHE_PREFIX') + name + '__page_lookup:' + page_key + '_site:' + str(site_id) + '_lang:' + str(lang)

--- a/cms/cache/__init__.py
+++ b/cms/cache/__init__.py
@@ -67,6 +67,7 @@ def invalidate_cms_page_cache():
     # anyway.
     #
     version = _get_cache_version()
+    print("invalidate", version)
     _set_cache_version(version + 1)
 
 

--- a/cms/cache/__init__.py
+++ b/cms/cache/__init__.py
@@ -67,7 +67,6 @@ def invalidate_cms_page_cache():
     # anyway.
     #
     version = _get_cache_version()
-    print("invalidate", version)
     _set_cache_version(version + 1)
 
 

--- a/cms/cache/choices.py
+++ b/cms/cache/choices.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+from collections import defaultdict
+from django.conf import settings
+from django.utils.datastructures import SortedDict
+from django.utils.safestring import mark_safe
+from cms.exceptions import LanguageError
+from cms.models import Title
+from cms.utils import i18n, get_cms_setting
+
+
+def update_site_and_page_choices(lang=None):
+    lang = lang or i18n.get_current_language()
+    SITE_CHOICES_KEY = _site_cache_key(lang)
+    PAGE_CHOICES_KEY = _page_cache_key(lang)
+    title_queryset = (Title.objects.drafts()
+    .select_related('page', 'page__site')
+    .order_by('page__path'))
+    pages = defaultdict(SortedDict)
+    sites = {}
+    for title in title_queryset:
+        page = pages[title.page.site.pk].get(title.page.pk, {})
+        page[title.language] = title
+        pages[title.page.site.pk][title.page.pk] = page
+        sites[title.page.site.pk] = title.page.site.name
+
+    site_choices = []
+    page_choices = [('', '----')]
+
+    try:
+        fallbacks = i18n.get_fallback_languages(lang)
+    except LanguageError:
+        fallbacks = []
+    language_order = [lang] + fallbacks
+
+    for sitepk, sitename in sites.items():
+        site_choices.append((sitepk, sitename))
+
+        site_page_choices = []
+        for titles in pages[sitepk].values():
+            title = None
+            for language in language_order:
+                title = titles.get(language)
+                if title:
+                    break
+            if not title:
+                continue
+
+            indent = u"&nbsp;&nbsp;" * (title.page.depth - 1)
+            page_title = mark_safe(u"%s%s" % (indent, title.title))
+            site_page_choices.append((title.page.pk, page_title))
+
+        page_choices.append((sitename, site_page_choices))
+    from django.core.cache import cache
+    # We set it to 1 day here because we actively invalidate this cache.
+    cache.set(SITE_CHOICES_KEY, site_choices, 86400)
+    cache.set(PAGE_CHOICES_KEY, page_choices, 86400)
+    return site_choices, page_choices
+
+
+def get_site_choices(lang=None):
+    from django.core.cache import cache
+    lang = lang or i18n.get_current_language()
+    site_choices = cache.get(_site_cache_key(lang))
+    if site_choices is None:
+        site_choices, page_choices = update_site_and_page_choices(lang)
+    return site_choices
+
+
+def get_page_choices(lang=None):
+    from django.core.cache import cache
+    lang = lang or i18n.get_current_language()
+    page_choices = cache.get(_page_cache_key(lang))
+    if page_choices is None:
+        site_choices, page_choices = update_site_and_page_choices(lang)
+    return page_choices
+
+
+def _site_cache_key(lang):
+    return "%s-%s" %(get_cms_setting('SITE_CHOICES_CACHE_KEY'), lang)
+
+
+def _page_cache_key(lang):
+    return "%s-%s" %(get_cms_setting('PAGE_CHOICES_CACHE_KEY'), lang)
+
+
+def _clean_many(prefix):
+    from django.core.cache import cache
+    keys = []
+    if settings.USE_I18N:
+        for lang in [language[0] for language in settings.LANGUAGES]:
+            keys.append("%s-%s" %(prefix, lang))
+    else:
+        keys = ["%s-%s" %(prefix, settings.LANGUAGE_CODE)]
+    cache.delete_many(keys)
+
+
+def clean_site_choices_cache(sender, **kwargs):
+    _clean_many(get_cms_setting('SITE_CHOICES_CACHE_KEY'))
+
+
+def clean_page_choices_cache(sender, **kwargs):
+    _clean_many(get_cms_setting('PAGE_CHOICES_CACHE_KEY'))

--- a/cms/cache/page.py
+++ b/cms/cache/page.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+import hashlib
+from django.conf import settings
+from django.utils.cache import add_never_cache_headers
+from django.utils.encoding import iri_to_uri, force_text
+from django.utils.timezone import get_current_timezone_name
+
+from cms.cache import _get_cache_version, _set_cache_version, _get_cache_key
+from cms.utils import get_cms_setting
+
+
+def _page_cache_key(request):
+    #md5 key of current path
+    cache_key = "%s:%d:%s" % (
+        get_cms_setting("CACHE_PREFIX"),
+        settings.SITE_ID,
+        hashlib.md5(iri_to_uri(request.get_full_path()).encode('utf-8')).hexdigest()
+    )
+    if settings.USE_TZ:
+        # The datetime module doesn't restrict the output of tzname().
+        # Windows is known to use non-standard, locale-dependant names.
+        # User-defined tzinfo classes may return absolutely anything.
+        # Hence this paranoid conversion to create a valid cache key.
+        tz_name = force_text(get_current_timezone_name(), errors='ignore')
+        cache_key += '.%s' % tz_name.encode('ascii', 'ignore').decode('ascii').replace(' ', '_')
+    return cache_key
+
+
+def set_page_cache(response):
+    from django.core.cache import cache
+
+    if not get_cms_setting('PAGE_CACHE'):
+        return response
+    request = response._request
+    save_cache = True
+    for placeholder in getattr(request, 'placeholders', []):
+        if not placeholder.cache_placeholder:
+            save_cache = False
+            break
+    if hasattr(request, 'toolbar'):
+        if request.toolbar.edit_mode or request.toolbar.show_toolbar:
+            save_cache = False
+    if request.user.is_authenticated():
+        save_cache = False
+    if not save_cache:
+        add_never_cache_headers(response)
+        return response
+    else:
+        version = _get_cache_version()
+        ttl = get_cms_setting('CACHE_DURATIONS')['content']
+
+        cache.set(
+            _page_cache_key(request),
+            (response.content, response._headers),
+            ttl,
+            version=version
+        )
+        # See note in invalidate_cms_page_cache()
+        _set_cache_version(version)
+
+
+def get_page_cache(request):
+    from django.core.cache import cache
+
+    return cache.get(_page_cache_key(request),
+                     version=_get_cache_version())
+
+
+def get_xframe_cache(page):
+    from django.core.cache import cache
+    return cache.get('cms:xframe_options:%s' % page.pk)
+
+
+def set_xframe_cache(page, xframe_options):
+    from django.core.cache import cache
+    cache.set('cms:xframe_options:%s' % page.pk,
+              xframe_options,
+              version=_get_cache_version())
+    _set_cache_version(_get_cache_version())
+
+
+def _page_url_key(page_lookup, lang, site_id):
+    return _get_cache_key('page_url', page_lookup, lang, site_id) + '_type:absolute_url'
+
+
+def set_page_url_cache(page_lookup, lang, site_id, url):
+    from django.core.cache import cache
+    cache.set(_page_url_key(page_lookup, lang, site_id),
+              url,
+              get_cms_setting('CACHE_DURATIONS')['content'], version=_get_cache_version())
+    _set_cache_version(_get_cache_version())
+
+
+def get_page_url_cache(page_lookup, lang, site_id):
+    from django.core.cache import cache
+    return cache.get(_page_url_key(page_lookup, lang, site_id),
+                     version=_get_cache_version())

--- a/cms/cache/permissions.py
+++ b/cms/cache/permissions.py
@@ -16,12 +16,14 @@ def get_cache_key(user, key):
     return "%s:permission:%s:%s" % (
         get_cms_setting('CACHE_PREFIX'), username, key)
 
-def get_cache_version_key():
+
+def get_cache_permission_version_key():
     return "%s:permission:version" % (get_cms_setting('CACHE_PREFIX'),)
 
-def get_cache_version():
+
+def get_cache_permission_version():
     from django.core.cache import cache
-    version = cache.get(get_cache_version_key())
+    version = cache.get(get_cache_permission_version_key())
     if version is None:
         version = 1
     return version
@@ -32,7 +34,7 @@ def get_permission_cache(user, key):
     Helper for reading values from cache
     """
     from django.core.cache import cache
-    return cache.get(get_cache_key(user, key), version=get_cache_version())
+    return cache.get(get_cache_key(user, key), version=get_cache_permission_version())
 
 
 def set_permission_cache(user, key, value):
@@ -44,8 +46,8 @@ def set_permission_cache(user, key, value):
     # store this key, so we can clean it when required
     cache_key = get_cache_key(user, key)
     cache.set(cache_key, value,
-            get_cms_setting('CACHE_DURATIONS')['permissions'],
-            version=get_cache_version())
+              get_cms_setting('CACHE_DURATIONS')['permissions'],
+              version=get_cache_permission_version())
 
 
 def clear_user_permission_cache(user):
@@ -54,14 +56,14 @@ def clear_user_permission_cache(user):
     """
     from django.core.cache import cache
     for key in PERMISSION_KEYS:
-        cache.delete(get_cache_key(user, key), version=get_cache_version())
+        cache.delete(get_cache_key(user, key), version=get_cache_permission_version())
 
 
 def clear_permission_cache():
     from django.core.cache import cache
-    version = get_cache_version()
+    version = get_cache_permission_version()
     if version > 1:
-        cache.incr(get_cache_version_key())
+        cache.incr(get_cache_permission_version_key())
     else:
-        cache.set(get_cache_version_key(), 2,
-                get_cms_setting('CACHE_DURATIONS')['permissions'])
+        cache.set(get_cache_permission_version_key(), 2,
+                  get_cms_setting('CACHE_DURATIONS')['permissions'])

--- a/cms/cache/placeholder.py
+++ b/cms/cache/placeholder.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+from django.conf import settings
+from django.utils.encoding import force_text
+from django.utils.timezone import get_current_timezone_name
+from cms.cache import _get_cache_version, _set_cache_version, _clean_key, _get_cache_key
+from cms.utils import get_cms_setting
+
+
+def _placeholder_cache_key(placeholder, lang):
+    cache_key = '%srender_placeholder:%s.%s' % (get_cms_setting("CACHE_PREFIX"), placeholder.pk, str(lang))
+    if settings.USE_TZ:
+        tz_name = force_text(get_current_timezone_name(), errors='ignore')
+        cache_key += '.%s' % tz_name.encode('ascii', 'ignore').decode('ascii').replace(' ', '_')
+    return cache_key
+
+
+def set_placeholder_cache(placeholder, lang, content):
+    """
+    Caches the rendering of a placeholder
+    """
+    from django.core.cache import cache
+    cache.set(_placeholder_cache_key(placeholder, lang),
+              content,
+              get_cms_setting('CACHE_DURATIONS')['content'],
+              version=_get_cache_version())
+    _set_cache_version(_get_cache_version())
+
+
+def get_placeholder_cache(placeholder, lang):
+    """
+    Retrieves the cached content of a placeholder
+    """
+    from django.core.cache import cache
+
+    return cache.get(_placeholder_cache_key(placeholder, lang),
+                     version=_get_cache_version())
+
+
+def clear_placeholder_cache(placeholder, lang):
+    from django.core.cache import cache
+
+    cache.delete(_placeholder_cache_key(placeholder, lang))
+
+
+def _placeholder_page_cache_key(page_lookup, lang, site_id, placeholder_name):
+    base_key = _get_cache_key('_show_placeholder_for_page', page_lookup, lang, site_id)
+    return _clean_key('%s_placeholder:%s' % (base_key, placeholder_name))
+
+
+def get_placeholder_page_cache(page_lookup, lang, site_id, placeholder_name):
+    from django.core.cache import cache
+
+    return cache.get(_placeholder_page_cache_key(page_lookup, lang, site_id, placeholder_name),
+                     version=_get_cache_version())
+
+
+def set_placeholder_page_cache(page_lookup, lang, site_id, placeholder_name, content):
+    from django.core.cache import cache
+
+    cache.set(_placeholder_page_cache_key(page_lookup, lang, site_id, placeholder_name),
+              content,
+              get_cms_setting('CACHE_DURATIONS')['content'], version=_get_cache_version())
+    _set_cache_version(_get_cache_version())

--- a/cms/forms/fields.py
+++ b/cms/forms/fields.py
@@ -1,12 +1,14 @@
 # -*- coding: utf-8 -*-
 import six
+
 from django.utils.translation import ugettext_lazy as _
 from django import forms
 from django.contrib.admin.widgets import RelatedFieldWidgetWrapper
 from django.forms.fields import EMPTY_VALUES
+
+from cms.cache.choices import get_site_choices, get_page_choices
 from cms.models.pagemodel import Page
 from cms.forms.widgets import PageSelectWidget, PageSmartLinkWidget
-from cms.forms.utils import get_site_choices, get_page_choices
 
 
 class SuperLazyIterator(object):

--- a/cms/forms/utils.py
+++ b/cms/forms/utils.py
@@ -1,115 +1,11 @@
 # -*- coding: utf-8 -*-
-from collections import defaultdict
 
-from cms.exceptions import LanguageError
-from cms.models import Page
-from cms.models.titlemodels import Title
-from cms.utils import i18n
-from cms.utils.conf import get_cms_setting
-from django.conf import settings
 from django.contrib.sites.models import Site
 from django.db.models.signals import post_save, post_delete
-from django.utils.datastructures import SortedDict
-from django.utils.safestring import mark_safe
 
+from cms.cache.choices import clean_site_choices_cache, clean_page_choices_cache
 
-def update_site_and_page_choices(lang=None):
-    lang = lang or i18n.get_current_language()
-    SITE_CHOICES_KEY = get_site_cache_key(lang)
-    PAGE_CHOICES_KEY = get_page_cache_key(lang)
-    title_queryset = (Title.objects.drafts()
-    .select_related('page', 'page__site')
-    .order_by('page__path'))
-    pages = defaultdict(SortedDict)
-    sites = {}
-    for title in title_queryset:
-        page = pages[title.page.site.pk].get(title.page.pk, {})
-        page[title.language] = title
-        pages[title.page.site.pk][title.page.pk] = page
-        sites[title.page.site.pk] = title.page.site.name
-
-    site_choices = []
-    page_choices = [('', '----')]
-
-    try:
-        fallbacks = i18n.get_fallback_languages(lang)
-    except LanguageError:
-        fallbacks = []
-    language_order = [lang] + fallbacks
-
-    for sitepk, sitename in sites.items():
-        site_choices.append((sitepk, sitename))
-
-        site_page_choices = []
-        for titles in pages[sitepk].values():
-            title = None
-            for language in language_order:
-                title = titles.get(language)
-                if title:
-                    break
-            if not title:
-                continue
-
-            indent = u"&nbsp;&nbsp;" * (title.page.depth - 1)
-            page_title = mark_safe(u"%s%s" % (indent, title.title))
-            site_page_choices.append((title.page.pk, page_title))
-
-        page_choices.append((sitename, site_page_choices))
-    from django.core.cache import cache
-    # We set it to 1 day here because we actively invalidate this cache.
-    cache.set(SITE_CHOICES_KEY, site_choices, 86400)
-    cache.set(PAGE_CHOICES_KEY, page_choices, 86400)
-    return site_choices, page_choices
-
-
-def get_site_choices(lang=None):
-    from django.core.cache import cache
-    lang = lang or i18n.get_current_language()
-    site_choices = cache.get(get_site_cache_key(lang))
-    if site_choices is None:
-        site_choices, page_choices = update_site_and_page_choices(lang)
-    return site_choices
-
-
-def get_page_choices(lang=None):
-    from django.core.cache import cache
-    lang = lang or i18n.get_current_language()
-    page_choices = cache.get(get_page_cache_key(lang))
-    if page_choices is None:
-        site_choices, page_choices = update_site_and_page_choices(lang)
-    return page_choices
-
-
-def _get_key(prefix, lang):
-    return "%s-%s" % (prefix, lang)
-
-
-def get_site_cache_key(lang):
-    return _get_key(get_cms_setting('SITE_CHOICES_CACHE_KEY'), lang)
-
-
-def get_page_cache_key(lang):
-    return _get_key(get_cms_setting('PAGE_CHOICES_CACHE_KEY'), lang)
-
-
-def _clean_many(prefix):
-    from django.core.cache import cache
-    keys = []
-    if settings.USE_I18N:
-        for lang in [language[0] for language in settings.LANGUAGES]:
-            keys.append(_get_key(prefix, lang))
-    else:
-        keys = [_get_key(prefix, settings.LANGUAGE_CODE)]
-    cache.delete_many(keys)
-
-
-def clean_site_choices_cache(sender, **kwargs):
-    _clean_many(get_cms_setting('SITE_CHOICES_CACHE_KEY'))
-
-
-def clean_page_choices_cache(sender, **kwargs):
-    _clean_many(get_cms_setting('PAGE_CHOICES_CACHE_KEY'))
-
+from cms.models import Page
 
 post_save.connect(clean_page_choices_cache, sender=Page)
 post_save.connect(clean_site_choices_cache, sender=Site)

--- a/cms/forms/widgets.py
+++ b/cms/forms/widgets.py
@@ -11,7 +11,7 @@ from django.utils.encoding import force_text
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
 
-from cms.forms.utils import get_site_choices, get_page_choices
+from cms.cache.choices import get_site_choices, get_page_choices
 from cms.models import Page, PageUser
 from cms.templatetags.cms_admin import CMS_ADMIN_ICON_BASE
 

--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -682,7 +682,6 @@ class Page(six.with_metaclass(PageMetaClass, MP_Node)):
         cms_signals.post_publish.send(sender=Page, instance=self, language=language)
 
         from cms.cache import invalidate_cms_page_cache
-        print("invalidate")
         invalidate_cms_page_cache()
 
         return published

--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -682,6 +682,7 @@ class Page(six.with_metaclass(PageMetaClass, MP_Node)):
         cms_signals.post_publish.send(sender=Page, instance=self, language=language)
 
         from cms.cache import invalidate_cms_page_cache
+        print("invalidate")
         invalidate_cms_page_cache()
 
         return published

--- a/cms/models/placeholdermodel.py
+++ b/cms/models/placeholdermodel.py
@@ -1,16 +1,13 @@
 # -*- coding: utf-8 -*-
 from cms.utils.compat import DJANGO_1_7
-from django.conf import settings
 from django.contrib import admin
 from django.contrib.auth import get_permission_codename
 from django.db import models
 from django.template.defaultfilters import title
-from django.utils.encoding import force_text, python_2_unicode_compatible
-from django.utils.timezone import get_current_timezone_name
+from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 
 from cms.exceptions import LanguageError
-from cms.utils import get_cms_setting
 from cms.utils.helpers import reversion_register
 from cms.utils.i18n import get_language_object
 from cms.utils.placeholder import PlaceholderNoAction, get_placeholder_conf
@@ -84,13 +81,6 @@ class Placeholder(models.Model):
     def get_extra_menu_items(self):
         from cms.plugin_pool import plugin_pool
         return plugin_pool.get_extra_placeholder_menu_items(self)
-
-    def get_cache_key(self, lang):
-        cache_key = '%srender_placeholder:%s.%s' % (get_cms_setting("CACHE_PREFIX"), self.pk, str(lang))
-        if settings.USE_TZ:
-            tz_name = force_text(get_current_timezone_name(), errors='ignore')
-            cache_key += '.%s' % tz_name.encode('ascii', 'ignore').decode('ascii').replace(' ', '_')
-        return cache_key
 
     def _get_url(self, key, pk=None):
         model = self._get_attached_model()

--- a/cms/plugin_pool.py
+++ b/cms/plugin_pool.py
@@ -28,7 +28,7 @@ class PluginPool(object):
     def discover_plugins(self):
         if self.discovered:
             return
-        from cms.views import invalidate_cms_page_cache
+        from cms.cache import invalidate_cms_page_cache
         invalidate_cms_page_cache()
         load('cms_plugins')
         self.discovered = True

--- a/cms/signals/apphook.py
+++ b/cms/signals/apphook.py
@@ -27,7 +27,7 @@ def apphook_post_page_checker(page):
                 old_page.application_urls != page.application_urls or old_page.application_namespace != page.application_namespace)) or (
             not old_page and page.application_urls):
 
-        from cms.views import invalidate_cms_page_cache
+        from cms.cache import invalidate_cms_page_cache
         invalidate_cms_page_cache()
         request_finished.connect(trigger_restart, dispatch_uid=DISPATCH_UID)
 
@@ -68,7 +68,7 @@ def apphook_post_delete_title_checker(instance, **kwargs):
     """
     Check if this was an apphook
     """
-    from cms.views import invalidate_cms_page_cache
+    from cms.cache import invalidate_cms_page_cache
     invalidate_cms_page_cache()
     if instance.page.application_urls:
         request_finished.connect(trigger_restart, dispatch_uid=DISPATCH_UID)

--- a/cms/signals/page.py
+++ b/cms/signals/page.py
@@ -65,7 +65,7 @@ def pre_delete_page(instance, **kwargs):
 def post_delete_page(instance, **kwargs):
     update_home(instance, **kwargs)
     apphook_post_delete_page_checker(instance)
-    from cms.views import invalidate_cms_page_cache
+    from cms.cache import invalidate_cms_page_cache
     invalidate_cms_page_cache()
 
 

--- a/cms/signals/plugins.py
+++ b/cms/signals/plugins.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from cms.cache.placeholder import clear_placeholder_cache
 from cms.constants import PUBLISHER_STATE_DIRTY
 from cms.models import CMSPlugin, Title, Page, StaticPlaceholder, Placeholder
 
@@ -20,10 +21,7 @@ def set_dirty(plugin, delete_cache=True):
         language = plugin.language
 
         if delete_cache:
-            from django.core.cache import cache
-
-            key = placeholder.get_cache_key(language)
-            cache.delete(key)
+            clear_placeholder_cache(placeholder, language)
 
         attached_model = placeholder._get_attached_model()
 

--- a/cms/templatetags/cms_tags.py
+++ b/cms/templatetags/cms_tags.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
-from copy import copy
 from datetime import datetime
 from itertools import chain
-import re
+
+from copy import copy
 
 try:
     from collections import OrderedDict
@@ -36,6 +36,9 @@ from sekizai.helpers import Watcher
 from sekizai.templatetags.sekizai_tags import SekizaiParser, RenderBlock
 
 from cms import __version__
+from cms.cache.page import get_page_url_cache, set_page_url_cache
+from cms.cache.placeholder import (get_placeholder_page_cache, set_placeholder_page_cache,
+                                   get_placeholder_cache)
 from cms.exceptions import PlaceholderNotFound
 from cms.models import Page, Placeholder as PlaceholderModel, CMSPlugin, StaticPlaceholder
 from cms.plugin_pool import plugin_pool
@@ -59,21 +62,6 @@ def has_permission(page, request):
 
 
 register.filter(has_permission)
-
-CLEAN_KEY_PATTERN = re.compile(r'[^a-zA-Z0-9_-]')
-
-
-def _clean_key(key):
-    return CLEAN_KEY_PATTERN.sub('-', key)
-
-
-def _get_cache_key(name, page_lookup, lang, site_id):
-    if isinstance(page_lookup, Page):
-        page_key = str(page_lookup.pk)
-    else:
-        page_key = str(page_lookup)
-    page_key = _clean_key(page_key)
-    return get_cms_setting('CACHE_PREFIX') + name + '__page_lookup:' + page_key + '_site:' + str(site_id) + '_lang:' + str(lang)
 
 
 def _get_page_by_untyped_arg(page_lookup, request, site_id):
@@ -134,6 +122,7 @@ def _get_page_by_untyped_arg(page_lookup, request, site_id):
                     mail_managers(subject, body, fail_silently=True)
             return None
 
+
 class PageUrl(AsTag):
     name = 'page_url'
 
@@ -161,7 +150,6 @@ class PageUrl(AsTag):
             return ''
 
     def get_value(self, context, page_lookup, lang, site):
-        from django.core.cache import cache
 
         site_id = get_site_id(site)
         request = context.get('request', False)
@@ -172,17 +160,12 @@ class PageUrl(AsTag):
         if lang is None:
             lang = get_language_from_request(request)
 
-        cache_key = _get_cache_key('page_url', page_lookup, lang, site_id) + \
-            '_type:absolute_url'
-
-        url = cache.get(cache_key)
-
-        if not url:
+        url = get_page_url_cache(page_lookup, lang, site_id)
+        if url is None:
             page = _get_page_by_untyped_arg(page_lookup, request, site_id)
             if page:
                 url = page.get_absolute_url(language=lang)
-                cache.set(cache_key, url,
-                          get_cms_setting('CACHE_DURATIONS')['content'])
+                set_page_url_cache(page_lookup, lang, site_id, url)
         if url:
             return url
         return ''
@@ -193,7 +176,6 @@ register.tag('page_id_url', PageUrl)
 
 
 def _get_placeholder(current_page, page, context, name):
-    from django.core.cache import cache
     placeholder_cache = getattr(current_page, '_tmp_placeholders_cache', {})
     if page.pk in placeholder_cache:
         placeholder = placeholder_cache[page.pk].get(name, None)
@@ -207,9 +189,8 @@ def _get_placeholder(current_page, page, context, name):
         fetch_placeholders = placeholders
     else:
         for placeholder in placeholders:
-            cache_key = placeholder.get_cache_key(get_language())
-            cached_value = cache.get(cache_key)
-            if not cached_value is None:
+            cached_value = get_placeholder_cache(placeholder, get_language())
+            if cached_value is not None:
                 restore_sekizai_context(context, cached_value['sekizai'])
                 placeholder.content_cache = cached_value['content']
             else:
@@ -229,7 +210,6 @@ def _get_placeholder(current_page, page, context, name):
 
 
 def get_placeholder_content(context, request, current_page, name, inherit, default):
-    from django.core.cache import cache
     edit_mode = getattr(request, 'toolbar', None) and getattr(request.toolbar, 'edit_mode')
     pages = [current_page]
     # don't display inherited plugins in edit mode, so that the user doesn't
@@ -245,9 +225,8 @@ def get_placeholder_content(context, request, current_page, name, inherit, defau
             if hasattr(placeholder, 'content_cache'):
                 return mark_safe(placeholder.content_cache)
             if not hasattr(placeholder, 'cache_checked'):
-                cache_key = placeholder.get_cache_key(get_language())
-                cached_value = cache.get(cache_key)
-                if not cached_value is None:
+                cached_value = get_placeholder_cache(placeholder, get_language())
+                if cached_value is not None:
                     restore_sekizai_context(context, cached_value['sekizai'])
                     return mark_safe(cached_value['content'])
         if not get_plugins(request, placeholder, page.get_template()):
@@ -575,7 +554,6 @@ def _show_placeholder_for_page(context, placeholder_name, page_lookup, lang=None
     See _get_page_by_untyped_arg() for detailed information on the allowed types
     and their interpretation for the page_lookup argument.
     """
-    from django.core.cache import cache
     validate_placeholder_name(placeholder_name)
 
     if DJANGO_1_7:
@@ -591,9 +569,7 @@ def _show_placeholder_for_page(context, placeholder_name, page_lookup, lang=None
         lang = get_language_from_request(request)
 
     if cache_result:
-        base_key = _get_cache_key('_show_placeholder_for_page', page_lookup, lang, site_id)
-        cache_key = _clean_key('%s_placeholder:%s' % (base_key, placeholder_name))
-        cached_value = cache.get(cache_key)
+        cached_value = get_placeholder_page_cache(page_lookup, lang, site_id, placeholder_name)
         if cached_value:
             restore_sekizai_context(context, cached_value['sekizai'])
             return {'content': mark_safe(cached_value['content'])}
@@ -610,7 +586,8 @@ def _show_placeholder_for_page(context, placeholder_name, page_lookup, lang=None
     content = render_placeholder(placeholder, context, placeholder_name, use_cache=cache_result)
     changes = watcher.get_changes()
     if cache_result:
-        cache.set(cache_key, {'content': content, 'sekizai': changes}, get_cms_setting('CACHE_DURATIONS')['content'])
+        set_placeholder_page_cache(page_lookup, lang, site_id, placeholder_name,
+                                   {'content': content, 'sekizai': changes})
 
     if content:
         return {'content': mark_safe(content)}

--- a/cms/tests/cache.py
+++ b/cms/tests/cache.py
@@ -1,5 +1,10 @@
 # -*- coding: utf-8 -*-
+from django.core.cache import cache
+from django.template import Template, RequestContext
+from django.conf import settings
+
 from cms.api import add_plugin, create_page
+from cms.cache import _get_cache_version
 from cms.models import Page
 from cms.plugin_pool import plugin_pool
 from cms.test_utils.project.pluginapp.plugins.caching.cms_plugins import NoCachePlugin, SekizaiPlugin
@@ -7,10 +12,6 @@ from cms.test_utils.testcases import CMSTestCase
 from cms.test_utils.util.fuzzy_int import FuzzyInt
 from cms.toolbar.toolbar import CMSToolbar
 from cms.utils import get_cms_setting
-from django.core.cache import cache
-from django.template import Template, RequestContext
-from django.conf import settings
-from cms.views import _get_cache_version
 
 
 class CacheTestCase(CMSTestCase):

--- a/cms/tests/forms.py
+++ b/cms/tests/forms.py
@@ -2,19 +2,20 @@
 from __future__ import with_statement
 from datetime import datetime
 
-from cms.models import ACCESS_PAGE, ACCESS_PAGE_AND_CHILDREN
-from cms.utils.permissions import set_current_user
 from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
 from django.core.cache import cache
+
 from cms.admin import forms
-from cms.admin.forms import PageUserForm, PagePermissionInlineAdminForm, ViewRestrictionInlineAdminForm, \
-    GlobalPagePermissionAdminForm, PageUserGroupForm
+from cms.admin.forms import (PageUserForm, PagePermissionInlineAdminForm,
+                             ViewRestrictionInlineAdminForm, GlobalPagePermissionAdminForm,
+                             PageUserGroupForm)
 from cms.api import create_page, create_page_user, assign_user_to_page
+from cms.cache.choices import update_site_and_page_choices, get_site_choices, get_page_choices
 from cms.forms.fields import PageSelectFormField, SuperLazyIterator
-from cms.forms.utils import (get_site_choices, get_page_choices,
-    update_site_and_page_choices)
+from cms.models import ACCESS_PAGE, ACCESS_PAGE_AND_CHILDREN
 from cms.test_utils.testcases import CMSTestCase
+from cms.utils.permissions import set_current_user
 
 
 class Mock_PageSelectFormField(PageSelectFormField):

--- a/cms/tests/multilingual.py
+++ b/cms/tests/multilingual.py
@@ -9,8 +9,8 @@ from django.http import Http404, HttpResponseRedirect
 from django.test.utils import override_settings
 
 from cms.api import create_page, create_title, publish_page, add_plugin
+from cms.cache.choices import update_site_and_page_choices
 from cms.exceptions import LanguageError
-from cms.forms.utils import update_site_and_page_choices
 from cms.menu import CMSMenu
 from cms.models import Title, EmptyTitle
 from cms.test_utils.testcases import (CMSTestCase,

--- a/cms/tests/rendering.py
+++ b/cms/tests/rendering.py
@@ -8,11 +8,9 @@ from sekizai.context import SekizaiContext
 
 from cms import plugin_rendering
 from cms.api import create_page, add_plugin
-from cms.models import Page
-from cms.models.placeholdermodel import Placeholder
-from cms.models.pluginmodel import CMSPlugin
+from cms.cache.placeholder import get_placeholder_cache, get_placeholder_page_cache
+from cms.models import Page, Placeholder, CMSPlugin
 from cms.plugin_rendering import render_plugins, PluginContext, render_placeholder_toolbar
-from cms.templatetags.cms_tags import _clean_key, _get_cache_key
 from cms.test_utils.project.placeholderapp.models import Example1
 from cms.test_utils.testcases import CMSTestCase
 from cms.test_utils.util.context_managers import ChangeModel
@@ -294,10 +292,9 @@ class RenderingTestCase(CMSTestCase):
 
         template = '{% load cms_tags %}<h1>{% render_uncached_placeholder ex1.placeholder %}</h1>'
 
-        cache_key = ex1.placeholder.get_cache_key(u"en")
-        cache_value_before = cache.get(cache_key)
+        cache_value_before = get_placeholder_cache(ex1.placeholder, 'en')
         self.render(template, self.test_page, {'ex1': ex1})
-        cache_value_after = cache.get(cache_key)
+        cache_value_after = get_placeholder_cache(ex1.placeholder, 'en')
 
         self.assertEqual(cache_value_before, cache_value_after)
         self.assertIsNone(cache_value_after)
@@ -315,10 +312,9 @@ class RenderingTestCase(CMSTestCase):
 
         template = '{% load cms_tags %}<h1>{% render_placeholder ex1.placeholder %}</h1>'
 
-        cache_key = ex1.placeholder.get_cache_key(u"en")
-        cache_value_before = cache.get(cache_key)
+        cache_value_before = get_placeholder_cache(ex1.placeholder, 'en')
         self.render(template, self.test_page, {'ex1': ex1})
-        cache_value_after = cache.get(cache_key)
+        cache_value_after = get_placeholder_cache(ex1.placeholder, 'en')
 
         self.assertNotEqual(cache_value_before, cache_value_after)
         self.assertIsNone(cache_value_before)
@@ -374,13 +370,9 @@ class RenderingTestCase(CMSTestCase):
         """
         template = '{% load cms_tags %}<h1>{% show_uncached_placeholder "sub" test_page %}</h1>'
 
-        base_key = _get_cache_key('_show_placeholder_for_page', self.test_page, "en",
-                                  self.test_page.site_id)
-        cache_key = _clean_key('%s_placeholder:%s' % (base_key, "sub"))
-
-        cache_value_before = cache.get(cache_key)
+        cache_value_before = get_placeholder_page_cache(self.test_page, 'en', self.test_page.site_id, 'sub')
         output = self.render(template, self.test_page, {'test_page': self.test_page})
-        cache_value_after = cache.get(cache_key)
+        cache_value_after = get_placeholder_page_cache(self.test_page, 'en', self.test_page.site_id, 'sub')
 
         self.assertEqual(output, '<h1>%s</h1>' % self.test_data['text_sub'])
         self.assertEqual(cache_value_before, cache_value_after)


### PR DESCRIPTION
And refactor the cache in the process

Refactoring is not needed to fix the issue but it makes way easier.
The scope of the fix is to use version for **every** cached item, not only pages. When a page is published the version is updated for placeholders, pages and menus not only the pages as it is now

Fix #4202