### PR TITLE
Extended "Other Plugins" to be consistent with tutorial

### DIFF
--- a/docs/how_to/install.rst
+++ b/docs/how_to/install.rst
@@ -67,6 +67,7 @@ Other Plugins
 * djangocms-grid
 * djangocms-oembed
 * djangocms-table
+* djangocms-flash
 
 
 File and image handling


### PR DESCRIPTION
Added djangocms-flash to "Other Plugins" list to be consistent with the rest of the tutorial e.g. INSTALLED_APPS settings in settings.py.