### PR TITLE
make sure version returned is an int

### DIFF
--- a/cms/cache/permissions.py
+++ b/cms/cache/permissions.py
@@ -26,7 +26,7 @@ def get_cache_permission_version():
     version = cache.get(get_cache_permission_version_key())
     if version is None:
         version = 1
-    return version
+    return int(version)
 
 
 def get_permission_cache(user, key):


### PR DESCRIPTION
while deploying to heroku together with memcachedcloud, we ran into a TypeError comparing a byte string to an int.

cms/cache/permissions.py in clear_permission_cache
    if version > 1:

This does not occur when running memcached locally. 

python 3.4.3
django 1.7.9
django-cms 3.1.2