### PR TITLE
Fix Page.get_cached_ancestors order

### DIFF
--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -790,8 +790,10 @@ class Page(six.with_metaclass(PageMetaClass, MP_Node)):
         return sorted([language for language in self.get_languages() if self.is_published(language)])
 
     def get_cached_ancestors(self):
+        # Unlike MPTT, Treebeard returns this in parent->child order, so you will have to reverse
+        # this list to have the same behavior as before
         if not hasattr(self, "ancestors_ascending"):
-            self.ancestors_ascending = list(reversed(self.get_ancestors()))
+            self.ancestors_ascending = list(self.get_ancestors())
         return self.ancestors_ascending
 
     def get_cached_descendants(self):

--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -791,7 +791,7 @@ class Page(six.with_metaclass(PageMetaClass, MP_Node)):
 
     def get_cached_ancestors(self):
         if not hasattr(self, "ancestors_ascending"):
-            self.ancestors_ascending = list(self.get_ancestors())
+            self.ancestors_ascending = list(reversed(self.get_ancestors()))
         return self.ancestors_ascending
 
     def get_cached_descendants(self):

--- a/cms/templatetags/cms_tags.py
+++ b/cms/templatetags/cms_tags.py
@@ -216,7 +216,7 @@ def get_placeholder_content(context, request, current_page, name, inherit, defau
     # mistakenly edit/delete them. This is a fix for issue #1303. See the discussion
     # there for possible enhancements
     if inherit and not edit_mode:
-        pages = chain([current_page], current_page.get_cached_ancestors())
+        pages = chain([current_page], list(reversed(current_page.get_cached_ancestors())))
     for page in pages:
         placeholder = _get_placeholder(current_page, page, context, name)
         if placeholder is None:

--- a/cms/tests/page.py
+++ b/cms/tests/page.py
@@ -1002,6 +1002,32 @@ class PagesTestCase(CMSTestCase):
         self.assertEqual(page3.get_absolute_url(),
                          self.get_pages_root() + 'test-page-4/test-page-3/')
 
+    def test_page_ancestors_order(self):
+        page1 = create_page('test page 1', 'nav_playground.html', 'en',
+                            published=True)
+
+        page2 = create_page('test page 2', 'nav_playground.html', 'en',
+                            published=True, parent=page1)
+
+        page3 = create_page('test page 3', 'nav_playground.html', 'en',
+                            published=True, parent=page2)
+
+        page6 = create_page('test page 3', 'nav_playground.html', 'en',
+                            published=True, parent=page3)
+
+        page4 = create_page('test page 4', 'nav_playground.html', 'en',
+                            published=True)
+
+        page5 = create_page('test page 5', 'nav_playground.html', 'en',
+                            published=True, parent=page4)
+
+        self.assertListEqual(page1.get_cached_ancestors(), [])
+        self.assertListEqual(page2.get_cached_ancestors(), [page1])
+        self.assertListEqual(page3.get_cached_ancestors(), [page2, page1])
+        self.assertListEqual(page6.get_cached_ancestors(), [page3, page2, page1])
+        self.assertListEqual(page4.get_cached_ancestors(), [])
+        self.assertListEqual(page5.get_cached_ancestors(), [page4])
+
     def test_page_overwrite_urls(self):
         page1 = create_page('test page 1', 'nav_playground.html', 'en',
                             published=True)

--- a/cms/tests/page.py
+++ b/cms/tests/page.py
@@ -1002,32 +1002,6 @@ class PagesTestCase(CMSTestCase):
         self.assertEqual(page3.get_absolute_url(),
                          self.get_pages_root() + 'test-page-4/test-page-3/')
 
-    def test_page_ancestors_order(self):
-        page1 = create_page('test page 1', 'nav_playground.html', 'en',
-                            published=True)
-
-        page2 = create_page('test page 2', 'nav_playground.html', 'en',
-                            published=True, parent=page1)
-
-        page3 = create_page('test page 3', 'nav_playground.html', 'en',
-                            published=True, parent=page2)
-
-        page6 = create_page('test page 3', 'nav_playground.html', 'en',
-                            published=True, parent=page3)
-
-        page4 = create_page('test page 4', 'nav_playground.html', 'en',
-                            published=True)
-
-        page5 = create_page('test page 5', 'nav_playground.html', 'en',
-                            published=True, parent=page4)
-
-        self.assertListEqual(page1.get_cached_ancestors(), [])
-        self.assertListEqual(page2.get_cached_ancestors(), [page1])
-        self.assertListEqual(page3.get_cached_ancestors(), [page2, page1])
-        self.assertListEqual(page6.get_cached_ancestors(), [page3, page2, page1])
-        self.assertListEqual(page4.get_cached_ancestors(), [])
-        self.assertListEqual(page5.get_cached_ancestors(), [page4])
-
     def test_page_overwrite_urls(self):
         page1 = create_page('test page 1', 'nav_playground.html', 'en',
                             published=True)


### PR DESCRIPTION
treebeard has the opposite default ordering of mptt

Fix #4305