### PR TITLE
Allow using migrations in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,18 +19,18 @@ env:
     - secure: NWiSBCHFB6LbTMget2qLIdqZlx0zeu3j+Y7Lsqb8kuYXyT2IUBGFVedcGWuGv/9Mzypb80EQWtVTokA3/3QIbesqr29uG95pMPHiYWLdnTO6UHcLMcNXiSzhBGdRDZ40iHSVv2dDHs4GNwGOH5+UCA0z3j7SWmChuFbNXh+Vsqw=
   matrix:
     - DJANGO=1.9 DATABASE_URL='postgres://postgres@127.0.0.1/djangocms_test' SELENIUM=1 AUTH_USER_MODEL='customuserapp.User'
-    - DJANGO=1.8 DATABASE_URL='sqlite://localhost/:memory:' SELENIUM=0
+    - DJANGO=1.8 DATABASE_URL='sqlite://localhost/:memory:' SELENIUM=0 MIGRATE_OPTION='--migrate'
     - DJANGO=1.8 DATABASE_URL='mysql://root@127.0.0.1/djangocms_test' SELENIUM=0
-    - DJANGO=1.8 DATABASE_URL='postgres://postgres@127.0.0.1/djangocms_test' SELENIUM=0
+    - DJANGO=1.8 DATABASE_URL='postgres://postgres@127.0.0.1/djangocms_test' SELENIUM=0 MIGRATE_OPTION='--migrate'
     - DJANGO=1.8 DATABASE_URL='postgres://postgres@127.0.0.1/djangocms_test' SELENIUM=1 AUTH_USER_MODEL='emailuserapp.EmailUser'
     - DJANGO=1.8 DATABASE_URL='postgres://postgres@127.0.0.1/djangocms_test' SELENIUM=1 AUTH_USER_MODEL='customuserapp.User'
     - DJANGO=1.7 DATABASE_URL='sqlite://localhost/:memory:' SELENIUM=0
     - DJANGO=1.7 DATABASE_URL='mysql://root@127.0.0.1/djangocms_test' SELENIUM=0
     - DJANGO=1.7 DATABASE_URL='postgres://postgres@127.0.0.1/djangocms_test' SELENIUM=0
     - DJANGO=1.7 DATABASE_URL='postgres://postgres@127.0.0.1/djangocms_test' SELENIUM=1 AUTH_USER_MODEL='emailuserapp.EmailUser'
-    - DJANGO=1.6 DATABASE_URL='sqlite://localhost/:memory:' SELENIUM=0
+    - DJANGO=1.6 DATABASE_URL='sqlite://localhost/:memory:' SELENIUM=0 MIGRATE_OPTION='--migrate'
     - DJANGO=1.6 DATABASE_URL='mysql://root@127.0.0.1/djangocms_test' SELENIUM=0
-    - DJANGO=1.6 DATABASE_URL='postgres://postgres@127.0.0.1/djangocms_test' SELENIUM=0
+    - DJANGO=1.6 DATABASE_URL='postgres://postgres@127.0.0.1/djangocms_test' SELENIUM=0 MIGRATE_OPTION='--migrate'
     - DJANGO=1.6 DATABASE_URL='postgres://postgres@127.0.0.1/djangocms_test' SELENIUM=1 AUTH_USER_MODEL='emailuserapp.EmailUser'
     - DJANGO=1.6 DATABASE_URL='postgres://postgres@127.0.0.1/djangocms_test' SELENIUM=1 AUTH_USER_MODEL='customuserapp.User'
 
@@ -55,7 +55,7 @@ install:
   - if [ $DATABASE_URL == 'mysql://root@127.0.0.1/djangocms_test' ]; then pip install mysqlclient ; fi
 
 script:
-  - coverage run --parallel-mode manage.py test
+  - coverage run --parallel-mode manage.py test $MIGRATE_OPTION
   - coverage combine
 
 after_success: coveralls
@@ -71,11 +71,11 @@ matrix:
   exclude:
 
     - python: 2.6
-      env: DJANGO=1.6 DATABASE_URL='sqlite://localhost/:memory:' SELENIUM=0
+      env: DJANGO=1.6 DATABASE_URL='sqlite://localhost/:memory:' SELENIUM=0 MIGRATE_OPTION='--migrate'
     - python: 2.6
       env: DJANGO=1.6 DATABASE_URL='mysql://root@127.0.0.1/djangocms_test' SELENIUM=0
     - python: 2.6
