### PR TITLE
More resilient apphooks

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,7 @@
 === 3.2.4 (unreleased) ===
 
 - Fixed regression when page couldn't be copied if CMS_PERMISSION was False
+- CMS handles uninstalled apphooks better
 
 
 === 3.2.3 (2016-03-09) ===

--- a/cms/apphook_pool.py
+++ b/cms/apphook_pool.py
@@ -2,6 +2,7 @@
 import warnings
 
 from django.core.exceptions import ImproperlyConfigured
+from django.utils.translation import ugettext as _
 
 from cms.app_base import CMSApp
 from cms.exceptions import AppAlreadyRegistered
@@ -100,7 +101,8 @@ class ApphookPool(object):
                 if app_name in app.urls:
                     return app
 
-        raise ImproperlyConfigured('No registered apphook %r found' % app_name)
+        warnings.warn(_('No registered apphook "%r" found') % app_name)
+        return None
 
 
 apphook_pool = ApphookPool()

--- a/cms/appresolver.py
+++ b/cms/appresolver.py
@@ -17,7 +17,6 @@ except ImportError:
     from django.utils.importlib import import_module
 
 from django.conf import settings
-from django.conf.urls import patterns
 from django.contrib.sites.models import Site
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import (RegexURLResolver, Resolver404, reverse,

--- a/cms/appresolver.py
+++ b/cms/appresolver.py
@@ -110,7 +110,8 @@ class AppRegexURLResolver(RegexURLResolver):
             raise Resolver404({'tried': tried, 'path': new_path})
 
 
-def recurse_patterns(path, pattern_list, page_id, default_args=None, nested=False):
+def recurse_patterns(path, pattern_list, page_id, default_args=None,
+                     nested=False):
     """
     Recurse over a list of to-be-hooked patterns for a given path prefix
     """
@@ -138,7 +139,6 @@ def recurse_patterns(path, pattern_list, page_id, default_args=None, nested=Fals
                 # this is an 'include', recurse!
                 resolver = RegexURLResolver(regex, urlconf_module,
                                             pattern.default_kwargs, pattern.app_name, pattern.namespace)
-            resolver.page_id = page_id
         else:
             # Re-do the RegexURLPattern with the new regular expression
             args = pattern.default_args
@@ -205,14 +205,17 @@ def _get_app_patterns():
 
     How this works:
 
-    By looking through all titles with an app hook (application_urls) we find all
-    urlconf modules we have to hook into titles.
+    By looking through all titles with an app hook (application_urls) we find
+    all urlconf modules we have to hook into titles.
 
     If we use the ML URL Middleware, we namespace those patterns with the title
     language.
 
     All 'normal' patterns from the urlconf get re-written by prefixing them with
     the title path and then included into the cms url patterns.
+
+    If the app is still configured, but is no longer installed/available, then
+    this method returns a degenerate patterns object: patterns('')
     """
     from cms.models import Title
 
@@ -231,30 +234,38 @@ def _get_app_patterns():
     hooked_applications = OrderedDict()
 
     # Loop over all titles with an application hooked to them
+    titles = (title_qs.exclude(page__application_urls=None)
+                      .exclude(page__application_urls='')
+                      .order_by('-page__path').select_related())
     # TODO: Need to be fixed for django-treebeard when forward ported to 3.1
-    for title in title_qs.exclude(page__application_urls=None).exclude(page__application_urls='').order_by('-page__path').select_related():
+    for title in titles:
         path = title.path
-        mix_id = "%s:%s:%s" % (path + "/", title.page.application_urls, title.language)
+        mix_id = "%s:%s:%s" % (
+            path + "/", title.page.application_urls, title.language)
         if mix_id in included:
             # don't add the same thing twice
             continue
         if not settings.APPEND_SLASH:
             path += '/'
+        app = apphook_pool.get_apphook(title.page.application_urls)
+        if not app:
+            continue
         if title.page_id not in hooked_applications:
             hooked_applications[title.page_id] = {}
-        app = apphook_pool.get_apphook(title.page.application_urls)
         app_ns = app.app_name, title.page.application_namespace
         with override(title.language):
-            hooked_applications[title.page_id][title.language] = (app_ns, get_patterns_for_title(path, title), app)
+            hooked_applications[title.page_id][title.language] = (
+                app_ns, get_patterns_for_title(path, title), app)
         included.append(mix_id)
         # Build the app patterns to be included in the cms urlconfs
     app_patterns = []
     for page_id in hooked_applications.keys():
         resolver = None
         for lang in hooked_applications[page_id].keys():
-            (app_ns, inst_ns), current_patterns, app = hooked_applications[page_id][lang]
+            (app_ns, inst_ns), current_patterns, app = hooked_applications[page_id][lang]  # nopyflakes
             if not resolver:
-                resolver = AppRegexURLResolver(r'', 'app_resolver', app_name=app_ns, namespace=inst_ns)
+                resolver = AppRegexURLResolver(
+                    r'', 'app_resolver', app_name=app_ns, namespace=inst_ns)
                 resolver.page_id = page_id
             if app.permissions:
                 _set_permissions(current_patterns, app.exclude_permissions)

--- a/cms/appresolver.py
+++ b/cms/appresolver.py
@@ -62,6 +62,8 @@ def applications_page_check(request, current_page=None, path=None):
         except Resolver404:
             # Raised if the page is not managed by an apphook
             pass
+        except Page.DoesNotExist:
+            pass
     return None
 
 
@@ -104,8 +106,8 @@ class AppRegexURLResolver(RegexURLResolver):
                         else:
                             tried.extend([pattern])
                     else:
-                        if sub_match and hasattr(pattern, 'page_id'):
-                            return pattern.page_id
+                        if sub_match:
+                            return getattr(pattern, 'page_id', None)
                         tried.append(pattern.regex.pattern)
             raise Resolver404({'tried': tried, 'path': new_path})
 

--- a/cms/appresolver.py
+++ b/cms/appresolver.py
@@ -17,6 +17,7 @@ except ImportError:
     from django.utils.importlib import import_module
 
 from django.conf import settings
+from django.conf.urls import patterns
 from django.contrib.sites.models import Site
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import (RegexURLResolver, Resolver404, reverse,

--- a/cms/appresolver.py
+++ b/cms/appresolver.py
@@ -104,7 +104,7 @@ class AppRegexURLResolver(RegexURLResolver):
                         else:
                             tried.extend([pattern])
                     else:
-                        if sub_match:
+                        if sub_match and hasattr(pattern, 'page_id'):
                             return pattern.page_id
                         tried.append(pattern.regex.pattern)
             raise Resolver404({'tried': tried, 'path': new_path})

--- a/cms/appresolver.py
+++ b/cms/appresolver.py
@@ -148,7 +148,7 @@ def recurse_patterns(path, pattern_list, page_id, default_args=None,
                 args.update(default_args)
             resolver = RegexURLPattern(regex, pattern.callback,
                                        args, pattern.name)
-            resolver.page_id = page_id
+        resolver.page_id = page_id
         newpatterns.append(resolver)
     return newpatterns
 

--- a/cms/cms_menus.py
+++ b/cms/cms_menus.py
@@ -144,7 +144,8 @@ def page_to_node(page, home, cut):
         app_name = page.get_application_urls(fallback=False)
         if app_name:  # it means it is an apphook
             app = apphook_pool.get_apphook(app_name)
-            extenders += app.menus
+            if app:
+                extenders += app.menus
     exts = []
     for ext in extenders:
         if hasattr(ext, "get_instances"):

--- a/cms/toolbar/toolbar.py
+++ b/cms/toolbar/toolbar.py
@@ -82,7 +82,7 @@ class CMSToolbar(ToolbarAPIMixin):
                 except (TypeError, AttributeError):
                     # no decorator
                     self.app_name = decorator.__module__
-            except Resolver404:
+            except (Resolver404, AttributeError):
                 self.app_name = ""
         toolbars = toolbar_pool.get_toolbars()
         parts = self.app_name.split('.')

--- a/cms/views.py
+++ b/cms/views.py
@@ -134,14 +134,15 @@ def details(request, slug):
         if app_urls and not skip_app:
             app = apphook_pool.get_apphook(app_urls)
             pattern_list = []
-            for urlpatterns in get_app_urls(app.urls):
-                pattern_list += urlpatterns
-            try:
-                view, args, kwargs = resolve('/', tuple(pattern_list))
-                return view(request, *args, **kwargs)
-            except Resolver404:
-                pass
-                # Check if the page has a redirect url defined for this language.
+            if app:
+                for urlpatterns in get_app_urls(app.urls):
+                    pattern_list += urlpatterns
+                try:
+                    view, args, kwargs = resolve('/', tuple(pattern_list))
+                    return view(request, *args, **kwargs)
+                except Resolver404:
+                    pass
+                    # Check if the page has a redirect url defined for this language.
     redirect_url = page.get_redirect(language=current_language)
     if redirect_url:
         if (is_language_prefix_patterns_used() and redirect_url[0] == "/"


### PR DESCRIPTION
This PR allows the CMS to actually start even when there's an apphook that is configured on a page, but is no longer installed. A warning is emitted, but otherwise, the CMS will start and even the apphooked page can be viewed.