### PR TITLE
Make implementation reflect documentation

### DIFF
--- a/cms/plugin_base.py
+++ b/cms/plugin_base.py
@@ -118,7 +118,8 @@ class CMSPluginBase(six.with_metaclass(CMSPluginBaseMetaclass, admin.ModelAdmin)
     require_parent = False
     parent_classes = None
 
-    disable_child_plugin = False
+    disable_child_plugins = False
+    disable_child_plugin = False  # DEPRECATED: REMOVE IN CMS v3.3
 
     cache = get_cms_setting('PLUGIN_CACHE')
     system = False


### PR DESCRIPTION
BACKGROUND: Since its original implementation, the corresponding documentation (http://docs.django-cms.org/en/latest/reference/plugins.html#disable-child-plugins) specifies the property: `disable_child_plugins` (plural), while the implementation was `disable_child_plugin` (singular).

Due to this, plugins have been implementing the plural of the property. Most notably djangocms-text-ckeditor, and the CMS structure-board also evaluates the plural.

Since the property's default value is the same as evaluating a non-existent property in the templates, this should be a benign change.