### PR TITLE
Tests for copy_relations, see #4143

### DIFF
--- a/cms/test_utils/project/pluginapp/plugins/manytomany_rel/cms_plugins.py
+++ b/cms/test_utils/project/pluginapp/plugins/manytomany_rel/cms_plugins.py
@@ -7,10 +7,6 @@ from cms.test_utils.project.pluginapp.plugins.manytomany_rel.models import (
     ArticlePluginModel, Article,
     PluginModelWithFKFromModel,
     PluginModelWithM2MToModel,
-    FKPluginModel,
-    M2MTargetPluginModel,
-    PluginModelWithFKFromPlugin,
-    PluginModelWithM2MToPlugin,
 )
 
 
@@ -66,31 +62,3 @@ class PluginWithM2MToModel(CMSPluginBase):
     render_template = "articles.html"
 
 plugin_pool.register_plugin(PluginWithM2MToModel)
-
-
-class FKPlugin(CMSPluginBase):
-    model = FKPluginModel
-    render_template = "articles.html"
-
-plugin_pool.register_plugin(FKPlugin)
-
-
-class M2MTargetPlugin(CMSPluginBase):
-    model = M2MTargetPluginModel
-    render_template = "articles.html"
-
-plugin_pool.register_plugin(M2MTargetPlugin)
-
-
-class PluginWithFKFromPlugin(CMSPluginBase):
-    model = PluginModelWithFKFromPlugin
-    render_template = "articles.html"
-
-plugin_pool.register_plugin(PluginWithFKFromPlugin)
-
-
-class PluginWithM2MToPlugin(CMSPluginBase):
-    model = PluginModelWithM2MToPlugin
-    render_template = "articles.html"
-
-plugin_pool.register_plugin(PluginWithM2MToPlugin)

--- a/cms/test_utils/project/pluginapp/plugins/manytomany_rel/cms_plugins.py
+++ b/cms/test_utils/project/pluginapp/plugins/manytomany_rel/cms_plugins.py
@@ -3,7 +3,15 @@ from django.utils.translation import ugettext as _
 from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
 
-from cms.test_utils.project.pluginapp.plugins.manytomany_rel.models import ArticlePluginModel, Article
+from cms.test_utils.project.pluginapp.plugins.manytomany_rel.models import (
+    ArticlePluginModel, Article,
+    PluginModelWithFKFromModel,
+    PluginModelWithM2MToModel,
+    FKPluginModel,
+    M2MTargetPluginModel,
+    PluginModelWithFKFromPlugin,
+    PluginModelWithM2MToPlugin,
+)
 
 
 class ArticlePlugin(CMSPluginBase):
@@ -41,3 +49,48 @@ class ArticleDynamicTemplatePlugin(CMSPluginBase):
         return context
 
 plugin_pool.register_plugin(ArticleDynamicTemplatePlugin)
+
+
+###
+
+
+class PluginWithFKFromModel(CMSPluginBase):
+    model = PluginModelWithFKFromModel
+    render_template = "articles.html"
+
+plugin_pool.register_plugin(PluginWithFKFromModel)
+
+
+class PluginWithM2MToModel(CMSPluginBase):
+    model = PluginModelWithM2MToModel
+    render_template = "articles.html"
+
+plugin_pool.register_plugin(PluginWithM2MToModel)
+
+
+class FKPlugin(CMSPluginBase):
+    model = FKPluginModel
+    render_template = "articles.html"
+
+plugin_pool.register_plugin(FKPlugin)
+
+
+class M2MTargetPlugin(CMSPluginBase):
+    model = M2MTargetPluginModel
+    render_template = "articles.html"
+
+plugin_pool.register_plugin(M2MTargetPlugin)
+
+
+class PluginWithFKFromPlugin(CMSPluginBase):
+    model = PluginModelWithFKFromPlugin
+    render_template = "articles.html"
+
+plugin_pool.register_plugin(PluginWithFKFromPlugin)
+
+
+class PluginWithM2MToPlugin(CMSPluginBase):
+    model = PluginModelWithM2MToPlugin
+    render_template = "articles.html"
+
+plugin_pool.register_plugin(PluginWithM2MToPlugin)

--- a/cms/test_utils/project/pluginapp/plugins/manytomany_rel/models.py
+++ b/cms/test_utils/project/pluginapp/plugins/manytomany_rel/models.py
@@ -31,3 +31,60 @@ class ArticlePluginModel(CMSPlugin):
 
     def copy_relations(self, oldinstance):
         self.sections = oldinstance.sections.all()
