### PR TITLE
Document cms 3.2 as the last version to support Django 1.7.

### DIFF
--- a/docs/upgrade/3.2.rst
+++ b/docs/upgrade/3.2.rst
@@ -212,7 +212,7 @@ Pending deprecations
 
 In django CMS 3.3:
 
-    Django 1.6 and Python 2.6 will no longer be supported. If you still using these versions, you
-    are strongly encouraged to begin exploring the upgrade process to a newer version.
+    Django 1.6, 1.7 and Python 2.6 will no longer be supported. If you still using these versions,
+    you are strongly encouraged to begin exploring the upgrade process to a newer version.
 
     The :ref:`CMS_TOOLBAR_SIMPLE_STRUCTURE_MODE` setting will be removed.


### PR DESCRIPTION
As discussed on https://groups.google.com/d/topic/django-cms-developers/WewxCMVtzSI/discussion