### PR TITLE
Fix redirect when deleting a page

### DIFF
--- a/cms/static/cms/js/modules/cms.base.js
+++ b/cms/static/cms/js/modules/cms.base.js
@@ -53,7 +53,7 @@ $(document).ready(function () {
 						if(response === '' && !url) {
 							// cancel if response is empty
 							return false;
-						} else if(parent.location.pathname !== response) {
+						} else if(response !== '' && parent.location.pathname !== response) {
 							// api call to the backend to check if the current path is still the same
 							that.reloadBrowser(response);
 						} else if(url === 'REFRESH_PAGE') {

--- a/cms/static/cms/js/modules/cms.modal.js
+++ b/cms/static/cms/js/modules/cms.modal.js
@@ -501,8 +501,6 @@ $(document).ready(function () {
 						// trigger only when blue action buttons are triggered
 						if(item.hasClass('default') || item.hasClass('deletelink')) {
  							that.options.newPlugin = null;
- 							// reset onClose when delete is triggered
-							//if(item.hasClass('deletelink')) that.options.onClose = null;
 							// hide iframe
 							that.modal.find('.cms_modal-frame iframe').hide();
 							// page has been saved or deleted, run checkup
@@ -585,9 +583,8 @@ $(document).ready(function () {
 				// also check that no delete-confirmation is required
 				if(that.saved && !contents.find('.delete-confirmation').length) {
 					if(that.options.onClose){
-						that.reloadBrowser(that.options.onClose);
-					}
-					else {
+						that.reloadBrowser(that.options.onClose, false, true);
+					} else {
 						that.reloadBrowser(window.location.href, false, true);
 					}
 				} else {

--- a/cms/static/cms/js/modules/cms.modal.js
+++ b/cms/static/cms/js/modules/cms.modal.js
@@ -502,7 +502,7 @@ $(document).ready(function () {
 						if(item.hasClass('default') || item.hasClass('deletelink')) {
  							that.options.newPlugin = null;
  							// reset onClose when delete is triggered
-							if(item.hasClass('deletelink')) that.options.onClose = null;
+							//if(item.hasClass('deletelink')) that.options.onClose = null;
 							// hide iframe
 							that.modal.find('.cms_modal-frame iframe').hide();
 							// page has been saved or deleted, run checkup
@@ -584,7 +584,12 @@ $(document).ready(function () {
 				// when the window has been changed pressing the blue or red button, we need to run a reload check
 				// also check that no delete-confirmation is required
 				if(that.saved && !contents.find('.delete-confirmation').length) {
-					that.reloadBrowser(window.location.href, false, true);
+					if(that.options.onClose){
+						that.reloadBrowser(that.options.onClose);
+					}
+					else {
+						that.reloadBrowser(window.location.href, false, true);
+					}
 				} else {
 					iframe.show();
 					// set title of not provided


### PR DESCRIPTION
Fix #3654 

This works by preserving ``this.options.onClose`` when deleting a page.

This does not fix the redirect when deleting an object in a apphooked application from the frontend