### PR TITLE
Fix breadcrumb and formatting issues

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,6 +3,7 @@
 - Fixed an issue with refreshing the UI when switching CMS language
 - Fixed an issue with sideframe urls not being remembered after reload
 - Added placeholder name to the edit tooltip
+- Fix breadcrumb in page revision list
 
 
 === 3.2.0 (2015-11-24) ===

--- a/cms/templates/admin/cms/extensions/change_form.html
+++ b/cms/templates/admin/cms/extensions/change_form.html
@@ -4,10 +4,9 @@
 <div class="submit-row"{% if is_popup %} style="overflow: auto;"{% endif %}>
     <input type="submit" name="_save" class="default" value="{% trans 'Save' %}"/>
     {% if not add %}
-    <p class="deletelink-box">
-        <a href="delete/" class="deletelink">{% trans "Delete" %}</a>
-    </p>
+        <p class="deletelink-box">
+            <a href="delete/" class="deletelink">{% trans "Delete" %}</a>
+        </p>
     {% endif %}
-
 </div>
 {% endblock %}

--- a/cms/templates/admin/cms/page/history/recover_header.html
+++ b/cms/templates/admin/cms/page/history/recover_header.html
@@ -1,22 +1,26 @@
 {% extends "admin/cms/page/history/revision_header.html" %}
-{% load i18n cms_tags %}
+{% load i18n cms_tags admin_urls %}
 
 {% block extrahead %}
-{{ block.super }}
-<script src="{% cms_admin_url "jsi18n" %}" type="text/javascript"></script>
-{{ media }}
+    {{ block.super }}
+    <script src="{% cms_admin_url "jsi18n" %}" type="text/javascript"></script>
+    {{ media }}
 {% endblock %}
 
 {% block breadcrumbs %}
-<div class="breadcrumbs">
-    <a href="../../../../">{% trans "Home" %}</a> &rsaquo;
-    <a href="../../../">{{ app_label|capfirst|escape }}</a> &rsaquo;
-    <a href="../../">{{ opts.verbose_name_plural|capfirst }}</a> &rsaquo;
-    <a href="../">{% blocktrans with opts.verbose_name as verbose_name %}Recover deleted {{ verbose_name }}{% endblocktrans %}</a> &rsaquo;
-    {{ title }}
-</div>
+    <div class="breadcrumbs">
+        <a href="{% url 'admin:index' %}">{% trans "Home" %}</a> &rsaquo;
+        <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a> &rsaquo;
+        <a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a> &rsaquo;
+        <a href="{% url opts|admin_urlname:'recoverlist' %}">
+            {% blocktrans with opts.verbose_name as verbose_name %}
+                Recover deleted {{ verbose_name }}
+            {% endblocktrans %}
+        </a> &rsaquo;
+        {{ title }}
+    </div>
 {% endblock %}
 
 {% block form_top %}
-<p>{% blocktrans %}Press the save button below to recover this version of the object.{% endblocktrans %}</p>
+    <p>{% blocktrans %}Press the save button below to recover this version of the object.{% endblocktrans %}</p>
 {% endblock %}

--- a/cms/templates/admin/cms/page/history/revision_header.html
+++ b/cms/templates/admin/cms/page/history/revision_header.html
@@ -1,22 +1,22 @@
 {% extends "admin/cms/page/change_form.html" %}
-{% load i18n %}
+{% load i18n cms_tags admin_urls %}
 
 {% block breadcrumbs %}
-<div class="breadcrumbs">
-    <a href="../../../../../">{% trans "Home" %}</a> &rsaquo;
-    <a href="../../../../">{{ app_label|capfirst|escape }}</a> &rsaquo;
-    <a href="../../../">{{ opts.verbose_name_plural|capfirst }}</a> &rsaquo;
-    <a href="../../">{{ original|truncatewords:"18" }}</a> &rsaquo;
-    <a href="../">{% trans "History" %}</a> &rsaquo;
-    {% blocktrans with opts.verbose_name as verbose_name %}Revert {{ verbose_name }}{% endblocktrans %}
-</div>
+    <div class="breadcrumbs">
+        <a href="{% url 'admin:index' %}">{% trans "Home" %}</a> &rsaquo;
+        <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a> &rsaquo;
+        <a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a> &rsaquo;
+        <a href="{% url opts|admin_urlname:'recoverlist' %}">{{ original|truncatewords:"18" }}</a> &rsaquo;
+        <a href="../">{% trans "History" %}</a> &rsaquo;
+        {% blocktrans with opts.verbose_name as verbose_name %}Revert {{ verbose_name }}{% endblocktrans %}
+    </div>
 {% endblock %}
 
 {% block content %}
-{% with 1 as is_popup %}{{ block.super }}{% endwith %}
+    {% with 1 as is_popup %}{{ block.super }}{% endwith %}
 {% endblock %}
 
 {% block form_top %}
-<p>{% blocktrans %}Press the save button below to revert to this version of the object.{% endblocktrans %}</p>
-{{ block.super }}
+    <p>{% blocktrans %}Press the save button below to revert to this version of the object.{% endblocktrans %}</p>
+    {{ block.super }}
 {% endblock %}

--- a/cms/templates/admin/cms/page/history/revision_header.html
+++ b/cms/templates/admin/cms/page/history/revision_header.html
@@ -7,6 +7,7 @@
         <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a> &rsaquo;
         <a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a> &rsaquo;
         <a href="{% url opts|admin_urlname:'recoverlist' %}">{{ original|truncatewords:"18" }}</a> &rsaquo;
+        {# FIXME need to add correct history django url #}
         <a href="../">{% trans "History" %}</a> &rsaquo;
         {% blocktrans with opts.verbose_name as verbose_name %}Revert {{ verbose_name }}{% endblocktrans %}
     </div>


### PR DESCRIPTION
- fixes url references
- fixes breadcrumb in ``admin/cms/page/recover/{id}/`` to reflect "django CMS" as name
- fixes codestyle

Fix from https://github.com/divio/django-cms/pull/4813