### PR TITLE
Revert "CMS 3.2.x requires admin-style 2.8.0 or later."

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ INSTALL_REQUIREMENTS = [
     'django-formtools>=1.0',
     'django-treebeard==3.0',
     'django-sekizai>=0.7',
-    'djangocms-admin-style>=2.8.0',
+    'djangocms-admin-style',
 ]
 
 #


### PR DESCRIPTION
Reverts divio/django-cms#4747