### PR TITLE
Pin djangocms-text-ckeditor version for older djangos

### DIFF
--- a/test_requirements/django-1.4.txt
+++ b/test_requirements/django-1.4.txt
@@ -2,4 +2,5 @@
 Django>=1.4.5,<1.5
 South==1.0.2
 django-reversion>=1.6.6,<1.7
+djangocms-text-ckeditor<2.6
 https://github.com/KristianOellegaard/django-hvad/archive/master.zip#egg=hvad

--- a/test_requirements/django-1.5.txt
+++ b/test_requirements/django-1.5.txt
@@ -2,4 +2,5 @@
 Django>=1.5,<1.6
 South==1.0.2
 django-reversion>=1.7,<=1.8
+djangocms-text-ckeditor<2.6
 https://github.com/KristianOellegaard/django-hvad/archive/master.zip#egg=hvad

--- a/test_requirements/django-1.6.txt
+++ b/test_requirements/django-1.6.txt
@@ -2,4 +2,5 @@
 django>=1.6,<1.7
 South==1.0.2
 django-reversion<1.8.3
+-e git+git://github.com/divio/djangocms-text-ckeditor.git#egg=djangocms-text-ckeditor
 https://github.com/KristianOellegaard/django-hvad/archive/master.zip#egg=hvad

--- a/test_requirements/django-1.7.txt
+++ b/test_requirements/django-1.7.txt
@@ -1,5 +1,6 @@
 -r requirements_base.txt
 django>=1.7,<1.8
 django-reversion>=1.8,<1.9
+-e git+git://github.com/divio/djangocms-text-ckeditor.git#egg=djangocms-text-ckeditor
 https://github.com/KristianOellegaard/django-hvad/archive/master.zip
 

--- a/test_requirements/requirements_base.txt
+++ b/test_requirements/requirements_base.txt
@@ -13,7 +13,6 @@ dj-database-url
 selenium
 django-debug-toolbar
 -e git+git://github.com/divio/djangocms-admin-style.git#egg=djangocms-admin-style
--e git+git://github.com/divio/djangocms-text-ckeditor.git#egg=djangocms-text-ckeditor
 -e git+git://github.com/divio/djangocms-column.git#egg=djangocms-column
 -e git+git://github.com/divio/djangocms-style.git#egg=djangocms-style
 -e git+git://github.com/divio/djangocms-file.git#egg=djangocms-file


### PR DESCRIPTION
As djangocms-text-ckeditor does not support Django 1.4/1.5 pinning version is required