### PR TITLE
Do not call transaction.atomic when used as a decorator

### DIFF
--- a/cms/wizards/views.py
+++ b/cms/wizards/views.py
@@ -26,7 +26,7 @@ from .forms import (
 class WizardViewMixin(object):
     language_code = None
 
-    @transaction.atomic()
+    @transaction.atomic
     def dispatch(self, request, *args, **kwargs):
         self.language_code = get_language_from_request(request, check_path=True)
         response = super(WizardViewMixin, self).dispatch(


### PR DESCRIPTION
Without this change I kept getting errors saying 

    TypeError: 'GeneratorContextManager' object is not callable

https://docs.djangoproject.com/en/1.8/topics/db/transactions/#controlling-transactions-explicitly

This is in line with the Django documentation. The test suite outcome is the same with and without this change.