### PR TITLE
bugfix for issue #4407 

### DIFF
--- a/cms/static/cms/js/modules/cms.plugins.js
+++ b/cms/static/cms/js/modules/cms.plugins.js
@@ -522,6 +522,9 @@ $(document).ready(function () {
 			var dropdown = nav.find('.cms_submenu-dropdown');
 			var offset = parseInt(dropdown.data('top'));
 
+			//fix issue #4407
+			nav.parents('.cms_draggable').data( 'menustate', 1).trigger('cms.structureboard.menustate.change');
+
 			// clearing
 			clearTimeout(this.timer);
 
@@ -603,6 +606,9 @@ $(document).ready(function () {
 			var that = this;
 			// cancel if quicksearch is focues
 			if(this.focused) return false;
+
+			//fix issue #4407
+			nav.parents('.cms_draggable').data( 'menustate', 0 ).trigger('cms.structureboard.menustate.change');
 
 			// set correct active state
 			nav.closest('.cms_draggable').data('active', false);

--- a/cms/static/cms/js/modules/cms.plugins.js
+++ b/cms/static/cms/js/modules/cms.plugins.js
@@ -522,8 +522,8 @@ $(document).ready(function () {
 			var dropdown = nav.find('.cms_submenu-dropdown');
 			var offset = parseInt(dropdown.data('top'));
 
-			//fix issue #4407
-			nav.parents('.cms_draggable').data( 'menustate', 1).trigger('cms.structureboard.menustate.change');
+			// fix issue #4407
+			nav.parents('.cms_draggable').data('menustate', true).trigger('cms.structureboard.menustate.change');
 
 			// clearing
 			clearTimeout(this.timer);
@@ -608,7 +608,7 @@ $(document).ready(function () {
 			if(this.focused) return false;
 
 			//fix issue #4407
-			nav.parents('.cms_draggable').data( 'menustate', 0 ).trigger('cms.structureboard.menustate.change');
+			nav.parents('.cms_draggable').data('menustate', false).trigger('cms.structureboard.menustate.change');
 
 			// set correct active state
 			nav.closest('.cms_draggable').data('active', false);

--- a/cms/static/cms/js/modules/cms.structureboard.js
+++ b/cms/static/cms/js/modules/cms.structureboard.js
@@ -113,9 +113,9 @@ $(document).ready(function () {
 			});
 
 			//fix issue #4407
-			$('.cms-toolbar-expanded .cms_dragarea .cms_draggables .cms_draggable').bind('cms.structureboard.menustate.change', function(e){
-				var drag    = $(this);
-				(drag.data( 'menustate') > 0) ? that.sortDisable() : that.sortEnable();
+			$('.cms_draggables .cms_draggable').on('cms.structureboard.menustate.change', function(e){
+				var drag = $(this);
+				drag.data('menustate') ? that.sortDisable() : that.sortEnable();
 			});
 
 			$(document).bind('keyup', function (e) {
@@ -352,14 +352,12 @@ $(document).ready(function () {
 			});
 		},
 
-		//fix issue #4407
+		// fix issue #4407
 		sortDisable: function() {
-			var that = this;
-			that.sortables.sortable('disable');
+			this.sortables.sortable('disable');
 		},
 		sortEnable: function() {
-			var that = this;
-			that.sortables.sortable('enable');
+			this.sortables.sortable('enable');
 		},
 
 		_drag: function () {

--- a/cms/static/cms/js/modules/cms.structureboard.js
+++ b/cms/static/cms/js/modules/cms.structureboard.js
@@ -112,6 +112,12 @@ $(document).ready(function () {
 				}
 			});
 
+			//fix issue #4407
+			$('.cms-toolbar-expanded .cms_dragarea .cms_draggables .cms_draggable').bind('cms.structureboard.menustate.change', function(e){
+				var drag    = $(this);
+				(drag.data( 'menustate') > 0) ? that.sortDisable() : that.sortEnable();
+			});
+
 			$(document).bind('keyup', function (e) {
 				if(e.keyCode === 16) {
 					$(this).data('expandmode', false);
@@ -344,6 +350,16 @@ $(document).ready(function () {
 					'width': item.width() + min
 				});
 			});
+		},
+
+		//fix issue #4407
+		sortDisable: function() {
+			var that = this;
+			that.sortables.sortable('disable');
+		},
+		sortEnable: function() {
+			var that = this;
+			that.sortables.sortable('enable');
 		},
 
 		_drag: function () {


### PR DESCRIPTION
issue: using scroll bar of plugin menu in Firefox & IE moves plugins
fix: enable / disable the sortable widget depending on whether it contains an open submenu or not