### PR TITLE
#4423: added hook for using custom query sets for plugins [fixed]

### DIFF
--- a/cms/plugin_base.py
+++ b/cms/plugin_base.py
@@ -156,6 +156,10 @@ class CMSPluginBase(six.with_metaclass(CMSPluginBaseMetaclass, admin.ModelAdmin)
         elif getattr(self, 'render_template', False):
             return getattr(self, 'render_template', False)
 
+    @classmethod
+    def get_render_queryset(cls):
+        return cls.model._default_manager.all()
+
     def render(self, context, instance, placeholder):
         context['instance'] = instance
         context['placeholder'] = placeholder

--- a/cms/utils/plugins.py
+++ b/cms/utils/plugins.py
@@ -155,7 +155,7 @@ def downcast_plugins(queryset, placeholders=None, select_placeholder=False):
     for plugin_type, pks in plugin_types_map.items():
         cls = plugin_pool.get_plugin(plugin_type)
         # get all the plugins of type cls.model
-        plugin_qs = cls.model.objects.filter(pk__in=pks)
+        plugin_qs = cls.get_render_queryset().filter(pk__in=pks)
         if select_placeholder:
             plugin_qs = plugin_qs.select_related('placeholder')
 


### PR DESCRIPTION
This time it should work :) I tested it with django 1.8 but I don't think this is in any way related to a specific django version. Sometime it should be explained in the docs so plugin developers can use this api to improve their queries.