### PR TITLE
restore the old seach form behaviour

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -50,6 +50,8 @@
 - Fixed edit and edit_off constants not being honoured in frontend code
 - Deprecate CMSPlugin.disable_child_plugin in favour of disable_child_plugins
 - Fixed an issue where ``allow_children`` and ``disable_child_plugins`` didn't work on dragitems
+- Replaced search_form template from django admin with a custom on to stop
+  forcing focus on the search input
 
 
 === 3.1.4 (Unreleased) ===

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -50,7 +50,7 @@
 - Fixed edit and edit_off constants not being honoured in frontend code
 - Deprecate CMSPlugin.disable_child_plugin in favour of disable_child_plugins
 - Fixed an issue where ``allow_children`` and ``disable_child_plugins`` didn't work on dragitems
-- Replaced search_form template from django admin with a custom on to stop
+- Replaced search_form template from django admin with a custom one to stop
   forcing focus on the search input
 
 

--- a/cms/templates/admin/cms/page/tree/base.html
+++ b/cms/templates/admin/cms/page/tree/base.html
@@ -99,25 +99,7 @@ $(document).ready(function () {
 {% endif %}
 </form>
 
-{# https://github.com/django/django/blob/6ff500127a21f5f2104dc77a09dfa73d5f7c94ce/django/contrib/admin/templates/admin/search_form.html#L16 #}
-{# removed document.getElementById("searchbar").focus(); #}
-{% if cl.search_fields %}
-<div id="toolbar">
-    <form id="changelist-search" method="get">
-        <div>
-            <label for="searchbar"><img src="{% static "admin/img/search.svg" %}" alt="Search" /></label>
-            <input type="text" size="40" name="{{ search_var }}" value="{{ cl.query }}" id="searchbar" />
-            <input type="submit" value="{% trans 'Search' %}" />
-            {% if show_result_count %}
-                <span class="small quiet">{% blocktrans count counter=cl.result_count %}{{ counter }} result{% plural %}{{ counter }} results{% endblocktrans %} (<a href="?{% if cl.is_popup %}_popup=1{% endif %}">{% if cl.show_full_result_count %}{% blocktrans with full_result_count=cl.full_result_count %}{{ full_result_count }} total{% endblocktrans %}{% else %}{% trans "Show all" %}{% endif %}</a>)</span>
-            {% endif %}
-            {% for pair in cl.params.items %}
-                {% if pair.0 != search_var %}<input type="hidden" name="{{ pair.0 }}" value="{{ pair.1 }}"/>{% endif %}
-            {% endfor %}
-        </div>
-    </form>
-</div>
-{% endif %}
+{% search_form cl %}
 
 {% endblock %}
 {% block date_hierarchy %}{% date_hierarchy cl %}{% endblock %}

--- a/cms/templates/admin/search_form.html
+++ b/cms/templates/admin/search_form.html
@@ -1,0 +1,18 @@
+{% load i18n admin_static %}
+{% if cl.search_fields %}
+<div id="toolbar"><form id="changelist-search" method="get">
+<div><!-- DIV needed for valid HTML -->
+<label for="searchbar"><img src="{% static "admin/img/search.svg" %}" alt="Search" /></label>
+<input type="text" size="40" name="{{ search_var }}" value="{{ cl.query }}" id="searchbar" />
+<input type="submit" value="{% trans 'Search' %}" />
+{% if show_result_count %}
+    <span class="small quiet">{% blocktrans count counter=cl.result_count %}{{ counter }} result{% plural %}{{ counter }} results{% endblocktrans %} (<a href="?{% if cl.is_popup %}_popup=1{% endif %}">{% if cl.show_full_result_count %}{% blocktrans with full_result_count=cl.full_result_count %}{{ full_result_count }} total{% endblocktrans %}{% else %}{% trans "Show all" %}{% endif %}</a>)</span>
+{% endif %}
+{% for pair in cl.params.items %}
+    {% if pair.0 != search_var %}<input type="hidden" name="{{ pair.0 }}" value="{{ pair.1 }}"/>{% endif %}
+{% endfor %}
+</div>
+</form></div>
+{# commented out to have better support for touch #}
+{# <script type="text/javascript">document.getElementById("searchbar").focus();</script> #}
+{% endif %}


### PR DESCRIPTION
it is necessary to have a template tag, otherwise some variables are not
available anymore. additionaly this fixes a problem with seach input
being focused on touch devices all the time