+
+
+###
+
+
+class FKModel(models.Model):
+    fk_field = models.ForeignKey('PluginModelWithFKFromModel')
+
+
+class M2MTargetModel(models.Model):
+    title = models.CharField(max_length=50)
+
+
+class PluginModelWithFKFromModel(CMSPlugin):
+    title = models.CharField(max_length=50)
+    
+    def copy_relations(self, oldinstance):
+        # Like suggested in the docs
+        for associated_item in oldinstance.fkmodel_set.all():
+            associated_item.pk = None
+            associated_item.fk_field = self
+            associated_item.save()
+
+
+class PluginModelWithM2MToModel(CMSPlugin):
+    m2m_field = models.ManyToManyField(M2MTargetModel)
+    
+    def copy_relations(self, oldinstance):
+        # Like suggested in the docs
+        self.m2m_field = oldinstance.m2m_field.all()
+
+
+class FKPluginModel(CMSPlugin):
+    fk_field = models.ForeignKey('PluginModelWithFKFromPlugin')
+
+
+class M2MTargetPluginModel(CMSPlugin):
+    title = models.CharField(max_length=50)
+
+
+class PluginModelWithFKFromPlugin(CMSPlugin):
+    title = models.CharField(max_length=50)
+    
+    def copy_relations(self, oldinstance):
+        # Like suggested in the docs
+        for associated_item in oldinstance.fkpluginmodel_set.all():
+            associated_item.pk = None
+            associated_item.fk_field = self
+            associated_item.save()
+
+
+class PluginModelWithM2MToPlugin(CMSPlugin):
+    m2m_field = models.ManyToManyField(M2MTargetPluginModel)
+    
+    def copy_relations(self, oldinstance):
+        # Like suggested in the docs
+        self.m2m_field = oldinstance.m2m_field.all()

--- a/cms/test_utils/project/pluginapp/plugins/manytomany_rel/models.py
+++ b/cms/test_utils/project/pluginapp/plugins/manytomany_rel/models.py
@@ -61,30 +61,3 @@ class PluginModelWithM2MToModel(CMSPlugin):
     def copy_relations(self, oldinstance):
         # Like suggested in the docs
         self.m2m_field = oldinstance.m2m_field.all()
-
-
-class FKPluginModel(CMSPlugin):
-    fk_field = models.ForeignKey('PluginModelWithFKFromPlugin')
-
-
-class M2MTargetPluginModel(CMSPlugin):
-    title = models.CharField(max_length=50)
-
-
-class PluginModelWithFKFromPlugin(CMSPlugin):
-    title = models.CharField(max_length=50)
-    
-    def copy_relations(self, oldinstance):
-        # Like suggested in the docs
-        for associated_item in oldinstance.fkpluginmodel_set.all():
-            associated_item.pk = None
-            associated_item.fk_field = self
-            associated_item.save()
-
-
-class PluginModelWithM2MToPlugin(CMSPlugin):
-    m2m_field = models.ManyToManyField(M2MTargetPluginModel)
-    
-    def copy_relations(self, oldinstance):
-        # Like suggested in the docs
-        self.m2m_field = oldinstance.m2m_field.all()

