### PR TITLE
Obliviate djangocms-flash

### DIFF
--- a/cms/test_utils/cli.py
+++ b/cms/test_utils/cli.py
@@ -98,7 +98,6 @@ def configure(db_url, **extra):
             'djangocms_column',
             'djangocms_picture',
             'djangocms_file',
-            'djangocms_flash',
             'djangocms_googlemap',
             'djangocms_teaser',
             'djangocms_video',
@@ -206,12 +205,12 @@ def configure(db_url, **extra):
         ),
         CMS_PLACEHOLDER_CONF={
             'col_sidebar': {
-                'plugins': ('FilePlugin', 'FlashPlugin', 'LinkPlugin', 'PicturePlugin',
+                'plugins': ('FilePlugin', 'LinkPlugin', 'PicturePlugin',
                             'TextPlugin', 'MultiColumnPlugin', 'SnippetPlugin'),
                 'name': gettext("sidebar column")
             },
             'col_left': {
-                'plugins': ('FilePlugin', 'FlashPlugin', 'LinkPlugin', 'PicturePlugin',
+                'plugins': ('FilePlugin', 'LinkPlugin', 'PicturePlugin',
                             'TextPlugin', 'SnippetPlugin', 'GoogleMapPlugin',
                             'MultiColumnPlugin', 'StylePlugin', 'EmptyPlugin'),
                 'name': gettext("left column"),
@@ -223,9 +222,9 @@ def configure(db_url, **extra):
                 },
             },
             'col_right': {
-                'plugins': ('FilePlugin', 'FlashPlugin', 'LinkPlugin', 'PicturePlugin',
-                            'TextPlugin', 'SnippetPlugin', 'GoogleMapPlugin', 'MultiColumnPlugin',
-                            'StylePlugin'),
+                'plugins': ('FilePlugin', 'LinkPlugin', 'PicturePlugin',
+                            'TextPlugin', 'SnippetPlugin', 'GoogleMapPlugin',
+                            'MultiColumnPlugin', 'StylePlugin'),
                 'name': gettext("right column")
             },
             'extra_context': {
@@ -310,9 +309,9 @@ def configure(db_url, **extra):
             }
         ]
 
-    plugins = ('djangocms_column', 'djangocms_file', 'djangocms_flash', 'djangocms_googlemap',
-               'djangocms_inherit', 'djangocms_link', 'djangocms_picture', 'djangocms_style',
-               'djangocms_teaser', 'djangocms_video')
+    plugins = ('djangocms_column', 'djangocms_file', 'djangocms_googlemap',
+               'djangocms_inherit', 'djangocms_link', 'djangocms_picture',
+               'djangocms_style', 'djangocms_teaser', 'djangocms_video')
 
     DJANGO_MIGRATION_MODULES, SOUTH_MIGRATION_MODULES = _detect_migration_layout(plugins)
 

--- a/cms/tests/test_toolbar.py
+++ b/cms/tests/test_toolbar.py
@@ -201,7 +201,7 @@ class ToolbarTests(ToolbarTestBase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, '<div class="cms-submenu-item cms-submenu-item-title"><span>Generic</span>')
 
-    def test_markup_flash_custom_module(self):
+    def test_markup_link_custom_module(self):
         superuser = self.get_superuser()
         create_page("toolbar-page", "col_two.html", "en", published=True)
         with self.login_user_context(superuser):

--- a/docs/how_to/custom_plugins.rst
+++ b/docs/how_to/custom_plugins.rst
@@ -293,8 +293,8 @@ clause.
     You cannot name your model fields the same as any installed plugins lower-
     cased model name, due to the implicit one-to-one relation Django uses for
     sub-classed models. If you use all core plugins, this includes: ``file``,
-    ``flash``, ``googlemap``, ``link``, ``picture``, ``snippetptr``,
-    ``teaser``, ``twittersearch``, ``twitterrecententries`` and ``video``.
+    ``googlemap``, ``link``, ``picture``, ``snippetptr``, ``teaser``,
+    ``twittersearch``, ``twitterrecententries`` and ``video``.
 
     Additionally, it is *recommended* that you avoid using ``page`` as a model
     field, as it is declared as a property of :class:`cms.models.pluginmodel.CMSPlugin`,

--- a/docs/how_to/install.rst
+++ b/docs/how_to/install.rst
@@ -67,7 +67,6 @@ Other Plugins
 * djangocms-grid
 * djangocms-oembed
 * djangocms-table
-* djangocms-flash
 
 
 File and image handling
@@ -337,7 +336,6 @@ Also add any (or all) of the following plugins, depending on your needs (see the
 :ref:`installed_apps` about ordering)::
 
     'djangocms_file',
-    'djangocms_flash',
     'djangocms_googlemap',
     'djangocms_inherit',
     'djangocms_picture',
@@ -525,7 +523,6 @@ on Django 1.7, you may need to specify where the migrations are situated using t
     MIGRATION_MODULES = {
         # Add also the following modules if you're using these plugins:
         'djangocms_file': 'djangocms_file.migrations_django',
-        'djangocms_flash': 'djangocms_flash.migrations_django',
         'djangocms_googlemap': 'djangocms_googlemap.migrations_django',
         'djangocms_inherit': 'djangocms_inherit.migrations_django',
         'djangocms_link': 'djangocms_link.migrations_django',

--- a/docs/topics/commonly_used_plugins.rst
+++ b/docs/topics/commonly_used_plugins.rst
@@ -52,32 +52,6 @@ You might consider using `django-filer`_ with `django filer CMS plugin`_ and its
 .. _django-filer: https://github.com/stefanfoulis/django-filer
 .. _django filer CMS plugin: https://github.com/stefanfoulis/cmsplugin-filer
 
-.. :module:: djangocms_flash
-
-.. :class:: djangocms_flash.cms_plugins.FlashPlugin
-
-*****
-Flash
-*****
-
-Available on `GitHub (divio/djangocms-flash) <http://github.com/divio/djangocms-flash>`_
-and on `PyPi (djangocms-flash) <https://pypi.python.org/pypi/djangocms-flash>`_.
-
-Allows you to upload and display a Flash SWF file on your page.
-
-Please install it using ``pip`` or similar and be sure you have the following in the
-:setting:`django:INSTALLED_APPS` setting in your project's ``settings.py`` file::
-
-    INSTALLED_APPS = (
-        # ...
-        'djangocms_flash',
-        # ...
-    )
-
-.. :module:: djangocms_googlemap
-
-.. :class:: djangocms_googlemap.cms_plugins.GoogleMapPlugin
-
 *********
 GoogleMap
 *********

--- a/manage.py
+++ b/manage.py
@@ -61,7 +61,6 @@ if __name__ == '__main__':
         'djangocms_column',
         'djangocms_picture',
         'djangocms_file',
-        'djangocms_flash',
         'djangocms_googlemap',
         'djangocms_teaser',
         'djangocms_video',
@@ -137,9 +136,9 @@ if __name__ == '__main__':
             }
         ]
 
