### PR TITLE
Update test requirements

### DIFF
--- a/test_requirements/django-1.6.txt
+++ b/test_requirements/django-1.6.txt
@@ -3,6 +3,6 @@ django>=1.6,<1.7
 South==1.0.2
 django-reversion<1.8.3
 -e git+git://github.com/divio/djangocms-text-ckeditor.git#egg=djangocms-text-ckeditor
-https://github.com/KristianOellegaard/django-hvad/archive/master.zip#egg=hvad
+django-hvad>=1.0
 django-classy-tags>=0.5
 django-sekizai>=0.7

--- a/test_requirements/django-1.7.txt
+++ b/test_requirements/django-1.7.txt
@@ -2,6 +2,6 @@
 django>=1.7,<1.8
 django-reversion>=1.8,<1.9
 -e git+git://github.com/divio/djangocms-text-ckeditor.git#egg=djangocms-text-ckeditor
-https://github.com/KristianOellegaard/django-hvad/archive/master.zip
+django-hvad>=1.1
 django-classy-tags>=0.5
 django-sekizai>=0.7

--- a/test_requirements/django-1.8.txt
+++ b/test_requirements/django-1.8.txt
@@ -2,6 +2,6 @@
 https://github.com/django/django/tarball/stable/1.8.x/django.tar.gz#egg=django
 django-reversion>=1.8,<1.9
 -e git+git://github.com/divio/djangocms-text-ckeditor.git#egg=djangocms-text-ckeditor
-https://github.com/KristianOellegaard/django-hvad/archive/master.zip
-https://github.com/ojii/django-sekizai/archive/master.zip
-https://github.com/ojii/django-classy-tags/archive/master.zip
+django-hvad>=1.1
+django-classy-tags>=0.6.1
+django-sekizai>=0.8.2

--- a/test_requirements/django-trunk.txt
+++ b/test_requirements/django-trunk.txt
@@ -1,4 +1,4 @@
 -r requirements_base.txt
 https://github.com/django/django/tarball/master/django.tar.gz#egg=django
 django-reversion>=1.8
-https://github.com/gabejackson/django-hvad/archive/django_1.7_compat.zip
+https://github.com/KristianOellegaard/django-hvad/archive/master.zip

--- a/test_requirements/requirements_base.txt
+++ b/test_requirements/requirements_base.txt
@@ -4,7 +4,7 @@ docopt==0.6.2
 unittest-xml-reporting==1.11.0
 sphinx
 Pillow==2.7.0
-html5lib>=0.90,<0.9999
+html5lib>=0.90,!=0.9999,!=0.99999
 django-treebeard==3.0
 argparse
 dj-database-url


### PR DESCRIPTION
Let's use released version instead of repositories, whenever possible