### PR TITLE
only open welcome modal if sideframe is not open

### DIFF
--- a/cms/templates/cms/welcome.html
+++ b/cms/templates/cms/welcome.html
@@ -84,8 +84,11 @@
                     });
                     CMS.API.Toolbar.open();
                 });
-                // automatically trigger the modal
-                btn.trigger('click');
+
+                // automatically trigger the modal if sideframe isn't open
+                if (!CMS.settings.sideframe.url) {
+                    btn.trigger('click');
+                }
             });
         {% else %}
             {% comment %}


### PR DESCRIPTION
if you close the modal and open a sideframe and then for whatever reason you refresh the page - the modal is opened on top of the sideframe which is not something that should happen