-    plugins = ('djangocms_column', 'djangocms_file', 'djangocms_flash', 'djangocms_googlemap',
-               'djangocms_inherit', 'djangocms_link', 'djangocms_picture', 'djangocms_style',
-               'djangocms_teaser', 'djangocms_video')
+    plugins = ('djangocms_column', 'djangocms_file', 'djangocms_googlemap',
+               'djangocms_inherit', 'djangocms_link', 'djangocms_picture',
+               'djangocms_style', 'djangocms_teaser', 'djangocms_video')
 
     DJANGO_MIGRATION_MODULES, SOUTH_MIGRATION_MODULES = _detect_migration_layout(plugins)
 
@@ -309,13 +308,14 @@ if __name__ == '__main__':
         ),
         CMS_PLACEHOLDER_CONF={
             'col_sidebar': {
-                'plugins': ('FilePlugin', 'FlashPlugin', 'LinkPlugin', 'PicturePlugin',
-                'TextPlugin', 'SnippetPlugin'),
+                'plugins': ('FilePlugin', 'LinkPlugin', 'PicturePlugin',
+                            'TextPlugin', 'SnippetPlugin'),
                 'name': gettext("sidebar column")
             },
             'col_left': {
-                'plugins': ('FilePlugin', 'FlashPlugin', 'LinkPlugin', 'PicturePlugin',
-                'TextPlugin', 'SnippetPlugin', 'GoogleMapPlugin', 'MultiColumnPlugin', 'StylePlugin'),
+                'plugins': ('FilePlugin', 'LinkPlugin', 'PicturePlugin',
+                            'TextPlugin', 'SnippetPlugin', 'GoogleMapPlugin',
+                            'MultiColumnPlugin', 'StylePlugin'),
                 'name': gettext("left column"),
                 'plugin_modules': {
                     'LinkPlugin': 'Different Grouper'
@@ -325,8 +325,9 @@ if __name__ == '__main__':
                 },
             },
             'col_right': {
-                'plugins': ('FilePlugin', 'FlashPlugin', 'LinkPlugin', 'PicturePlugin',
-                'TextPlugin', 'SnippetPlugin', 'GoogleMapPlugin', 'MultiColumnPlugin', 'StylePlugin'),
+                'plugins': ('FilePlugin', 'LinkPlugin', 'PicturePlugin',
+                            'TextPlugin', 'SnippetPlugin', 'GoogleMapPlugin',
+                            'MultiColumnPlugin', 'StylePlugin'),
                 'name': gettext("right column")
             },
             'extra_context': {

--- a/test_requirements/requirements_base.txt
+++ b/test_requirements/requirements_base.txt
@@ -12,7 +12,6 @@ djangocms-admin-style==0.2.7
 -e git+git://github.com/divio/djangocms-column.git#egg=djangocms-column
 -e git+git://github.com/divio/djangocms-style.git#egg=djangocms-style
 -e git+git://github.com/divio/djangocms-file.git#egg=djangocms-file
--e git+git://github.com/divio/djangocms-flash.git#egg=djangocms-flash
 -e git+git://github.com/divio/djangocms-googlemap.git#egg=djangocms-googlemap
 -e git+git://github.com/divio/djangocms-inherit.git#egg=djangocms-inherit
 -e git+git://github.com/divio/djangocms-picture.git#egg=djangocms-picture


### PR DESCRIPTION
We wish to no longer propagate the djangocms-flash plugin. This PR removes it from code, management and documentation. (backward-facing documentation, still retains references).