### PR TITLE
Fix incorrect example command in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -92,7 +92,7 @@ You can use the `django CMS installer <http://djangocms-installer.readthedocs.or
     $ source env/bin/activate
     (env) $ pip install djangocms-installer
     (env) $ mkdir myproject && cd myproject
-    (env) $ djangocms -p -f . my_demo
+    (env) $ djangocms -f -p . my_demo
     (env) $ python manage.py
 
 


### PR DESCRIPTION
A command in the [Quick Start](https://github.com/divio/django-cms#quick-start) section of the README is broken. If I type the command, this is what I get:

```
$ djangocms -p -f . my_demo
usage: djangocms [-h] [--config-file CONFIG_FILE] [--config-dump CONFIG_DUMP]
                 [--db DB] [--i18n {yes,no}] [--use-tz {yes,no}]
                 [--timezone TIMEZONE] [--reversion {yes,no}]
                 [--permissions {yes,no}] [--languages LANGUAGES]
                 [--django-version {1.4,1.5,1.6,1.7,1.8,stable}]
                 [--cms-version {2.4,3.0,3.1,stable,develop}]
                 [--parent-dir PROJECT_DIRECTORY] [--bootstrap {yes,no}]
                 [--templates TEMPLATES] [--starting-page {yes,no}]
                 [--list-plugins] [--dump-requirements] [--no-input] [--filer]
                 [--requirements REQUIREMENTS_FILE] [--no-deps]
                 [--no-db-driver] [--no-sync] [--no-user]
                 [--template TEMPLATE] [--extra-settings EXTRA_SETTINGS]
                 [--skip-empty-check] [--utc]
                 project_name
djangocms: error: argument --parent-dir/-p: expected one argument
```

The `-p` and `-f` arguments are flipped. The correct command is this: `djangocms -f -p . my_demo`. This PR fixes this bug.