--- a/cms/test_utils/project/pluginapp/plugins/manytomany_rel/south_migrations/0002_auto__add_pluginmodelwithfkfrommodel__add_fkmodel__add_pluginmodelwith.py
+++ b/cms/test_utils/project/pluginapp/plugins/manytomany_rel/south_migrations/0002_auto__add_pluginmodelwithfkfrommodel__add_fkmodel__add_pluginmodelwith.py
@@ -1,0 +1,196 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'PluginModelWithFKFromModel'
+        db.create_table(u'manytomany_rel_pluginmodelwithfkfrommodel', (
+            (u'cmsplugin_ptr', self.gf('django.db.models.fields.related.OneToOneField')(to=orm['cms.CMSPlugin'], unique=True, primary_key=True)),
+            ('title', self.gf('django.db.models.fields.CharField')(max_length=50)),
+        ))
+        db.send_create_signal(u'manytomany_rel', ['PluginModelWithFKFromModel'])
+
+        # Adding model 'FKModel'
+        db.create_table(u'manytomany_rel_fkmodel', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('fk_field', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['manytomany_rel.PluginModelWithFKFromModel'])),
+        ))
+        db.send_create_signal(u'manytomany_rel', ['FKModel'])
+
+        # Adding model 'PluginModelWithM2MToModel'
+        db.create_table(u'manytomany_rel_pluginmodelwithm2mtomodel', (
+            (u'cmsplugin_ptr', self.gf('django.db.models.fields.related.OneToOneField')(to=orm['cms.CMSPlugin'], unique=True, primary_key=True)),
+        ))
+        db.send_create_signal(u'manytomany_rel', ['PluginModelWithM2MToModel'])
+
+        # Adding M2M table for field m2m_field on 'PluginModelWithM2MToModel'
+        m2m_table_name = db.shorten_name(u'manytomany_rel_pluginmodelwithm2mtomodel_m2m_field')
+        db.create_table(m2m_table_name, (
+            ('id', models.AutoField(verbose_name='ID', primary_key=True, auto_created=True)),
+            ('pluginmodelwithm2mtomodel', models.ForeignKey(orm[u'manytomany_rel.pluginmodelwithm2mtomodel'], null=False)),
+            ('m2mtargetmodel', models.ForeignKey(orm[u'manytomany_rel.m2mtargetmodel'], null=False))
+        ))
+        db.create_unique(m2m_table_name, ['pluginmodelwithm2mtomodel_id', 'm2mtargetmodel_id'])
+
+        # Adding model 'M2MTargetModel'
+        db.create_table(u'manytomany_rel_m2mtargetmodel', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('title', self.gf('django.db.models.fields.CharField')(max_length=50)),
+        ))
+        db.send_create_signal(u'manytomany_rel', ['M2MTargetModel'])
+
+        # Adding model 'M2MTargetPluginModel'
+        db.create_table(u'manytomany_rel_m2mtargetpluginmodel', (
+            (u'cmsplugin_ptr', self.gf('django.db.models.fields.related.OneToOneField')(to=orm['cms.CMSPlugin'], unique=True, primary_key=True)),
+            ('title', self.gf('django.db.models.fields.CharField')(max_length=50)),
+        ))
+        db.send_create_signal(u'manytomany_rel', ['M2MTargetPluginModel'])
+
+        # Adding model 'PluginModelWithM2MToPlugin'
+        db.create_table(u'manytomany_rel_pluginmodelwithm2mtoplugin', (
+            (u'cmsplugin_ptr', self.gf('django.db.models.fields.related.OneToOneField')(to=orm['cms.CMSPlugin'], unique=True, primary_key=True)),
+        ))
+        db.send_create_signal(u'manytomany_rel', ['PluginModelWithM2MToPlugin'])
+
+        # Adding M2M table for field m2m_field on 'PluginModelWithM2MToPlugin'
+        m2m_table_name = db.shorten_name(u'manytomany_rel_pluginmodelwithm2mtoplugin_m2m_field')
+        db.create_table(m2m_table_name, (
+            ('id', models.AutoField(verbose_name='ID', primary_key=True, auto_created=True)),
+            ('pluginmodelwithm2mtoplugin', models.ForeignKey(orm[u'manytomany_rel.pluginmodelwithm2mtoplugin'], null=False)),
+            ('m2mtargetpluginmodel', models.ForeignKey(orm[u'manytomany_rel.m2mtargetpluginmodel'], null=False))
+        ))
+        db.create_unique(m2m_table_name, ['pluginmodelwithm2mtoplugin_id', 'm2mtargetpluginmodel_id'])
+
+        # Adding model 'PluginModelWithFKFromPlugin'
+        db.create_table(u'manytomany_rel_pluginmodelwithfkfromplugin', (
+            (u'cmsplugin_ptr', self.gf('django.db.models.fields.related.OneToOneField')(to=orm['cms.CMSPlugin'], unique=True, primary_key=True)),
+            ('title', self.gf('django.db.models.fields.CharField')(max_length=50)),
+        ))
+        db.send_create_signal(u'manytomany_rel', ['PluginModelWithFKFromPlugin'])
+
+        # Adding model 'FKPluginModel'
+        db.create_table(u'manytomany_rel_fkpluginmodel', (
+            (u'cmsplugin_ptr', self.gf('django.db.models.fields.related.OneToOneField')(to=orm['cms.CMSPlugin'], unique=True, primary_key=True)),
+            ('fk_field', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['manytomany_rel.PluginModelWithFKFromPlugin'])),
+        ))
+        db.send_create_signal(u'manytomany_rel', ['FKPluginModel'])
+
+
+    def backwards(self, orm):
+        # Deleting model 'PluginModelWithFKFromModel'
+        db.delete_table(u'manytomany_rel_pluginmodelwithfkfrommodel')
+
+        # Deleting model 'FKModel'
+        db.delete_table(u'manytomany_rel_fkmodel')
+
+        # Deleting model 'PluginModelWithM2MToModel'
+        db.delete_table(u'manytomany_rel_pluginmodelwithm2mtomodel')
+
+        # Removing M2M table for field m2m_field on 'PluginModelWithM2MToModel'
+        db.delete_table(db.shorten_name(u'manytomany_rel_pluginmodelwithm2mtomodel_m2m_field'))
+
+        # Deleting model 'M2MTargetModel'
+        db.delete_table(u'manytomany_rel_m2mtargetmodel')
+
+        # Deleting model 'M2MTargetPluginModel'
+        db.delete_table(u'manytomany_rel_m2mtargetpluginmodel')
+
+        # Deleting model 'PluginModelWithM2MToPlugin'
+        db.delete_table(u'manytomany_rel_pluginmodelwithm2mtoplugin')
+
+        # Removing M2M table for field m2m_field on 'PluginModelWithM2MToPlugin'
+        db.delete_table(db.shorten_name(u'manytomany_rel_pluginmodelwithm2mtoplugin_m2m_field'))
+
+        # Deleting model 'PluginModelWithFKFromPlugin'
+        db.delete_table(u'manytomany_rel_pluginmodelwithfkfromplugin')
+
+        # Deleting model 'FKPluginModel'
+        db.delete_table(u'manytomany_rel_fkpluginmodel')
+
+
+    models = {
+        'cms.cmsplugin': {
+            'Meta': {'object_name': 'CMSPlugin'},
+            'changed_date': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'creation_date': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'depth': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language': ('django.db.models.fields.CharField', [], {'max_length': '15', 'db_index': 'True'}),
+            'numchild': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['cms.CMSPlugin']", 'null': 'True', 'blank': 'True'}),
+            'path': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'placeholder': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['cms.Placeholder']", 'null': 'True'}),
+            'plugin_type': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'}),
+            'position': ('django.db.models.fields.PositiveSmallIntegerField', [], {'null': 'True', 'blank': 'True'})
+        },
+        'cms.placeholder': {
+            'Meta': {'object_name': 'Placeholder'},
+            'default_width': ('django.db.models.fields.PositiveSmallIntegerField', [], {'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'slot': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'})
+        },
+        u'manytomany_rel.article': {
+            'Meta': {'object_name': 'Article'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'section': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['manytomany_rel.Section']"}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'manytomany_rel.articlepluginmodel': {
+            'Meta': {'object_name': 'ArticlePluginModel', '_ormbases': ['cms.CMSPlugin']},
+            u'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['cms.CMSPlugin']", 'unique': 'True', 'primary_key': 'True'}),
+            'sections': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['manytomany_rel.Section']", 'symmetrical': 'False'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'manytomany_rel.fkmodel': {
+            'Meta': {'object_name': 'FKModel'},
+            'fk_field': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['manytomany_rel.PluginModelWithFKFromModel']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        u'manytomany_rel.fkpluginmodel': {
+            'Meta': {'object_name': 'FKPluginModel', '_ormbases': ['cms.CMSPlugin']},
+            u'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['cms.CMSPlugin']", 'unique': 'True', 'primary_key': 'True'}),
+            'fk_field': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['manytomany_rel.PluginModelWithFKFromPlugin']"})
+        },
+        u'manytomany_rel.m2mtargetmodel': {
+            'Meta': {'object_name': 'M2MTargetModel'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'manytomany_rel.m2mtargetpluginmodel': {
+            'Meta': {'object_name': 'M2MTargetPluginModel', '_ormbases': ['cms.CMSPlugin']},
+            u'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['cms.CMSPlugin']", 'unique': 'True', 'primary_key': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'manytomany_rel.pluginmodelwithfkfrommodel': {
+            'Meta': {'object_name': 'PluginModelWithFKFromModel', '_ormbases': ['cms.CMSPlugin']},
+            u'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['cms.CMSPlugin']", 'unique': 'True', 'primary_key': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'manytomany_rel.pluginmodelwithfkfromplugin': {
+            'Meta': {'object_name': 'PluginModelWithFKFromPlugin', '_ormbases': ['cms.CMSPlugin']},
+            u'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['cms.CMSPlugin']", 'unique': 'True', 'primary_key': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'manytomany_rel.pluginmodelwithm2mtomodel': {
+            'Meta': {'object_name': 'PluginModelWithM2MToModel', '_ormbases': ['cms.CMSPlugin']},
+            u'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['cms.CMSPlugin']", 'unique': 'True', 'primary_key': 'True'}),
+            'm2m_field': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['manytomany_rel.M2MTargetModel']", 'symmetrical': 'False'})
+        },
+        u'manytomany_rel.pluginmodelwithm2mtoplugin': {
+            'Meta': {'object_name': 'PluginModelWithM2MToPlugin', '_ormbases': ['cms.CMSPlugin']},
+            u'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['cms.CMSPlugin']", 'unique': 'True', 'primary_key': 'True'}),
+            'm2m_field': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['manytomany_rel.M2MTargetPluginModel']", 'symmetrical': 'False'})
+        },
+        u'manytomany_rel.section': {
+            'Meta': {'object_name': 'Section'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        }
+    }
+
+    complete_apps = ['manytomany_rel']

--- a/cms/test_utils/project/pluginapp/plugins/manytomany_rel/south_migrations/0003_auto__del_m2mtargetpluginmodel__del_pluginmodelwithm2mtoplugin__del_pl.py
+++ b/cms/test_utils/project/pluginapp/plugins/manytomany_rel/south_migrations/0003_auto__del_m2mtargetpluginmodel__del_pluginmodelwithm2mtoplugin__del_pl.py
@@ -1,0 +1,125 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Deleting model 'M2MTargetPluginModel'
+        db.delete_table(u'manytomany_rel_m2mtargetpluginmodel')
+
+        # Deleting model 'PluginModelWithM2MToPlugin'
+        db.delete_table(u'manytomany_rel_pluginmodelwithm2mtoplugin')
+
+        # Removing M2M table for field m2m_field on 'PluginModelWithM2MToPlugin'
+        db.delete_table(db.shorten_name(u'manytomany_rel_pluginmodelwithm2mtoplugin_m2m_field'))
+
+        # Deleting model 'PluginModelWithFKFromPlugin'
+        db.delete_table(u'manytomany_rel_pluginmodelwithfkfromplugin')
+
+        # Deleting model 'FKPluginModel'
+        db.delete_table(u'manytomany_rel_fkpluginmodel')
+
+
+    def backwards(self, orm):
+        # Adding model 'M2MTargetPluginModel'
+        db.create_table(u'manytomany_rel_m2mtargetpluginmodel', (
+            (u'cmsplugin_ptr', self.gf('django.db.models.fields.related.OneToOneField')(to=orm['cms.CMSPlugin'], unique=True, primary_key=True)),
+            ('title', self.gf('django.db.models.fields.CharField')(max_length=50)),
+        ))
+        db.send_create_signal(u'manytomany_rel', ['M2MTargetPluginModel'])
+
+        # Adding model 'PluginModelWithM2MToPlugin'
+        db.create_table(u'manytomany_rel_pluginmodelwithm2mtoplugin', (
+            (u'cmsplugin_ptr', self.gf('django.db.models.fields.related.OneToOneField')(to=orm['cms.CMSPlugin'], unique=True, primary_key=True)),
+        ))
+        db.send_create_signal(u'manytomany_rel', ['PluginModelWithM2MToPlugin'])
+
+        # Adding M2M table for field m2m_field on 'PluginModelWithM2MToPlugin'
+        m2m_table_name = db.shorten_name(u'manytomany_rel_pluginmodelwithm2mtoplugin_m2m_field')
+        db.create_table(m2m_table_name, (
+            ('id', models.AutoField(verbose_name='ID', primary_key=True, auto_created=True)),
+            ('pluginmodelwithm2mtoplugin', models.ForeignKey(orm[u'manytomany_rel.pluginmodelwithm2mtoplugin'], null=False)),
+            ('m2mtargetpluginmodel', models.ForeignKey(orm[u'manytomany_rel.m2mtargetpluginmodel'], null=False))
+        ))
+        db.create_unique(m2m_table_name, ['pluginmodelwithm2mtoplugin_id', 'm2mtargetpluginmodel_id'])
+
+        # Adding model 'PluginModelWithFKFromPlugin'
+        db.create_table(u'manytomany_rel_pluginmodelwithfkfromplugin', (
+            (u'cmsplugin_ptr', self.gf('django.db.models.fields.related.OneToOneField')(to=orm['cms.CMSPlugin'], unique=True, primary_key=True)),
+            ('title', self.gf('django.db.models.fields.CharField')(max_length=50)),
+        ))
+        db.send_create_signal(u'manytomany_rel', ['PluginModelWithFKFromPlugin'])
+
+        # Adding model 'FKPluginModel'
+        db.create_table(u'manytomany_rel_fkpluginmodel', (
+            ('fk_field', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['manytomany_rel.PluginModelWithFKFromPlugin'])),
+            (u'cmsplugin_ptr', self.gf('django.db.models.fields.related.OneToOneField')(to=orm['cms.CMSPlugin'], unique=True, primary_key=True)),
+        ))
+        db.send_create_signal(u'manytomany_rel', ['FKPluginModel'])
+
+
+    models = {
+        'cms.cmsplugin': {
+            'Meta': {'object_name': 'CMSPlugin'},
+            'changed_date': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'creation_date': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'depth': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language': ('django.db.models.fields.CharField', [], {'max_length': '15', 'db_index': 'True'}),
+            'numchild': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['cms.CMSPlugin']", 'null': 'True', 'blank': 'True'}),
+            'path': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'placeholder': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['cms.Placeholder']", 'null': 'True'}),
+            'plugin_type': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'}),
+            'position': ('django.db.models.fields.PositiveSmallIntegerField', [], {'null': 'True', 'blank': 'True'})
+        },
+        'cms.placeholder': {
+            'Meta': {'object_name': 'Placeholder'},
+            'default_width': ('django.db.models.fields.PositiveSmallIntegerField', [], {'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'slot': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'})
+        },
+        u'manytomany_rel.article': {
+            'Meta': {'object_name': 'Article'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'section': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['manytomany_rel.Section']"}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'manytomany_rel.articlepluginmodel': {
+            'Meta': {'object_name': 'ArticlePluginModel', '_ormbases': ['cms.CMSPlugin']},
+            u'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['cms.CMSPlugin']", 'unique': 'True', 'primary_key': 'True'}),
+            'sections': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['manytomany_rel.Section']", 'symmetrical': 'False'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'manytomany_rel.fkmodel': {
+            'Meta': {'object_name': 'FKModel'},
+            'fk_field': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['manytomany_rel.PluginModelWithFKFromModel']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        u'manytomany_rel.m2mtargetmodel': {
+            'Meta': {'object_name': 'M2MTargetModel'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'manytomany_rel.pluginmodelwithfkfrommodel': {
+            'Meta': {'object_name': 'PluginModelWithFKFromModel', '_ormbases': ['cms.CMSPlugin']},
+            u'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['cms.CMSPlugin']", 'unique': 'True', 'primary_key': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'manytomany_rel.pluginmodelwithm2mtomodel': {
+            'Meta': {'object_name': 'PluginModelWithM2MToModel', '_ormbases': ['cms.CMSPlugin']},
+            u'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['cms.CMSPlugin']", 'unique': 'True', 'primary_key': 'True'}),
+            'm2m_field': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['manytomany_rel.M2MTargetModel']", 'symmetrical': 'False'})
+        },
+        u'manytomany_rel.section': {
+            'Meta': {'object_name': 'Section'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        }
+    }
+
+    complete_apps = ['manytomany_rel']

--- a/cms/tests/test_plugins.py
+++ b/cms/tests/test_plugins.py
@@ -9,7 +9,6 @@ from django import http
 from django.conf import settings
 from django.conf.urls import url
 from django.contrib import admin
-from django.contrib.auth.models import User
 from django.core import urlresolvers
 from django.core.cache import cache
 from django.core.exceptions import ValidationError, ImproperlyConfigured
@@ -1541,10 +1540,6 @@ class PluginCopyRelationsTestCase(PluginsTestBaseCase):
         self.page2 = api.create_page(**page_data2)
         self.placeholder1 = self.page1.placeholders.get(slot='body')
         self.placeholder2 = self.page2.placeholders.get(slot='body')
-    
-    def tearDown(self):
-        User.objects.all().delete()
-        Page.objects.all().delete()
     
     def test_copy_fk_from_model(self):
         plugin = api.add_plugin(

--- a/cms/tests/test_plugins.py
+++ b/cms/tests/test_plugins.py
@@ -1532,6 +1532,8 @@ class PluginCopyRelationsTestCase(PluginsTestBaseCase):
     def setUp(self):
         self.super_user = self._create_user("test", True, True)
         self.FIRST_LANG = settings.LANGUAGES[0][0]
+        self._login_context = self.login_user_context(self.super_user)
+        self._login_context.__enter__()
         page_data1 = self.get_new_page_data_dbfields()
         page_data1['published'] = False
         self.page1 = api.create_page(**page_data1)

--- a/cms/tests/test_plugins.py
+++ b/cms/tests/test_plugins.py
@@ -30,9 +30,7 @@ from cms.sitemaps.cms_sitemap import CMSSitemap
 from cms.test_utils.project.pluginapp.plugins.manytomany_rel.models import (
     Article, Section, ArticlePluginModel,
     FKModel,
-    M2MTargetModel,
-    FKPluginModel,
-    PluginModelWithM2MToPlugin)
+    M2MTargetModel)
 from cms.test_utils.project.pluginapp.plugins.meta.cms_plugins import (
     TestPlugin, TestPlugin2, TestPlugin3, TestPlugin4, TestPlugin5)
 from cms.test_utils.project.pluginapp.plugins.validation.cms_plugins import (
@@ -1589,72 +1587,6 @@ class PluginCopyRelationsTestCase(PluginsTestBaseCase):
         )
         new_public_count = M2MTargetModel.objects.filter(
             pluginmodelwithm2mtomodel__placeholder__page__publisher_is_draft=False
-        ).count()
-        self.assertEqual(
-            new_public_count,
-            old_public_count + 1
-        )
-    
-    def test_copy_fk_from_plugin(self):
-        plugin = api.add_plugin(
-            placeholder=self.placeholder1,
-            plugin_type="PluginWithFKFromPlugin",
-            language=self.FIRST_LANG,
-        )
-        api.add_plugin(
-            placeholder=self.placeholder2,
-            plugin_type='FKPlugin',
-            language=self.FIRST_LANG,
-            fk_field=plugin
-        )
-        old_plugin_count = FKPluginModel.objects.filter(
-            fk_field__placeholder__page__publisher_is_draft=False
-        ).count()
-        api.publish_page(
-            self.page1,
-            self.super_user,
-            self.FIRST_LANG
-        )
-        api.publish_page(
-            self.page2,
-            self.super_user,
-            self.FIRST_LANG
-        )
-        new_plugin_count = FKPluginModel.objects.filter(
-            fk_field__placeholder__page__publisher_is_draft=False
-        ).count()
-        self.assertEqual(
-            new_plugin_count,
-            old_plugin_count + 1
-        )
-    
-    def test_copy_m2m_to_plugin(self):
-        plugin = api.add_plugin(
-            placeholder=self.placeholder1,
-            plugin_type="PluginWithM2MToPlugin",
-            language=self.FIRST_LANG,
-        )
-        m2m_target = api.add_plugin(
-            placeholder=self.placeholder2,
-            plugin_type='M2MTargetPlugin',
-            language=self.FIRST_LANG
-        )
-        plugin.m2m_field.add(m2m_target)
-        old_public_count = PluginModelWithM2MToPlugin.objects.filter(
-            m2m_field__placeholder__page__publisher_is_draft=False
-        ).count()
-        api.publish_page(
-            self.page1,
-            self.super_user,
-            self.FIRST_LANG
-        )
-        api.publish_page(
-            self.page2,
-            self.super_user,
-            self.FIRST_LANG
-        )
-        new_public_count = PluginModelWithM2MToPlugin.objects.filter(
-            m2m_field__placeholder__page__publisher_is_draft=False
         ).count()
         self.assertEqual(
             new_public_count,

--- a/cms/tests/test_plugins.py
+++ b/cms/tests/test_plugins.py
@@ -9,6 +9,7 @@ from django import http
 from django.conf import settings
 from django.conf.urls import url
 from django.contrib import admin
+from django.contrib.auth.models import User
 from django.core import urlresolvers
 from django.core.cache import cache
 from django.core.exceptions import ValidationError, ImproperlyConfigured
@@ -27,7 +28,11 @@ from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
 from cms.sitemaps.cms_sitemap import CMSSitemap
 from cms.test_utils.project.pluginapp.plugins.manytomany_rel.models import (
-    Article, Section, ArticlePluginModel)
+    Article, Section, ArticlePluginModel,
+    FKModel,
+    M2MTargetModel,
+    FKPluginModel,
+    PluginModelWithM2MToPlugin)
 from cms.test_utils.project.pluginapp.plugins.meta.cms_plugins import (
     TestPlugin, TestPlugin2, TestPlugin3, TestPlugin4, TestPlugin5)
 from cms.test_utils.project.pluginapp.plugins.validation.cms_plugins import (
@@ -1522,6 +1527,139 @@ class PluginManyToManyTestCase(PluginsTestBaseCase):
         db_counts = [plgn.sections.count() for plgn in ArticlePluginModel.objects.all()]
         expected = [self.section_count for _ in range(len(db_counts))]
         self.assertEqual(expected, db_counts)
+
+
+class PluginCopyRelationsTestCase(PluginsTestBaseCase):
+    """Test the suggestions in the docs for copy_relations()"""
+    
+    def setUp(self):
+        self.super_user = self._create_user("test", True, True)
+        self.FIRST_LANG = settings.LANGUAGES[0][0]
+        page_data1 = self.get_new_page_data_dbfields()
+        page_data1['published'] = False
+        self.page1 = api.create_page(**page_data1)
+        page_data2 = self.get_new_page_data_dbfields()
+        page_data2['published'] = False
+        self.page2 = api.create_page(**page_data2)
+        self.placeholder1 = self.page1.placeholders.get(slot='body')
+        self.placeholder2 = self.page2.placeholders.get(slot='body')
+    
+    def tearDown(self):
+        User.objects.all().delete()
+        Page.objects.all().delete()
+    
+    def test_copy_fk_from_model(self):
+        plugin = api.add_plugin(
+            placeholder=self.placeholder1,
+            plugin_type="PluginWithFKFromModel",
+            language=self.FIRST_LANG,
+        )
+        FKModel.objects.create(fk_field=plugin)
+        old_public_count = FKModel.objects.filter(
+            fk_field__placeholder__page__publisher_is_draft=False
+        ).count()
+        api.publish_page(
+            self.page1,
+            self.super_user,
+            self.FIRST_LANG
+        )
+        new_public_count = FKModel.objects.filter(
+            fk_field__placeholder__page__publisher_is_draft=False
+        ).count()
+        self.assertEqual(
+            new_public_count,
+            old_public_count + 1
+        )
+    
+    def test_copy_m2m_to_model(self):
+        plugin = api.add_plugin(
+            placeholder=self.placeholder1,
+            plugin_type="PluginWithM2MToModel",
+            language=self.FIRST_LANG,
+        )
+        m2m_target = M2MTargetModel.objects.create()
+        plugin.m2m_field.add(m2m_target)
+        old_public_count = M2MTargetModel.objects.filter(
+            pluginmodelwithm2mtomodel__placeholder__page__publisher_is_draft=False
+        ).count()
+        api.publish_page(
+            self.page1,
+            self.super_user,
+            self.FIRST_LANG
+        )
+        new_public_count = M2MTargetModel.objects.filter(
+            pluginmodelwithm2mtomodel__placeholder__page__publisher_is_draft=False
+        ).count()
+        self.assertEqual(
+            new_public_count,
+            old_public_count + 1
+        )
+    
+    def test_copy_fk_from_plugin(self):
+        plugin = api.add_plugin(
+            placeholder=self.placeholder1,
+            plugin_type="PluginWithFKFromPlugin",
+            language=self.FIRST_LANG,
+        )
+        api.add_plugin(
+            placeholder=self.placeholder2,
+            plugin_type='FKPlugin',
+            language=self.FIRST_LANG,
+            fk_field=plugin
+        )
+        old_plugin_count = FKPluginModel.objects.filter(
+            fk_field__placeholder__page__publisher_is_draft=False
+        ).count()
+        api.publish_page(
+            self.page1,
+            self.super_user,
+            self.FIRST_LANG
+        )
+        api.publish_page(
+            self.page2,
+            self.super_user,
+            self.FIRST_LANG
+        )
+        new_plugin_count = FKPluginModel.objects.filter(
+            fk_field__placeholder__page__publisher_is_draft=False
+        ).count()
+        self.assertEqual(
+            new_plugin_count,
+            old_plugin_count + 1
+        )
+    
+    def test_copy_m2m_to_plugin(self):
+        plugin = api.add_plugin(
+            placeholder=self.placeholder1,
+            plugin_type="PluginWithM2MToPlugin",
+            language=self.FIRST_LANG,
+        )
+        m2m_target = api.add_plugin(
+            placeholder=self.placeholder2,
+            plugin_type='M2MTargetPlugin',
+            language=self.FIRST_LANG
+        )
+        plugin.m2m_field.add(m2m_target)
+        old_public_count = PluginModelWithM2MToPlugin.objects.filter(
+            m2m_field__placeholder__page__publisher_is_draft=False
+        ).count()
+        api.publish_page(
+            self.page1,
+            self.super_user,
+            self.FIRST_LANG
+        )
+        api.publish_page(
+            self.page2,
+            self.super_user,
+            self.FIRST_LANG
+        )
+        new_public_count = PluginModelWithM2MToPlugin.objects.filter(
+            m2m_field__placeholder__page__publisher_is_draft=False
+        ).count()
+        self.assertEqual(
+            new_public_count,
+            old_public_count + 1
+        )
 
 
 class PluginsMetaOptionsTests(TestCase):


### PR DESCRIPTION
Here's the pull request for the passing tests on copy_relations as suggested in Issue #4143 - for review...

I've set up three environments with Django 1.6, 1.7, and 1.8. In each one the two new tests pass.

Somehow, Django's built in makemigrations does not create the correct files, while the South schemamigration command works. But ... the tests work without the migration files, too...