### PR TITLE
Fixed check for template instance in Django 1.8.x

### DIFF
--- a/cms/plugin_rendering.py
+++ b/cms/plugin_rendering.py
@@ -60,8 +60,8 @@ def render_plugin(context, instance, placeholder, template, processors=None, cur
         processors = []
     if isinstance(template, six.string_types):
         content = render_to_string(template, context)
-    elif isinstance(template, Template) or (hasattr(template, 'template') and\
-         hasattr(template, 'render') and isinstance(template.template, Template)):
+    elif (isinstance(template, Template) or (hasattr(template, 'template') and\
+         hasattr(template, 'render') and isinstance(template.template, Template))):
         content = template.render(context)
     else:
         content = ''

--- a/cms/plugin_rendering.py
+++ b/cms/plugin_rendering.py
@@ -60,7 +60,7 @@ def render_plugin(context, instance, placeholder, template, processors=None, cur
         processors = []
     if isinstance(template, six.string_types):
         content = render_to_string(template, context)
-    elif (isinstance(template, Template) or (hasattr(template, 'template') and\
+    elif (isinstance(template, Template) or (hasattr(template, 'template') and
          hasattr(template, 'render') and isinstance(template.template, Template))):
         content = template.render(context)
     else:

--- a/cms/plugin_rendering.py
+++ b/cms/plugin_rendering.py
@@ -60,7 +60,8 @@ def render_plugin(context, instance, placeholder, template, processors=None, cur
         processors = []
     if isinstance(template, six.string_types):
         content = render_to_string(template, context)
-    elif isinstance(template, Template):
+    elif isinstance(template, Template) or (hasattr(template, 'template') and\
+         hasattr(template, 'render') and isinstance(template.template, Template)):
         content = template.render(context)
     else:
         content = ''


### PR DESCRIPTION
I have has problems using the cmsplugin-filer-image after upgrading to Django 1.8.x. I have traced the bug back to the way that django-cms is checking for templates, and the changes in Django 1.8 supporting multiple templating engines.

This is the best solution I have been able to pull off due to the template object often not being an instance of Template, which is also the case for both the included engines.

Fixes #4253