### PR TITLE
Only attempt to delete cache keys if there are some to be deleted

### DIFF
--- a/menus/menu_pool.py
+++ b/menus/menu_pool.py
@@ -155,8 +155,9 @@ class MenuPool(object):
         else:
             cache_keys = CacheKey.objects.get_keys(site_id, language)
         to_be_deleted = cache_keys.distinct().values_list('key', flat=True)
-        cache.delete_many(to_be_deleted)
-        cache_keys.delete()
+        if to_be_deleted:
+            cache.delete_many(to_be_deleted)
+            cache_keys.delete()
 
     def register_menu(self, menu_cls):
         import os


### PR DESCRIPTION
If no cached keys are found for a particular menu, do not attempt to remove them as this will cause 

`redis.exceptions.ResponseError: wrong number of arguments for 'del' command` 

when used with Redis as the cache backend.

Referenced here: https://github.com/andymccurdy/redis-py/issues/513