### PR TITLE
Remove references to deprecated dict 'placeholders'

### DIFF
--- a/cms/plugin_rendering.py
+++ b/cms/plugin_rendering.py
@@ -164,14 +164,9 @@ def render_placeholder(placeholder, context_to_copy, name_fallback="Placeholder"
     toolbar_content = ''
 
     if edit and editable:
-        # TODO remove ``placeholders`` in 3.3
-        if not hasattr(request.toolbar, 'placeholders'):
-            request.toolbar.placeholders = {}
         if not hasattr(request.toolbar, 'placeholder_list'):
             request.toolbar.placeholder_list = []
-        if placeholder.pk not in request.toolbar.placeholders:
-            # TODO remove ``placeholders`` in 3.3
-            request.toolbar.placeholders[placeholder.pk] = placeholder
+        if placeholder.pk not in request.toolbar.placeholder_list:
             request.toolbar.placeholder_list.append(placeholder)
         toolbar_content = mark_safe(render_placeholder_toolbar(placeholder, context, name_fallback, save_language))
     if content:


### PR DESCRIPTION
`toolbar.placeholders` was deprecated in 3.2 for removal in 3.3, this satisfies that removal.