### PR TITLE
More welcoming welcome page

### DIFF
--- a/cms/page_rendering.py
+++ b/cms/page_rendering.py
@@ -1,13 +1,22 @@
 # -*- coding: utf-8 -*-
+from cms import constants
+from cms.api import create_page
+from cms.utils.permissions import has_page_add_permission
+from django import forms
 from django.conf import settings
+from django.contrib.admin.forms import AdminAuthenticationForm
+from django.contrib.auth.views import login
 from django.core.urlresolvers import resolve, Resolver404
-from django.http import Http404
+from django.http import Http404, HttpResponseRedirect
+from django.shortcuts import render
 from django.template import RequestContext
 from django.template.response import TemplateResponse
+from django.utils.translation import ugettext_lazy as _, \
+    get_language_from_request
 
 from cms.cache.page import set_page_cache
 from cms.models import Page
-from cms.utils import get_template_from_request
+from cms.utils import get_template_from_request, get_cms_setting
 
 
 def render_page(request, page, current_language, slug):
@@ -29,7 +38,8 @@ def render_page(request, page, current_language, slug):
 
     response.add_post_render_callback(set_page_cache)
 
-    # Add headers for X Frame Options - this really should be changed upon moving to class based views
+    # Add headers for X Frame Options - this really should be changed upon
+    # moving to class based views
     xframe_options = page.get_xframe_options()
     # xframe_options can be None if there's no xframe information on the page
     # (eg. a top-level page which has xframe options set to "inherit")
@@ -50,11 +60,68 @@ def render_page(request, page, current_language, slug):
     return response
 
 
+class SimpleAddPageForm(forms.Form):
+    title = forms.CharField(label=_("Title"), widget=forms.TextInput(),
+                            help_text=_('Title of your home page'))
+
+    def save(self, template, language, user):
+        return create_page(
+            title=self.cleaned_data['title'],
+            language=language,
+            template=template,
+            created_by=user,
+        )
+
+
+def welcome(request):
+    if not request.user.is_authenticated():
+        response = login(
+            request,
+            authentication_form=AdminAuthenticationForm,
+            template_name='cms/welcome_login.html'
+        )
+        if request.user.is_authenticated():
+            return HttpResponseRedirect(request.path)
+        else:
+            return response
+    else:
+        config_errors = []
+        templates = get_cms_setting('TEMPLATES')
+        if (len(templates) == 0 and
+                templates[0] == constants.TEMPLATE_INHERITANCE_MAGIC):
+            config_errors.append(_("You must configure CMS_TEMPLATES"))
+        if not has_page_add_permission(request):
+            config_errors.append(_("You do not have permission to add a page"))
+            can_save = False
+        else:
+            can_save = True
+        if request.method == 'POST':
+            form = SimpleAddPageForm(request.POST)
+            if form.is_valid() and can_save:
+                language = get_language_from_request(request)
+                page = form.save(
+                    templates[0][0],
+                    language,
+                    request.user,
+                )
+                return HttpResponseRedirect('{path}?{flag}'.format(
+                    path=page.get_absolute_url(language=language),
+                    flag=get_cms_setting('TOOLBAR_URL__EDIT_ON')
+                ))
+        else:
+            form = SimpleAddPageForm()
+        context = {
+            'form': form,
+            'config_errors': config_errors
+        }
+        return render(request, 'cms/welcome.html', context)
+
+
 def _handle_no_page(request, slug):
     if not slug and settings.DEBUG:
-        return TemplateResponse(request, "cms/welcome.html", RequestContext(request))
+        return welcome(request)
     try:
-        #add a $ to the end of the url (does not match on the cms anymore)
+        # add a $ to the end of the url (does not match on the cms anymore)
         resolve('%s$' % request.path)
     except Resolver404 as e:
         # raise a django http 404 page

--- a/cms/templates/cms/welcome.html
+++ b/cms/templates/cms/welcome.html
@@ -44,17 +44,24 @@
 <div class="wrapper">
     <div class="inner">
         <h1 class="logo">Installation successful!</h1>
-        <p>Switch to <a href="/?{{ request.toolbar.edit_mode_url_on }}">edit mode</a>,<br />log in and start <a href="{% cms_admin_url "cms_page_add" %}?title=Home" id="add-page">adding pages</a>.</p>
-        <p class="buttons">
-            <a href="//docs.django-cms.org/" class="btn" target="_blank">Documentation</a>
-            <a href="//www.django-cms.org/" class="btn" target="_blank">Support</a>
-        </p>
+        {% block body %}
+          {% if config_errors %}
+            {% for error in config_errors %}
+              {{ error }}
+            {%  endfor %}
+          {% else %}
+            <form method="POST">{% csrf_token %}
+              {{ form.as_p }}
+              <button>Create Page</button>
+            </form>
+          {% endif %}
         <p class="footnote">
             If you don't see the django CMS logo at the top, make sure you linked the <code>static/cms</code> folder to your static files.</p>
         <p class="footnote">
             You're seeing this message because you have <code>DEBUG = True</code> in your
             django settings file and haven't added any pages yet.
         </p>
+        {% endblock %}
     </div>
 </div>
 {% render_block "js" %}

--- a/cms/templates/cms/welcome_login.html
+++ b/cms/templates/cms/welcome_login.html
@@ -1,0 +1,29 @@
+{% extends "cms/welcome.html" %}
+
+{% load i18n %}
+
+{% block body %}
+  <h2>Log in to get started</h2>
+
+  <div id="content-main">
+  <form action="{% url 'pages-root' %}" method="post" id="login-form">{% csrf_token %}
+    <div class="form-row">
+      {{ form.username.errors }}
+      {{ form.username.label_tag }} {{ form.username }}
+    </div>
+    <div class="form-row">
+      {{ form.password.errors }}
+      {{ form.password.label_tag }} {{ form.password }}
+      <input type="hidden" name="next" value="{{ next }}" />
+    </div>
+    <div class="submit-row">
+      <label>&nbsp;</label><input type="submit" value="{% trans 'Log in' %}" />
+    </div>
+  </form>
+
+  <script type="text/javascript">
+  document.getElementById('id_username').focus()
+  </script>
+  </div>
+
+{% endblock %}


### PR DESCRIPTION
Currently, when starting a new django CMS project, the first thing you get greeted with is our welcome page, which asks you to add a page or enter edit mode. The first problem with this is that new users might just be confused by the idea to enter an edit mode in the first place, but the bigger issue is what happens if a user hits "add a page". In that case, the user is sent to the admin to add a page, and then is in the admin page list, likely completely lost and not sure where to go next.

This PR proposes we change this welcome page to ask you to log in, then choose the title of your home page, then sends you to the home page in edit mode.

The form asks you for a single input: the title of your home page. This is to keep friction as low as possible and make the whole process as fast/easy as possible. For the template it uses the first template in the list, the language is the current request language and since it's the home page, slug doesn't matter.

TODO:
- [x] Implement logic
- [ ] Actually style/design the pages