### PR TITLE
hopefully make TEMPLATE_INHERITANCE_LABEL translatable

### DIFF
--- a/cms/constants.py
+++ b/cms/constants.py
@@ -2,7 +2,6 @@
 
 
 TEMPLATE_INHERITANCE_MAGIC = 'INHERIT'
-TEMPLATE_INHERITANCE_LABEL = 'Inherit the template of the nearest ancestor'
 REFRESH_PAGE = 'REFRESH_PAGE'
 URL_CHANGE = 'URL_CHANGE'
 RIGHT = object() # this is a trick so "foo is RIGHT" will only ever work for this, same goes for LEFT.

--- a/cms/tests/test_templates.py
+++ b/cms/tests/test_templates.py
@@ -50,7 +50,7 @@ class TemplatesConfig(CMSTestCase):
         labels = [force_text(template[1]) for template in templates]
         files = [template[0] for template in templates]
         if get_cms_setting('TEMPLATE_INHERITANCE'):
-            original_labels.append(force_text(_(constants.TEMPLATE_INHERITANCE_LABEL)))
+            original_labels.append(force_text(_('Inherit the template of the nearest ancestor')))
             original_files.append(constants.TEMPLATE_INHERITANCE_MAGIC)
         self.assertEqual(set(labels), set(original_labels))
         self.assertEqual(set(files), set(original_files))

--- a/cms/utils/conf.py
+++ b/cms/utils/conf.py
@@ -148,7 +148,7 @@ def get_templates():
     else:
         templates = list(getattr(settings, 'CMS_TEMPLATES', []))
     if get_cms_setting('TEMPLATE_INHERITANCE'):
-        templates.append((constants.TEMPLATE_INHERITANCE_MAGIC, _(constants.TEMPLATE_INHERITANCE_LABEL)))
+        templates.append((constants.TEMPLATE_INHERITANCE_MAGIC, _('Inherit the template of the nearest ancestor')))
     return templates
 
 


### PR DESCRIPTION
The string 'Inherit the template of the nearest ancestor" doesn't appear in translations. And seems to be the same if you switch the language in the backend.

I suppose the reason is thats its a passed  as a constant and not as a string to _(...).

Maybe I just didnt get the point of a constant in this case... but nervertheless it would remain untranslatable...

Saludos,
Sacha

