### PR TITLE
Fix issue preventing migrations to run on a new database (django 1.8)

### DIFF
--- a/cms/migrations/0010_migrate_use_structure.py
+++ b/cms/migrations/0010_migrate_use_structure.py
@@ -43,6 +43,8 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ('cms', '0009_merge'),
+        # fix issue when performing migrations on an empty database
+        ('contenttypes', '0002_remove_content_type_name'),
     ]
 
     operations = [


### PR DESCRIPTION
When performing a clean installation of my project, I encountered this error:

```
Applying cms.0001_initial... OK
 Applying cms.0002_auto_20140816_1918... OK
 Applying cms.0003_auto_20140926_2347... OK
 Applying cms.0004_auto_20140924_1038... OK
 Applying cms.0005_auto_20140924_1039... OK
 Applying cms.0006_auto_20140924_1110... OK
 Applying cms.0007_auto_20141028_1559... OK
 Applying cms.0008_auto_20150208_2149... OK
 Applying cms.0008_auto_20150121_0059... OK
 Applying cms.0009_merge... OK
 Applying cms.0010_migrate_use_structure...Traceback (most recent call last):
 File "manage.py", line 10, in <module>
   execute_from_command_line(sys.argv)
   ...
RuntimeError: Error creating new content types. Please make sure contenttypes is migrated before trying to migrate apps individually.
```

Adding a dependency to the contenttypes application fixes the issue.