### PR TITLE
Fix page redirect when using the "Create" button

### DIFF
--- a/cms/cms_toolbars.py
+++ b/cms/cms_toolbars.py
@@ -105,7 +105,7 @@ class PlaceholderToolbar(CMSToolbar):
         disabled = user and hasattr(self, "page") and len(
             list(entry_choices(user, self.page))) == 0
 
-        url = "{url}?page={page}".format(
+        url = "{url}?page={page}&edit".format(
             url=reverse("cms_wizard_create"),
             page=page_pk
         )

--- a/cms/cms_toolbars.py
+++ b/cms/cms_toolbars.py
@@ -105,7 +105,7 @@ class PlaceholderToolbar(CMSToolbar):
         disabled = user and hasattr(self, "page") and len(
             list(entry_choices(user, self.page))) == 0
 
-        url = "{url}?page={page}&edit".format(
+        url = '{url}?page={page}&edit'.format(
             url=reverse("cms_wizard_create"),
             page=page_pk
         )


### PR DESCRIPTION
If you create new content in **edit mode**, redirects result in a 404 as you are not in **draft mode**.

This PR makes sure you always switch to **draft mode**