### PR TITLE
Welcome screen fix

### DIFF
--- a/cms/templates/cms/welcome.html
+++ b/cms/templates/cms/welcome.html
@@ -62,8 +62,10 @@
 if(window.CMS !== undefined) {
     CMS.$('#add-page').bind('click', function (e) {
         e.preventDefault();
-        var sideframe = new CMS.Sideframe();
-            sideframe.open('{% cms_admin_url "cms_page_add" %}?title=Home', true);
+        var modal = new CMS.Modal();
+            modal.open({
+                url: '{% cms_admin_url "cms_page_add" %}?title=Home'
+        });
     });
 }
 </script>


### PR DESCRIPTION
The welcome screen is still using the old `sideframe.open()` API. This PR fixes the opening and uses the modal instead.