### PR TITLE
Fix usersettings reload

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,9 @@
+=== 3.2.1 (Unreleased) ===
+
+- Fixed an issue with refreshing the UI when switching CMS language
+- Fixed an issue with sideframe urls not being remembered after reload
+
+
 === 3.2.0 (2015-11-24) ===
 
 - Added new wizard to improve content creation

--- a/cms/static/cms/js/modules/cms.sideframe.js
+++ b/cms/static/cms/js/modules/cms.sideframe.js
@@ -271,7 +271,6 @@ var CMS = window.CMS || {};
                     }
 
                     // save url in settings
-                    // FIXME iframe.prop('src') never changes
                     CMS.settings.sideframe.url = iframe.prop('src');
                     CMS.settings = that.setSettings(CMS.settings);
 

--- a/cms/static/cms/js/modules/cms.sideframe.js
+++ b/cms/static/cms/js/modules/cms.sideframe.js
@@ -271,6 +271,7 @@ var CMS = window.CMS || {};
                     }
 
                     // save url in settings
+                    // FIXME iframe.prop('src') never changes
                     CMS.settings.sideframe.url = iframe.prop('src');
                     CMS.settings = that.setSettings(CMS.settings);
 

--- a/cms/templates/admin/cms/usersettings/change_form.html
+++ b/cms/templates/admin/cms/usersettings/change_form.html
@@ -3,15 +3,24 @@
 {% block extrahead %}
 {{ block.super }}
 <script>
-    var CMS = window.parent.CMS;
-    // we need to reload the parent window once "?reload_window" is defined and
-    // set the new url for the sideframe with the correct language specification
-    if (location.href.indexOf('reload_window') > -1 && CMS) {
-        // save url in settings
-        CMS.settings.sideframe.url = window.location.href.replace(/[?&]reload_window/, '');
-        CMS.settings = CMS.API.Helpers.setSettings(CMS.settings);
-        // reload everything
-        CMS.API.Helpers.reloadBrowser();
+    // we have to wait till the window is loaded, otherwise
+    // the sideframe code will override the url, because every time
+    // the iframe is loaded, it's current url is saved in the settings
+    window.onload = function () {
+        // we have to setTimeout here because the cms.sideframe load event
+        // fires after this one :(
+        setTimeout(function () {
+            var CMS = window.parent.CMS;
+            // we need to reload the parent window once "?reload_window" is defined and
+            // set the new url for the sideframe with the correct language specification
+            if (location.href.indexOf('reload_window') > -1 && CMS) {
+                // save url in settings
+                CMS.settings.sideframe.url = window.location.href.replace(/[?&]reload_window/, '');
+                CMS.settings = CMS.API.Helpers.setSettings(CMS.settings);
+                // reload everything
+                CMS.API.Helpers.reloadBrowser();
+            }
+        }, 0);
     }
 </script>
 {% endblock %}


### PR DESCRIPTION
https://github.com/divio/django-cms/pull/4796 our original thought was that the language part of the url
wasn't correctly replaced, but it turns out that was not the case

when the page is loaded in sideframe we want to override the url of the
sideframe and reload the parent so the change in language is reflected
in the UI. however there's also a load handler for the sideframe to save
the url in the settings so that after you reload - correct frame is
restored. problem is, this load event happens after we try to modify the
sideframe url manually, so we want ours to trigger last.

i'm not very happy with the solution, but we definitely need both behaviours

also, we do not actually update the url in settings correctly, but that's going to be a different pull request

refs #4797 