### PR TITLE
Fix CMS_TOOLBAR_SIMPLE_STRUCTURE_MODE usage

### DIFF
--- a/cms/toolbar/toolbar.py
+++ b/cms/toolbar/toolbar.py
@@ -56,7 +56,7 @@ class CMSToolbar(ToolbarAPIMixin):
         self.clipboard = None
         self.language = None
         self.toolbar_language = None
-        self.simple_structure_mode = getattr(settings, 'CMS_TOOLBAR_SIMPLE_STRUCTURE_MODE', False)
+        self.simple_structure_mode = get_cms_setting('TOOLBAR_SIMPLE_STRUCTURE_MODE')
         self.show_toolbar = True
         self.init_toolbar(request)
 

--- a/cms/utils/conf.py
+++ b/cms/utils/conf.py
@@ -31,6 +31,7 @@ def default(name):
 
 DEFAULTS = {
     'TEMPLATE_INHERITANCE': True,
+    'TOOLBAR_SIMPLE_STRUCTURE_MODE': True,
     'PLACEHOLDER_CONF': {},
     'PERMISSION': False,
     # Whether to use raw ID lookups for users when PERMISSION is True


### PR DESCRIPTION
The current usage is not consistent with the rest of the code