### PR TITLE
Revert "CMS 3.0 cannot use admin-style >= 2.8.0"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         'html5lib>=0.90,!=0.9999,!=0.99999',
         'django-mptt>=0.6,<0.6.2',
         'django-sekizai>=0.7',
-        'djangocms-admin-style<2.8.0'
+        'djangocms-admin-style'
     ],
     tests_require=[
         'django-reversion==1.8.2',


### PR DESCRIPTION
Reverts divio/django-cms#4749