### PR TITLE
Updating reversion imports to suport django-reversion>=1.10.0

### DIFF
--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -52,7 +52,7 @@ require_POST = method_decorator(require_POST)
 
 if is_installed('reversion'):
     from reversion.admin import VersionAdmin as ModelAdmin
-    from reversion import create_revision
+    from reversion.revisions import create_revision
 else:  # pragma: no cover
     from django.contrib.admin import ModelAdmin
 

--- a/cms/cms_toolbars.py
+++ b/cms/cms_toolbars.py
@@ -548,7 +548,7 @@ class PageToolbar(CMSToolbar):
             history_menu = self.toolbar.get_or_create_menu(HISTORY_MENU_IDENTIFIER, _('History'), position=2)
 
             if is_installed('reversion'):
-                import reversion
+                from reversion import revisions as reversion
                 from reversion.models import Revision
 
                 versions = reversion.get_for_object(self.page)

--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -1290,7 +1290,7 @@ class Page(six.with_metaclass(PageMetaClass, MP_Node)):
         """
         Revert the current page to the previous revision
         """
-        import reversion
+        from reversion import revisions as reversion
 
         # Get current reversion version by matching the reversion_id for the page
         versions = reversion.get_for_object(self)
@@ -1317,7 +1317,7 @@ class Page(six.with_metaclass(PageMetaClass, MP_Node)):
         """
         Revert the current page to the next revision
         """
-        import reversion
+        from reversion import revisions as reversion
 
         # Get current reversion version by matching the reversion_id for the page
         versions = reversion.get_for_object(self)

--- a/cms/tests/test_reversion_tests.py
+++ b/cms/tests/test_reversion_tests.py
@@ -8,7 +8,7 @@ from djangocms_text_ckeditor.models import Text
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core.files.uploadedfile import SimpleUploadedFile
-import reversion
+from reversion import revisions as reversion
 from reversion.models import Revision, Version
 
 from cms.models import Page, Title, Placeholder

--- a/cms/utils/helpers.py
+++ b/cms/utils/helpers.py
@@ -40,7 +40,7 @@ def make_revision_with_plugins(obj, user=None, message=None):
     from cms.models.pluginmodel import CMSPlugin
     # we can safely import reversion - calls here always check for
     # reversion in installed_applications first
-    import reversion
+    from reversion import revisions as reversion
     if hasattr(reversion.models, 'VERSION_CHANGE'):
         from reversion.models import VERSION_CHANGE
     """

--- a/cms/utils/reversion_hacks.py
+++ b/cms/utils/reversion_hacks.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import reversion
+from reversion import revisions as reversion
 from reversion.revisions import RegistrationError, VersionAdapter
 
 


### PR DESCRIPTION
In order to support Django 1.9, some breaking changes had to be made to django-reversion's import locations.

https://github.com/etianen/django-reversion/blob/master/CHANGELOG.md#110---02122015

This pull request allows django-cms to work with django-reversion >= 1.10.0