### PR TITLE
Revert "CMS 3.1.x cannot use admin-style 2.8+"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         'html5lib>=0.90,!=0.9999,!=0.99999',
         'django-treebeard==3.0',
         'django-sekizai>=0.7',
-        'djangocms-admin-style<2.8.0'
+        'djangocms-admin-style'
     ],
     extras_require={
         'south': ['south>=1.0.0'],


### PR DESCRIPTION
Reverts divio/django-cms#4748