### PR TITLE
Configurable options for page wizard

### DIFF
--- a/cms/forms/wizards.py
+++ b/cms/forms/wizards.py
@@ -215,15 +215,16 @@ class CreateCMSPageForm(BaseCMSPageForm):
             # If the user provided content, then use that instead.
             content = self.cleaned_data.get('content')
             if content and permissions.has_plugin_permission(
-                    self.user, "TextPlugin", "add"):
+                    self.user, get_cms_setting('WIZARD_CONTENT_PLUGIN'), "add"):
                 placeholder = self.get_first_placeholder(page)
                 if placeholder:
-                    add_plugin(
-                        placeholder=placeholder,
-                        plugin_type='TextPlugin',
-                        language=self.language_code,
-                        body=content
-                    )
+                    add_plugin(**{
+                        'placeholder': placeholder,
+                        'plugin_type': get_cms_setting('WIZARD_CONTENT_PLUGIN'),
+                        'language': self.language_code,
+                        get_cms_setting('WIZARD_CONTENT_PLUGIN_BODY'): content
+
+                    })
 
         return page
 

--- a/cms/forms/wizards.py
+++ b/cms/forms/wizards.py
@@ -180,7 +180,7 @@ class CreateCMSPageForm(BaseCMSPageForm):
         title = self.cleaned_data['title']
         page = create_page(
             title=title,
-            template=TEMPLATE_INHERITANCE_MAGIC,
+            template=get_cms_setting('WIZARD_DEFAULT_TEMPLATE'),
             language=self.language_code,
             created_by=smart_text(self.user),
             parent=parent,

--- a/cms/forms/wizards.py
+++ b/cms/forms/wizards.py
@@ -8,7 +8,7 @@ from django.core.exceptions import PermissionDenied
 from django.utils.encoding import smart_text
 from django.utils.translation import ugettext_lazy as _, get_language
 
-from cms.constants import TEMPLATE_INHERITANCE_MAGIC, PAGE_TYPES_ID
+from cms.constants import PAGE_TYPES_ID
 from cms.exceptions import NoPermissionsException
 from cms.models import Page, Title
 from cms.models.titlemodels import EmptyTitle

--- a/cms/utils/conf.py
+++ b/cms/utils/conf.py
@@ -63,7 +63,9 @@ DEFAULTS = {
     'TOOLBAR_URL__DISABLE': 'toolbar_off',
     'ADMIN_NAMESPACE': 'admin',
     'APP_NAME': None,
-    'TOOLBAR_HIDE': False
+    'TOOLBAR_HIDE': False,
+    'WIZARD_CONTENT_PLUGIN': 'TextPlugin',
+    'WIZARD_CONTENT_PLUGIN_BODY': 'body',
 }
 
 

--- a/cms/utils/conf.py
+++ b/cms/utils/conf.py
@@ -64,6 +64,7 @@ DEFAULTS = {
     'ADMIN_NAMESPACE': 'admin',
     'APP_NAME': None,
     'TOOLBAR_HIDE': False,
+    'WIZARD_DEFAULT_TEMPLATE': constants.TEMPLATE_INHERITANCE_MAGIC,
     'WIZARD_CONTENT_PLUGIN': 'TextPlugin',
     'WIZARD_CONTENT_PLUGIN_BODY': 'body',
 }

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -1017,6 +1017,18 @@ Example::
 
     CMS_TOOLBAR_SIMPLE_STRUCTURE_MODE = False
 
+.. setting:: WIZARD_DEFAULT_TEMPLATE
+
+WIZARD_DEFAULT_TEMPLATE
+=======================
+
+default
+    ``TEMPLATE_INHERITANCE_MAGIC``
+
+This is the path of the template used to create pages in the wizard. It must be one
+of the templates in :setting:`CMS_TEMPLATES`.
+
+.. setting:: CMS_WIZARD_CONTENT_PLUGIN
 
 CMS_WIZARD_CONTENT_PLUGIN
 =========================
@@ -1029,6 +1041,7 @@ filled in.
 There should be no need to change it, unless you **don't** use
 ``djangocms-text-ckeditor`` in your project.
 
+.. setting:: CMS_WIZARD_CONTENT_PLUGIN_BODY
 
 CMS_WIZARD_CONTENT_PLUGIN_BODY
 ==============================
@@ -1040,4 +1053,4 @@ This is the name of the body field in the plugin created in the Page Wizard when
 "Content" field is filled in.
 There should be no need to change it, unless you **don't** use
 ``djangocms-text-ckeditor`` in your project **and** your custom plugin defined in
-``CMS_WIZARD_CONTENT_PLUGIN`` have a body field **different** than ``body``.
+:setting:`CMS_WIZARD_CONTENT_PLUGIN` have a body field **different** than ``body``.

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -1017,3 +1017,27 @@ Example::
 
     CMS_TOOLBAR_SIMPLE_STRUCTURE_MODE = False
 
+
+CMS_WIZARD_CONTENT_PLUGIN
+=========================
+
+default
+    ``TextPlugin``
+
+This is the name of the plugin created in the Page Wizard when the "Content" field is
+filled in.
+There should be no need to change it, unless you **don't** use
+``djangocms-text-ckeditor`` in your project.
+
+
+CMS_WIZARD_CONTENT_PLUGIN_BODY
+==============================
+
+default
+    ``body``
+
+This is the name of the body field in the plugin created in the Page Wizard when the
+"Content" field is filled in.
+There should be no need to change it, unless you **don't** use
+``djangocms-text-ckeditor`` in your project **and** your custom plugin defined in
+``CMS_WIZARD_CONTENT_PLUGIN`` have a body field **different** than ``body``.


### PR DESCRIPTION
Fixes to annoyances with current wizard setup:
* Standard ``TextPlugin`` is not guaranteed to exists
* The ``TEMPLATE_INHERITANCE_MAGIC`` template may not be the most appropriate one

Fix #4669
