### PR TITLE
Trick Django to get us a login URL even in version 1.6.

### DIFF
--- a/cms/templates/cms/welcome.html
+++ b/cms/templates/cms/welcome.html
@@ -88,9 +88,11 @@
                 btn.trigger('click');
             });
         {% else %}
-            {# Django <= 1.6 doesn't provide a login URL handler. Rely on #}
-            {# it redirecting to the login page when attempting to access a #}
-            {# protected handler while not logged in. #}
+            {% comment %}
+            Django <= 1.6 doesn't provide a login URL handler. Rely on
+            it redirecting to the login page when attempting to access a
+            protected handler while not logged in.
+            {% endcomment %}
             {% url "admin:login" as login_url %}
             {% url "admin:index" as admin_index_url %}
             window.location.href = '{% firstof login_url admin_index_url %}?next=/{{ LANGUAGE_CODE }}/?{{ cms_edit_on }}';

--- a/cms/templates/cms/welcome.html
+++ b/cms/templates/cms/welcome.html
@@ -88,7 +88,12 @@
                 btn.trigger('click');
             });
         {% else %}
-            window.location.href = '{% url "admin:login" %}?next=/{{ LANGUAGE_CODE }}/?{{ cms_edit_on }}';
+            {# Django <= 1.6 doesn't provide a login URL handler. Rely on #}
+            {# it redirecting to the login page when attempting to access a #}
+            {# protected handler while not logged in. #}
+            {% url "admin:login" as login_url %}
+            {% url "admin:index" as admin_index_url %}
+            window.location.href = '{% firstof login_url admin_index_url %}?next=/{{ LANGUAGE_CODE }}/?{{ cms_edit_on }}';
         {% endif %}
     </script>
 </body>


### PR DESCRIPTION
Django 1.6 does not provide a reversible /login URL, so
we need to rely on it providing a login handler when attemtpting
to get a protected URL without being logged in.

Credit @czpython for the fix.