### PR TITLE
Fix formtools issue in django 1.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,9 +28,10 @@ INSTALL_REQUIREMENTS = [
     'Django>=1.6.9,<1.9',
     'django-classy-tags>=0.5',
     'html5lib>=0.90,!=0.9999,!=0.99999',
+    'django-formtools>=1.0',
     'django-treebeard==3.0',
     'django-sekizai>=0.7',
-    'djangocms-admin-style'
+    'djangocms-admin-style',
 ]
 
 setup(


### PR DESCRIPTION
https://docs.djangoproject.com/en/1.8/ref/contrib/formtools/

Formtools is deprecated in django 1.8 and moved into its own package. This needs to be defined within ``INSTALL_REQUIREMENTS``