### PR TITLE
apply the toolbar language to the placeholder label

### DIFF
--- a/cms/templates/cms/toolbar/placeholder.html
+++ b/cms/templates/cms/toolbar/placeholder.html
@@ -4,6 +4,7 @@
 <div class="cms-placeholder cms-placeholder-{{ placeholder.pk|unlocalize }}"></div>
 
 {% endspaceless %}{% addtoblock "js" %}
+{% language request.toolbar.toolbar_language %}
 <script>
 CMS._plugins.push(['cms-placeholder-{{ placeholder.pk|unlocalize }}', {
     type: 'placeholder',
@@ -13,10 +14,11 @@ CMS._plugins.push(['cms-placeholder-{{ placeholder.pk|unlocalize }}', {
     plugin_language: '{{ language }}',
     plugin_restriction: [{% for module in allowed_plugins %}"{{ module }}"{% if not forloop.last %}, {% endif %}{% endfor %}],
     addPluginHelpTitle: '{% trans "Add plugin to placeholder" %} "{{ placeholder.get_label|escapejs }}"',
-    urls: { {% language request.toolbar.toolbar_language %}
+    urls: {
         add_plugin: '{{ placeholder.get_add_url }}',
         copy_plugin: '{{ placeholder.get_copy_url }}'
-    } {% endlanguage %}
+    }
 }]);
 </script>
+{% endlanguage %}
 {% endaddtoblock %}


### PR DESCRIPTION
Bug reported by @kkovrizhenko 

**Precondition:**
    User language is english. Page exists in german and english. Page is opened.

**Steps to reproduce:**
* Switch to german language of the page
* Switch to structure mode
* Click add button

**Actual result:**
Add plugin to placeholder" list shown in language of the site not in user language
![cms_language_plugin list](https://cloud.githubusercontent.com/assets/994951/12003947/cc7b8a70-ab02-11e5-9377-66ced1f675e5.png)