-      env: DJANGO=1.6 DATABASE_URL='postgres://postgres@127.0.0.1/djangocms_test' SELENIUM=0
+      env: DJANGO=1.6 DATABASE_URL='postgres://postgres@127.0.0.1/djangocms_test' SELENIUM=0 MIGRATE_OPTION='--migrate'
     - python: 2.6
       env: DJANGO=1.6 DATABASE_URL='postgres://postgres@127.0.0.1/djangocms_test' SELENIUM=1 AUTH_USER_MODEL='emailuserapp.EmailUser'
 
@@ -89,20 +89,20 @@ matrix:
       env: DJANGO=1.7 DATABASE_URL='postgres://postgres@127.0.0.1/djangocms_test' SELENIUM=1 AUTH_USER_MODEL='emailuserapp.EmailUser'
 
     - python: 2.6
-      env: DJANGO=1.8 DATABASE_URL='sqlite://localhost/:memory:' SELENIUM=0
+      env: DJANGO=1.8 DATABASE_URL='sqlite://localhost/:memory:' SELENIUM=0 MIGRATE_OPTION='--migrate'
     - python: 2.6
       env: DJANGO=1.8 DATABASE_URL='mysql://root@127.0.0.1/djangocms_test' SELENIUM=0
     - python: 2.6
-      env: DJANGO=1.8 DATABASE_URL='postgres://postgres@127.0.0.1/djangocms_test' SELENIUM=0
+      env: DJANGO=1.8 DATABASE_URL='postgres://postgres@127.0.0.1/djangocms_test' SELENIUM=0 MIGRATE_OPTION='--migrate'
     - python: 2.6
       env: DJANGO=1.8 DATABASE_URL='postgres://postgres@127.0.0.1/djangocms_test' SELENIUM=1 AUTH_USER_MODEL='emailuserapp.EmailUser'
     - python: 2.6
       env: DJANGO=1.8 DATABASE_URL='postgres://postgres@127.0.0.1/djangocms_test' SELENIUM=1 AUTH_USER_MODEL='customuserapp.User'
 
     - python: 2.7
-      env: DJANGO=1.6 DATABASE_URL='sqlite://localhost/:memory:' SELENIUM=0
+      env: DJANGO=1.6 DATABASE_URL='sqlite://localhost/:memory:' SELENIUM=0 MIGRATE_OPTION='--migrate'
     - python: 2.7
-      env: DJANGO=1.6 DATABASE_URL='postgres://postgres@127.0.0.1/djangocms_test' SELENIUM=0
+      env: DJANGO=1.6 DATABASE_URL='postgres://postgres@127.0.0.1/djangocms_test' SELENIUM=0 MIGRATE_OPTION='--migrate'
     - python: 2.7
       env: DJANGO=1.6 DATABASE_URL='postgres://postgres@127.0.0.1/djangocms_test' SELENIUM=1 AUTH_USER_MODEL='emailuserapp.EmailUser'
 
@@ -112,11 +112,11 @@ matrix:
       env: DJANGO=1.7 DATABASE_URL='postgres://postgres@127.0.0.1/djangocms_test' SELENIUM=0
 
     - python: 3.3
-      env: DJANGO=1.6 DATABASE_URL='sqlite://localhost/:memory:' SELENIUM=0
+      env: DJANGO=1.6 DATABASE_URL='sqlite://localhost/:memory:' SELENIUM=0 MIGRATE_OPTION='--migrate'
     - python: 3.3
       env: DJANGO=1.6 DATABASE_URL='mysql://root@127.0.0.1/djangocms_test' SELENIUM=0
     - python: 3.3
-      env: DJANGO=1.6 DATABASE_URL='postgres://postgres@127.0.0.1/djangocms_test' SELENIUM=0
+      env: DJANGO=1.6 DATABASE_URL='postgres://postgres@127.0.0.1/djangocms_test' SELENIUM=0 MIGRATE_OPTION='--migrate'
     - python: 3.3
       env: DJANGO=1.6 DATABASE_URL='postgres://postgres@127.0.0.1/djangocms_test' SELENIUM=1 AUTH_USER_MODEL='emailuserapp.EmailUser'
 
@@ -128,20 +128,20 @@ matrix:
       env: DJANGO=1.7 DATABASE_URL='postgres://postgres@127.0.0.1/djangocms_test' SELENIUM=0
 
     - python: 3.3
