### PR TITLE
Add icon to toolbar_plugin_struct

### DIFF
--- a/cms/tests/plugins.py
+++ b/cms/tests/plugins.py
@@ -1165,12 +1165,14 @@ class PluginsTestCase(PluginsTestBaseCase):
         toolbar plugin struct for those given parent Plugins
         """
         ParentClassesPlugin = type('ParentClassesPlugin', (CMSPluginBase,),
-                                    dict(parent_classes=['GenericParentPlugin'], render_plugin=False))
+                                    dict(parent_classes=['GenericParentPlugin'], render_plugin=False,
+                                    text_editor_button_icon='fake.png'))
         GenericParentPlugin = type('GenericParentPlugin', (CMSPluginBase,), {'render_plugin':False})
         KidnapperPlugin = type('KidnapperPlugin', (CMSPluginBase,), {'render_plugin':False})
 
         expected_struct = {'module': u'Generic',
                             'name': u'Parent Classes Plugin',
+                            'icon': 'fake.png',
                             'value': 'ParentClassesPlugin'}
 
         for plugin in [ParentClassesPlugin, GenericParentPlugin, KidnapperPlugin]:
@@ -1197,6 +1199,7 @@ class PluginsTestCase(PluginsTestBaseCase):
                                                     page)
         expected_struct = {'module': u'Generic',
                             'name': u'Generic Parent Plugin',
+                            'icon': '',
                             'value': 'GenericParentPlugin'}
         self.assertTrue(expected_struct in toolbar_struct)
         for plugin in [ParentClassesPlugin, GenericParentPlugin, KidnapperPlugin]:

--- a/cms/utils/placeholder.py
+++ b/cms/utils/placeholder.py
@@ -108,6 +108,7 @@ def get_toolbar_plugin_struct(plugins_list, slot, page, parent=None):
         names = get_placeholder_conf("plugin_labels", slot, template, default={})
         main_list.append({'value': plugin.value,
                           'name': force_text(names.get(plugin.value, plugin.name)),
+                          'icon': getattr(plugin, 'text_editor_button_icon', ''),
                           'module': force_text(modules.get(plugin.value, plugin.module))})
     return sorted(main_list, key=operator.itemgetter("module"))
 


### PR DESCRIPTION
This is needed for #3765 to work. It add icon to toolbar_plugin_struct so text editor plugins can use it.