### PR TITLE
Revert "Change migration dependency"

### DIFF
--- a/cms/migrations/0010_migrate_use_structure.py
+++ b/cms/migrations/0010_migrate_use_structure.py
@@ -47,7 +47,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ('cms', '0009_merge'),
-        ('contenttypes', '__first__'),
+        ('contenttypes', '__latest__'),
     ]
 
     operations = [


### PR DESCRIPTION
Reverts divio/django-cms#4725

It does more harm than good