-      env: DJANGO=1.8 DATABASE_URL='sqlite://localhost/:memory:' SELENIUM=0
+      env: DJANGO=1.8 DATABASE_URL='sqlite://localhost/:memory:' SELENIUM=0 MIGRATE_OPTION='--migrate'
     - python: 3.3
       env: DJANGO=1.8 DATABASE_URL='mysql://root@127.0.0.1/djangocms_test' SELENIUM=0
     - python: 3.3
-      env: DJANGO=1.8 DATABASE_URL='postgres://postgres@127.0.0.1/djangocms_test' SELENIUM=0
+      env: DJANGO=1.8 DATABASE_URL='postgres://postgres@127.0.0.1/djangocms_test' SELENIUM=0 MIGRATE_OPTION='--migrate'
     - python: 3.3
       env: DJANGO=1.8 DATABASE_URL='postgres://postgres@127.0.0.1/djangocms_test' SELENIUM=1 AUTH_USER_MODEL='emailuserapp.EmailUser'
 
     - python: 3.5
-      env: DJANGO=1.6 DATABASE_URL='sqlite://localhost/:memory:' SELENIUM=0
+      env: DJANGO=1.6 DATABASE_URL='sqlite://localhost/:memory:' SELENIUM=0 MIGRATE_OPTION='--migrate'
     - python: 3.5
       env: DJANGO=1.6 DATABASE_URL='mysql://root@127.0.0.1/djangocms_test' SELENIUM=0
     - python: 3.5
-      env: DJANGO=1.6 DATABASE_URL='postgres://postgres@127.0.0.1/djangocms_test' SELENIUM=0
+      env: DJANGO=1.6 DATABASE_URL='postgres://postgres@127.0.0.1/djangocms_test' SELENIUM=0 MIGRATE_OPTION='--migrate'
     - python: 3.5
       env: DJANGO=1.6 DATABASE_URL='postgres://postgres@127.0.0.1/djangocms_test' SELENIUM=1 AUTH_USER_MODEL='emailuserapp.EmailUser'
     - python: 3.5

--- a/docs/contributing/testing.rst
+++ b/docs/contributing/testing.rst
@@ -112,6 +112,11 @@ Use ``--retest`` to run the tests using the same configuration as the last run.
 Use ``--vanilla`` to bypass the advanced testing system and use the built-in
 Django test command.
 
+Use ``--migrate`` to run migrations during tests.
+
+To use a different database, set the ``DATABASE_URL`` environment variable to a
+dj-database-url compatible value.
+
 
 Using X virtual framebuffer for headless frontend testing
 ---------------------------------------------------------

--- a/manage.py
+++ b/manage.py
@@ -1,5 +1,7 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import os
+import sys
 
 import app_manage
 
@@ -141,12 +143,15 @@ if __name__ == '__main__':
 
     DJANGO_MIGRATION_MODULES, SOUTH_MIGRATION_MODULES = _detect_migration_layout(plugins)
 
+    migrate = '--migrate' in sys.argv and '--no-migrations' not in sys.argv
+
     if DJANGO_1_6:
         INSTALLED_APPS.insert(0, 'south')
         dynamic_configs['SOUTH_MIGRATION_MODULES'] = SOUTH_MIGRATION_MODULES
+        SOUTH_TESTS_MIGRATE = migrate
     else:
         dynamic_configs['MIGRATION_MODULES'] = DJANGO_MIGRATION_MODULES
-        if not dynamic_configs.get('TESTS_MIGRATE', False):
+        if not dynamic_configs.get('TESTS_MIGRATE', migrate):
             # Disable migrations for Django 1.7+
             class DisableMigrations(object):
 
@@ -338,7 +343,6 @@ if __name__ == '__main__':
         CMS_PLUGIN_CONTEXT_PROCESSORS=(),
         CMS_SITE_CHOICES_CACHE_KEY='CMS:site_choices',
         CMS_PAGE_CHOICES_CACHE_KEY='CMS:page_choices',
-        SOUTH_TESTS_MIGRATE=False,
         CMS_NAVIGATION_EXTENDERS=[
             ('cms.test_utils.project.sampleapp.menu_extender.get_nodes',
              'SampleApp Menu'),


### PR DESCRIPTION
This re-enables migrations by default during tests and makes manage.py executable
Migrations are enabled for selected test cases in travis