### PR TITLE
CMSPlugin.position not null 

### DIFF
--- a/cms/models/pluginmodel.py
+++ b/cms/models/pluginmodel.py
@@ -75,7 +75,7 @@ class CMSPlugin(six.with_metaclass(PluginModelBase, MP_Node)):
     '''
     placeholder = models.ForeignKey(Placeholder, editable=False, null=True)
     parent = models.ForeignKey('self', blank=True, null=True, editable=False)
-    position = models.PositiveSmallIntegerField(_("position"), blank=True, null=True, editable=False)
+    position = models.PositiveSmallIntegerField(_("position"), default = 0, editable=False)
     language = models.CharField(_("language"), max_length=15, blank=False, db_index=True, editable=False)
     plugin_type = models.CharField(_("plugin_name"), max_length=50, db_index=True, editable=False)
     creation_date = models.DateTimeField(_("creation date"), editable=False, default=timezone.now)
@@ -319,6 +319,7 @@ class CMSPlugin(six.with_metaclass(PluginModelBase, MP_Node)):
             plugin_instance.language = target_language
             plugin_instance.parent = new_plugin.parent
             plugin_instance.depth = new_plugin.depth
+            plugin_instance.position = new_plugin.position
             plugin_instance.path = new_plugin.path
             plugin_instance.numchild = new_plugin.numchild
             plugin_instance._no_reorder = True

--- a/cms/models/pluginmodel.py
+++ b/cms/models/pluginmodel.py
@@ -319,7 +319,6 @@ class CMSPlugin(six.with_metaclass(PluginModelBase, MP_Node)):
             plugin_instance.language = target_language
             plugin_instance.parent = new_plugin.parent
             plugin_instance.depth = new_plugin.depth
-            plugin_instance.position = new_plugin.position
             plugin_instance.path = new_plugin.path
             plugin_instance.numchild = new_plugin.numchild
             plugin_instance._no_reorder = True


### PR DESCRIPTION
Django CMSPlugin.position null raises unorderable types: NoneType() < int()