### PR TITLE
Fix RemovedInDjango19Warning: django.utils.importlib

### DIFF
--- a/cms/models/permissionmodels.py
+++ b/cms/models/permissionmodels.py
@@ -4,7 +4,6 @@ from django.conf import settings
 from django.contrib.auth.models import Group, UserManager
 from django.contrib.sites.models import Site
 from django.core.exceptions import ImproperlyConfigured
-from django.utils import importlib
 from django.utils.encoding import force_text, python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 
@@ -18,6 +17,7 @@ from cms.utils.helpers import reversion_register
 user_app_name, user_model_name = settings.AUTH_USER_MODEL.rsplit('.', 1)
 User = None
 if DJANGO_1_6:
+    from django.utils import importlib
     for app in settings.INSTALLED_APPS:
         if app.endswith(user_app_name):
             user_app_models = importlib.import_module(app + ".models")

--- a/cms/utils/compat/forms.py
+++ b/cms/utils/compat/forms.py
@@ -1,6 +1,11 @@
 # -*- coding: utf-8 -*-
+try:
+    import importlib
+except ImportError:
+    # Python 2.6
+    from django.utils import importlib
+
 from django.conf import settings
-from django.utils import importlib
 from django.db import models
 
 


### PR DESCRIPTION
Import `django.utils.importlib` only where it is needed (for Django 1.6 only). This will remove the warning:

    RemovedInDjango19Warning: django.utils.importlib will be removed in Django 1.9.