### PR TITLE
Fix support for reversion >=1.9

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 === 3.2.1 (Unreleased) ===
 
+- Add support for django-reversion 1.10+
 - Fixed an issue with refreshing the UI when switching CMS language
 - Fixed an issue with sideframe urls not being remembered after reload
 - Added placeholder name to the edit tooltip

--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -18,7 +18,7 @@ from django.contrib.admin.options import IncorrectLookupParameters
 try:
     from django.contrib.admin.utils import get_deleted_objects, quote
 except ImportError:
-    from django.contrib.admin.util import get_deleted_objects
+    from django.contrib.admin.util import get_deleted_objects, quote
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.sites.models import Site
 try:

--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -452,9 +452,9 @@ class PageAdmin(PlaceholderAdminMixin, ModelAdmin):
             response._headers['location'] = (location[0], "%s?language=%s" % (location[1], tab_language))
         if request.method == "POST" and response.status_code in (200, 302):
             if 'history' in request.path_info:
-                return HttpResponseRedirect("../../")
+                return HttpResponseRedirect(admin_reverse('cms_page_change', args=(quote(object_id),)))
             elif 'recover' in request.path_info:
-                return HttpResponseRedirect("../../%s/" % quote(object_id))
+                return HttpResponseRedirect(admin_reverse('cms_page_change', args=(quote(object_id),)))
         return response
 
     def render_change_form(self, request, context, add=False, change=False, form_url='', obj=None):
@@ -469,7 +469,6 @@ class PageAdmin(PlaceholderAdminMixin, ModelAdmin):
         return super(PageAdmin, self).render_change_form(request, context, add, change, form_url, obj)
 
     def _get_site_languages(self, obj=None):
-        site_id = None
         if obj:
             site_id = obj.site_id
         else:
@@ -915,7 +914,7 @@ class PageAdmin(PlaceholderAdminMixin, ModelAdmin):
         target = request.POST.get('target', None)
         position = request.POST.get('position', None)
         if target is None or position is None:
-            return HttpResponseRedirect('../../')
+            return HttpResponseRedirect(admin_reverse('cms_page_change', args=(page_id,)))
 
         try:
             page = self.model.objects.get(pk=page_id)
@@ -1026,7 +1025,7 @@ class PageAdmin(PlaceholderAdminMixin, ModelAdmin):
                     exc = sys.exc_info()[1]
                     return jsonify_request(HttpResponseBadRequest(exc.messages))
         context.update(extra_context or {})
-        return HttpResponseRedirect('../../')
+        return HttpResponseRedirect(admin_reverse('cms_page_changelist'))
 
     @require_POST
     @transaction.atomic
@@ -1278,8 +1277,8 @@ class PageAdmin(PlaceholderAdminMixin, ModelAdmin):
                 helpers.make_revision_with_plugins(obj, request.user, message)
 
             if not self.has_change_permission(request, None):
-                return HttpResponseRedirect("../../../../")
-            return HttpResponseRedirect("../../")
+                return HttpResponseRedirect(admin_reverse('index'))
+            return HttpResponseRedirect(admin_reverse('cms_page_changelist'))
 
         context = {
             "title": _("Are you sure?"),

--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -3,6 +3,9 @@ import copy
 from functools import wraps
 import json
 import sys
+
+from django.utils.formats import localize
+
 from cms.utils.compat import DJANGO_1_7
 
 import django
@@ -13,7 +16,7 @@ from django.contrib import admin, messages
 from django.contrib.admin.models import LogEntry, CHANGE
 from django.contrib.admin.options import IncorrectLookupParameters
 try:
-    from django.contrib.admin.utils import get_deleted_objects
+    from django.contrib.admin.utils import get_deleted_objects, quote
 except ImportError:
     from django.contrib.admin.util import get_deleted_objects
 from django.contrib.contenttypes.models import ContentType
@@ -58,8 +61,7 @@ from cms.utils.urlutils import add_url_parameters, admin_reverse
 require_POST = method_decorator(require_POST)
 
 if is_installed('reversion'):
-    from reversion.admin import VersionAdmin as ModelAdmin
-    from reversion.revisions import create_revision
+    from cms.utils.reversion_hacks import ModelAdmin, create_revision, Version, RollBackRevisionView
 else:  # pragma: no cover
     from django.contrib.admin import ModelAdmin
 
@@ -427,7 +429,6 @@ class PageAdmin(PlaceholderAdminMixin, ModelAdmin):
             # to determine whether a given object exists.
             obj = None
         else:
-            #activate(user_lang_set)
             context = {
                 'page': obj,
                 'CMS_PERMISSION': get_cms_setting('PERMISSION'),
@@ -448,6 +449,11 @@ class PageAdmin(PlaceholderAdminMixin, ModelAdmin):
         if tab_language and response.status_code == 302 and response._headers['location'][1] == request.path_info:
             location = response._headers['location']
             response._headers['location'] = (location[0], "%s?language=%s" % (location[1], tab_language))
+        if request.method == "POST" and response.status_code == 200:
+            if 'history' in request.path_info:
+                return HttpResponseRedirect("../../")
+            elif 'recover' in request.path_info:
+                return HttpResponseRedirect("../../%s/" % quote(object_id))
         return response
 
     def render_change_form(self, request, context, add=False, change=False, form_url='', obj=None):
@@ -746,12 +752,14 @@ class PageAdmin(PlaceholderAdminMixin, ModelAdmin):
         if not self.has_recover_permission(request):
             raise PermissionDenied
         extra_context = self.update_language_tab_context(request, None, extra_context)
+        request.original_version_id = version_id
         return super(PageAdmin, self).recover_view(request, version_id, extra_context)
 
     def revision_view(self, request, object_id, version_id, extra_context=None):
         if not self.has_change_permission(request, Page.objects.get(pk=object_id)):
             raise PermissionDenied
         extra_context = self.update_language_tab_context(request, None, extra_context)
+        request.original_version_id = version_id
         response = super(PageAdmin, self).revision_view(request, object_id, version_id, extra_context)
         return response
 
@@ -761,8 +769,21 @@ class PageAdmin(PlaceholderAdminMixin, ModelAdmin):
         extra_context = self.update_language_tab_context(request, None, extra_context)
         return super(PageAdmin, self).history_view(request, object_id, extra_context)
 
-    def render_revision_form(self, request, obj, version, context, revert=False, recover=False):
-        # reset parent to null if parent is not found
+    def get_object(self, request, object_id, from_field=None):
+        if from_field:
+            obj = super(PageAdmin, self).get_object(request, object_id, from_field)
+        else:
+            # This is for DJANGO_16
+            obj = super(PageAdmin, self).get_object(request, object_id)
+
+        if is_installed('reversion') and getattr(request, 'original_version_id', None):
+            version = get_object_or_404(Version, pk=getattr(request, 'original_version_id', None))
+            recover = 'recover' in request.path_info
+            revert = 'history' in request.path_info
+            obj, version = self._reset_parent_during_reversion(obj, version, revert, recover)
+        return obj
+
+    def _reset_parent_during_reversion(self, obj, version, revert=False, recover=False):
         if version.field_dict['parent']:
             try:
                 Page.objects.get(pk=version.field_dict['parent'])
@@ -775,7 +796,33 @@ class PageAdmin(PlaceholderAdminMixin, ModelAdmin):
                     version.field_dict['parent'] = None
 
         obj.version = version
+        return obj, version
 
+    # This is just for Django 1.6 / reversion 1.8 compatibility
+    # The handling of recover / revision in 3.3 can be simplified
+    # by using the new reversin semantic and django changeform_view
+    def revisionform_view(self, request, version, template_name, extra_context=None):
+        try:
+            with transaction.atomic():
+                # Revert the revision.
+                version.revision.revert(delete=True)
+                # Run the normal change_view view.
+                with self._create_revision(request):
+                    response = self.change_view(request, version.object_id, request.path, extra_context)
+                    # Decide on whether the keep the changes.
+                    if request.method == "POST" and response.status_code == 302:
+                        self.revision_context_manager.set_comment(_("Reverted to previous version, saved on %(datetime)s") % {"datetime": localize(version.revision.date_created)})
+                    else:
+                        response.template_name = template_name
+                        response.render()
+                        raise RollBackRevisionView
+        except RollBackRevisionView:
+            pass
+        return response
+
+    def render_revision_form(self, request, obj, version, context, revert=False, recover=False):
+        # reset parent to null if parent is not found
+        obj, version = self._reset_parent_during_reversion(obj, version, revert, recover)
         return super(PageAdmin, self).render_revision_form(request, obj, version, context, revert, recover)
 
     @require_POST
@@ -1034,7 +1081,7 @@ class PageAdmin(PlaceholderAdminMixin, ModelAdmin):
     def cleanup_history(self, page, publish=False):
         if is_installed('reversion') and page:
             # delete revisions that are not publish revisions
-            from reversion.models import Version
+            from cms.utils.reversion_hacks import Version
 
             content_type = ContentType.objects.get_for_model(Page)
             # reversion 1.8+ removes type field, revision filtering must be based on comments

--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -59,7 +59,7 @@ require_POST = method_decorator(require_POST)
 
 if is_installed('reversion'):
     from reversion.admin import VersionAdmin as ModelAdmin
-    from reversion import create_revision
+    from reversion.revisions import create_revision
 else:  # pragma: no cover
     from django.contrib.admin import ModelAdmin
 

--- a/cms/admin/permissionadmin.py
+++ b/cms/admin/permissionadmin.py
@@ -22,6 +22,7 @@ for model, admin_instance in site._registry.items():
     if model == user_model:
         admin_class = admin_instance.__class__
 
+
 class TabularInline(admin.TabularInline):
     pass
 

--- a/cms/admin/views.py
+++ b/cms/admin/views.py
@@ -6,7 +6,8 @@ from cms.models import Page, Title, CMSPlugin, Placeholder
 
 
 def revert_plugins(request, version_id, obj):
-    from reversion.models import Version
+    from cms.utils.reversion_hacks import Version
+
     version = get_object_or_404(Version, pk=version_id)
     revs = [related_version.object_version for related_version in version.revision.version_set.all()]
     cms_plugin_list = []
@@ -25,7 +26,6 @@ def revert_plugins(request, version_id, obj):
             plugin_list.append(obj)
         elif obj.__class__ == Page:
             pass
-            #page = obj #Page.objects.get(pk=obj.pk)
         elif obj.__class__ == Title:
             titles.append(obj)
         else:

--- a/cms/cms_toolbars.py
+++ b/cms/cms_toolbars.py
@@ -548,7 +548,7 @@ class PageToolbar(CMSToolbar):
             history_menu = self.toolbar.get_or_create_menu(HISTORY_MENU_IDENTIFIER, _('History'), position=2)
 
             if is_installed('reversion'):
-                import reversion
+                from reversion import revisions as reversion
                 from reversion.models import Revision
 
                 versions = reversion.get_for_object(self.page)

--- a/cms/cms_toolbars.py
+++ b/cms/cms_toolbars.py
@@ -548,8 +548,7 @@ class PageToolbar(CMSToolbar):
             history_menu = self.toolbar.get_or_create_menu(HISTORY_MENU_IDENTIFIER, _('History'), position=2)
 
             if is_installed('reversion'):
-                from reversion import revisions as reversion
-                from reversion.models import Revision
+                from cms.utils.reversion_hacks import reversion, Revision
 
                 versions = reversion.get_for_object(self.page)
                 if self.page.revision_id:

--- a/cms/forms/wizards.py
+++ b/cms/forms/wizards.py
@@ -276,14 +276,15 @@ class CreateCMSPageForm(BaseCMSPageForm):
                     })
 
         if is_installed('reversion'):
-            import reversion
             from cms.utils.helpers import make_revision_with_plugins
+            from cms.admin.pageadmin import INITIAL_COMMENT
+            from cms.utils.reversion_hacks import create_revision
 
-            with reversion.create_revision():
+            with create_revision():
                 make_revision_with_plugins(
                     obj=page,
                     user=self.user,
-                    message=ugettext('Initial version.'),
+                    message=ugettext(INITIAL_COMMENT),
                 )
         return page
 

--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -1290,7 +1290,7 @@ class Page(six.with_metaclass(PageMetaClass, MP_Node)):
         """
         Revert the current page to the previous revision
         """
-        import reversion
+        from reversion import revisions as reversion
 
         # Get current reversion version by matching the reversion_id for the page
         versions = reversion.get_for_object(self)
@@ -1317,7 +1317,7 @@ class Page(six.with_metaclass(PageMetaClass, MP_Node)):
         """
         Revert the current page to the next revision
         """
-        import reversion
+        from reversion import revisions as reversion
 
         # Get current reversion version by matching the reversion_id for the page
         versions = reversion.get_for_object(self)

--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -445,7 +445,7 @@ class Page(six.with_metaclass(PageMetaClass, MP_Node)):
         menu_pool.clear(site_id=site.pk)
         return first_page
 
-    def delete(self):
+    def delete(self, *args, **kwargs):
         pages = [self.pk]
         if self.publisher_public_id:
             pages.append(self.publisher_public_id)
@@ -1340,7 +1340,7 @@ class Page(six.with_metaclass(PageMetaClass, MP_Node)):
         clean = self._apply_revision(next_revision)
         return Page.objects.get(pk=self.pk), clean
 
-    def _apply_revision(self, target_revision):
+    def _apply_revision(self, target_revision, set_dirty=False):
         """
         Revert to a specific revision
         """
@@ -1357,7 +1357,7 @@ class Page(six.with_metaclass(PageMetaClass, MP_Node)):
         self.placeholders.all().delete()
 
         # populate the page status data from the target version
-        target_revision.revert(True)
+        target_revision.revert(delete=True)
         rev_page = get_object_or_404(Page, pk=self.pk)
         rev_page.revision_id = target_revision.pk
         rev_page.publisher_public_id = self.publisher_public_id
@@ -1387,6 +1387,8 @@ class Page(six.with_metaclass(PageMetaClass, MP_Node)):
                         title.slug = old_title.slug
                         title.save()
                         clean = False
+            if set_dirty:
+                self.set_publisher_state(title.language, PUBLISHER_STATE_DIRTY)
         return clean
 
 

--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -957,7 +957,7 @@ class Page(six.with_metaclass(PageMetaClass, MP_Node)):
             from cms.models.titlemodels import Title
 
             if version_id:
-                from reversion.models import Version
+                from cms.utils.reversion_hacks import Version
 
                 version = get_object_or_404(Version, pk=version_id)
                 revs = [related_version.object_version for related_version in version.revision.version_set.all()]
@@ -1290,12 +1290,12 @@ class Page(six.with_metaclass(PageMetaClass, MP_Node)):
         """
         Revert the current page to the previous revision
         """
-        from reversion import revisions as reversion
+        from cms.utils.reversion_hacks import reversion, Revision
 
         # Get current reversion version by matching the reversion_id for the page
         versions = reversion.get_for_object(self)
         if self.revision_id:
-            current_revision = reversion.models.Revision.objects.get(pk=self.revision_id)
+            current_revision = Revision.objects.get(pk=self.revision_id)
         else:
             try:
                 current_version = versions[0]
@@ -1317,12 +1317,12 @@ class Page(six.with_metaclass(PageMetaClass, MP_Node)):
         """
         Revert the current page to the next revision
         """
-        from reversion import revisions as reversion
+        from cms.utils.reversion_hacks import reversion, Revision
 
         # Get current reversion version by matching the reversion_id for the page
         versions = reversion.get_for_object(self)
         if self.revision_id:
-            current_revision = reversion.models.Revision.objects.get(pk=self.revision_id)
+            current_revision = Revision.objects.get(pk=self.revision_id)
         else:
             try:
                 current_version = versions[0]

--- a/cms/models/placeholdermodel.py
+++ b/cms/models/placeholdermodel.py
@@ -99,7 +99,7 @@ class Placeholder(models.Model):
         Generic method to check the permissions for a request for a given key,
         the key can be: 'add', 'change' or 'delete'. For each attached object
         permission has to be granted either on attached model or on attached object.
-          * 'add' and 'change' permissions on placeholder need either on add or change 
+          * 'add' and 'change' permissions on placeholder need either on add or change
             permission on attached object to be granted.
           * 'delete' need either on add, change or delete
         """
@@ -293,4 +293,4 @@ class Placeholder(models.Model):
             self._actions_cache = getattr(field, 'actions', PlaceholderNoAction())
         return self._actions_cache
 
-reversion_register(Placeholder)  # follow=["cmsplugin_set"] not following plugins since they are a spechial case
+reversion_register(Placeholder)

--- a/cms/plugin_pool.py
+++ b/cms/plugin_pool.py
@@ -111,7 +111,7 @@ class PluginPool(object):
         signals.pre_delete.connect(pre_delete_plugins, sender=CMSPlugin,
                                    dispatch_uid='cms_pre_delete_plugin_%s' % plugin_name)
         if is_installed('reversion'):
-            from reversion.revisions import RegistrationError
+            from cms.utils.reversion_hacks import RegistrationError
             try:
                 reversion_register(plugin.model)
             except RegistrationError:

--- a/cms/signals/__init__.py
+++ b/cms/signals/__init__.py
@@ -99,6 +99,6 @@ if get_cms_setting('PERMISSION'):
 ###################### reversion #########################
 
 if is_installed('reversion'):
-    from reversion.models import post_revision_commit
+    from cms.utils.reversion_hacks import post_revision_commit
 
     post_revision_commit.connect(post_revision, dispatch_uid='cms_post_revision')

--- a/cms/tests/test_reversion_tests.py
+++ b/cms/tests/test_reversion_tests.py
@@ -51,7 +51,6 @@ class ReversionTestCase(TransactionCMSTestCase):
                 'placeholder_id': placeholderpk,
                 'plugin_parent': '',
             }
-            print("add plugin")
             response = self.client.post(URL_CMS_PLUGIN_ADD, plugin_data)
             self.assertEqual(response.status_code, 200)
             # now edit the plugin
@@ -59,20 +58,17 @@ class ReversionTestCase(TransactionCMSTestCase):
                 0] + "/"
             response = self.client.get(edit_url)
             self.assertEqual(response.status_code, 200)
-            print("change plugin")
             response = self.client.post(edit_url, {"body": "Hello World"})
             self.assertEqual(response.status_code, 200)
             txt = Text.objects.all()[0]
             self.assertEqual("Hello World", txt.body)
             self.txt = txt
             # change the content
-            print("change plugin")
             response = self.client.post(edit_url, {"body": "Bye Bye World"})
             self.assertEqual(response.status_code, 200)
             txt = Text.objects.all()[0]
             self.assertEqual("Bye Bye World", txt.body)
             p_data = self.page_data.copy()
-            print("chage data")
             response = self.client.post(URL_CMS_PAGE_CHANGE % page.pk, p_data)
             self.assertRedirects(response, URL_CMS_PAGE)
             page.publish('en')
@@ -206,7 +202,6 @@ class ReversionTestCase(TransactionCMSTestCase):
         with self.login_user_context(self.user):
             self.assertEqual(Revision.objects.all().count(), 5)
             ctype = ContentType.objects.get_for_model(Page)
-            print(Revision.objects.all())
             revision = Revision.objects.all()[4]
             version = Version.objects.filter(content_type=ctype, revision=revision)[0]
 
@@ -236,7 +231,6 @@ class ReversionTestCase(TransactionCMSTestCase):
 
             # test that CMSPlugin subclasses are recovered
             self.assertEqual(Text.objects.all().count(), 1)
-            print(Text.objects.all())
 
     def test_recover_path_collision(self):
         with self.login_user_context(self.user):

--- a/cms/tests/test_reversion_tests.py
+++ b/cms/tests/test_reversion_tests.py
@@ -51,6 +51,7 @@ class ReversionTestCase(TransactionCMSTestCase):
                 'placeholder_id': placeholderpk,
                 'plugin_parent': '',
             }
+            print("add plugin")
             response = self.client.post(URL_CMS_PLUGIN_ADD, plugin_data)
             self.assertEqual(response.status_code, 200)
             # now edit the plugin
@@ -58,17 +59,20 @@ class ReversionTestCase(TransactionCMSTestCase):
                 0] + "/"
             response = self.client.get(edit_url)
             self.assertEqual(response.status_code, 200)
+            print("change plugin")
             response = self.client.post(edit_url, {"body": "Hello World"})
             self.assertEqual(response.status_code, 200)
             txt = Text.objects.all()[0]
             self.assertEqual("Hello World", txt.body)
             self.txt = txt
             # change the content
+            print("change plugin")
             response = self.client.post(edit_url, {"body": "Bye Bye World"})
             self.assertEqual(response.status_code, 200)
             txt = Text.objects.all()[0]
             self.assertEqual("Bye Bye World", txt.body)
             p_data = self.page_data.copy()
+            print("chage data")
             response = self.client.post(URL_CMS_PAGE_CHANGE % page.pk, p_data)
             self.assertRedirects(response, URL_CMS_PAGE)
             page.publish('en')
@@ -202,6 +206,7 @@ class ReversionTestCase(TransactionCMSTestCase):
         with self.login_user_context(self.user):
             self.assertEqual(Revision.objects.all().count(), 5)
             ctype = ContentType.objects.get_for_model(Page)
+            print(Revision.objects.all())
             revision = Revision.objects.all()[4]
             version = Version.objects.filter(content_type=ctype, revision=revision)[0]
 
@@ -231,6 +236,7 @@ class ReversionTestCase(TransactionCMSTestCase):
 
             # test that CMSPlugin subclasses are recovered
             self.assertEqual(Text.objects.all().count(), 1)
+            print(Text.objects.all())
 
     def test_recover_path_collision(self):
         with self.login_user_context(self.user):

--- a/cms/tests/test_reversion_tests.py
+++ b/cms/tests/test_reversion_tests.py
@@ -9,18 +9,13 @@ from djangocms_text_ckeditor.models import Text
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core.files.uploadedfile import SimpleUploadedFile
-from reversion import revisions as reversion
-from reversion.models import Revision, Version
 
 from cms.models import Page, Title, Placeholder
 from cms.models.pluginmodel import CMSPlugin
 from cms.test_utils.project.fileapp.models import FileModel
 from cms.test_utils.testcases import CMSTestCase, TransactionCMSTestCase, URL_CMS_PAGE, URL_CMS_PAGE_CHANGE, URL_CMS_PAGE_ADD, \
     URL_CMS_PLUGIN_ADD, URL_CMS_PLUGIN_EDIT
-
-if hasattr(reversion.models, 'VERSION_CHANGE'):
-    from reversion.models import VERSION_CHANGE
-
+from cms.utils.reversion_hacks import Revision, reversion, Version
 
 class BasicReversionTestCase(CMSTestCase):
     def setUp(self):
@@ -303,15 +298,10 @@ class ReversionFileFieldTests(CMSTestCase):
             # manually add a revision because we use the explicit way
             # django-cms uses too.
             adapter = reversion.get_adapter(FileModel)
-            if hasattr(reversion.models, 'VERSION_CHANGE'):
-                reversion.revision_context_manager.add_to_context(
-                    reversion.default_revision_manager, file1,
-                    adapter.get_version_data(file1, VERSION_CHANGE))
-            else:
-                reversion.revision_context_manager.add_to_context(
-                    reversion.default_revision_manager, file1,
-                    adapter.get_version_data(file1))
-                # reload the instance from db
+            reversion.revision_context_manager.add_to_context(
+                reversion.default_revision_manager, file1,
+                adapter.get_version_data(file1))
+        # reload the instance from db
         file2 = FileModel.objects.all()[0]
         # delete the instance.
         file2.delete()

--- a/cms/tests/test_reversion_tests.py
+++ b/cms/tests/test_reversion_tests.py
@@ -9,7 +9,7 @@ from djangocms_text_ckeditor.models import Text
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core.files.uploadedfile import SimpleUploadedFile
-import reversion
+from reversion import revisions as reversion
 from reversion.models import Revision, Version
 
 from cms.models import Page, Title, Placeholder

--- a/cms/tests/test_reversion_tests.py
+++ b/cms/tests/test_reversion_tests.py
@@ -17,6 +17,7 @@ from cms.test_utils.testcases import CMSTestCase, TransactionCMSTestCase, URL_CM
     URL_CMS_PLUGIN_ADD, URL_CMS_PLUGIN_EDIT
 from cms.utils.reversion_hacks import Revision, reversion, Version
 
+
 class BasicReversionTestCase(CMSTestCase):
     def setUp(self):
         self.user = self._create_user("test", True, True)
@@ -95,9 +96,7 @@ class ReversionTestCase(TransactionCMSTestCase):
             self.assertEqual(response.status_code, 200)
 
             revert_url = history_url + "%s/" % version.pk
-            response = self.client.get(revert_url)
-            self.assertEqual(response.status_code, 200)
-            response = self.client.post("%s?language=en&" % revert_url, self.page_data)
+            response = self.client.post("%s?language=en&" % revert_url)
             self.assertRedirects(response, URL_CMS_PAGE_CHANGE % page.pk)
             # test for publisher_is_draft, published is set for both draft and
             # published page

--- a/cms/utils/helpers.py
+++ b/cms/utils/helpers.py
@@ -44,7 +44,7 @@ def make_revision_with_plugins(obj, user=None, message=None):
     Only add to revision if it is a draft.
     """
     from cms.utils.reversion_hacks import revision_context,  revision_manager
-
+    print("make revision")
     cls = obj.__class__
     if hasattr(revision_manager, '_registration_key_for_model'):
         model_key = revision_manager._registration_key_for_model(cls)

--- a/cms/utils/helpers.py
+++ b/cms/utils/helpers.py
@@ -40,7 +40,7 @@ def make_revision_with_plugins(obj, user=None, message=None):
     from cms.models.pluginmodel import CMSPlugin
     # we can safely import reversion - calls here always check for
     # reversion in installed_applications first
-    import reversion
+    from reversion import revisions as reversion
     if hasattr(reversion.models, 'VERSION_CHANGE'):
         from reversion.models import VERSION_CHANGE
     """

--- a/cms/utils/helpers.py
+++ b/cms/utils/helpers.py
@@ -44,7 +44,6 @@ def make_revision_with_plugins(obj, user=None, message=None):
     Only add to revision if it is a draft.
     """
     from cms.utils.reversion_hacks import revision_context,  revision_manager
-    print("make revision")
     cls = obj.__class__
     if hasattr(revision_manager, '_registration_key_for_model'):
         model_key = revision_manager._registration_key_for_model(cls)

--- a/cms/utils/helpers.py
+++ b/cms/utils/helpers.py
@@ -40,14 +40,10 @@ def make_revision_with_plugins(obj, user=None, message=None):
     from cms.models.pluginmodel import CMSPlugin
     # we can safely import reversion - calls here always check for
     # reversion in installed_applications first
-    from reversion import revisions as reversion
-    if hasattr(reversion.models, 'VERSION_CHANGE'):
-        from reversion.models import VERSION_CHANGE
     """
     Only add to revision if it is a draft.
     """
-    revision_manager = reversion.revision
-    revision_context = reversion.revision_context_manager
+    from cms.utils.reversion_hacks import revision_context,  revision_manager
 
     cls = obj.__class__
     if hasattr(revision_manager, '_registration_key_for_model'):
@@ -66,32 +62,20 @@ def make_revision_with_plugins(obj, user=None, message=None):
                 revision_context.set_comment(message)
             # add toplevel object to the revision
             adapter = revision_manager.get_adapter(obj.__class__)
-            if hasattr(reversion.models, 'VERSION_CHANGE'):
-                revision_context.add_to_context(revision_manager, obj, adapter.get_version_data(obj, VERSION_CHANGE))
-            else:
-                revision_context.add_to_context(revision_manager, obj, adapter.get_version_data(obj))
+            revision_context.add_to_context(revision_manager, obj, adapter.get_version_data(obj))
             # add placeholders to the revision
             for ph in obj.get_placeholders():
                 phadapter = revision_manager.get_adapter(ph.__class__)
-                if hasattr(reversion.models, 'VERSION_CHANGE'):
-                    revision_context.add_to_context(revision_manager, ph, phadapter.get_version_data(ph, VERSION_CHANGE))
-                else:
-                    revision_context.add_to_context(revision_manager, ph, phadapter.get_version_data(ph))
+                revision_context.add_to_context(revision_manager, ph, phadapter.get_version_data(ph))
             # add plugins and subclasses to the revision
             filters = {'placeholder__%s' % placeholder_relation: obj}
             for plugin in CMSPlugin.objects.filter(**filters):
                 plugin_instance, admin = plugin.get_plugin_instance()
                 if plugin_instance:
                     padapter = revision_manager.get_adapter(plugin_instance.__class__)
-                    if hasattr(reversion.models, 'VERSION_CHANGE'):
-                        revision_context.add_to_context(revision_manager, plugin_instance, padapter.get_version_data(plugin_instance, VERSION_CHANGE))
-                    else:
-                        revision_context.add_to_context(revision_manager, plugin_instance, padapter.get_version_data(plugin_instance))
+                    revision_context.add_to_context(revision_manager, plugin_instance, padapter.get_version_data(plugin_instance))
                 bpadapter = revision_manager.get_adapter(plugin.__class__)
-                if hasattr(reversion.models, 'VERSION_CHANGE'):
-                    revision_context.add_to_context(revision_manager, plugin, bpadapter.get_version_data(plugin, VERSION_CHANGE))
-                else:
-                    revision_context.add_to_context(revision_manager, plugin, bpadapter.get_version_data(plugin))
+                revision_context.add_to_context(revision_manager, plugin, bpadapter.get_version_data(plugin))
 
 
 def find_placeholder_relation(obj):

--- a/cms/utils/reversion_hacks.py
+++ b/cms/utils/reversion_hacks.py
@@ -1,6 +1,26 @@
 # -*- coding: utf-8 -*-
-from reversion import revisions as reversion
-from reversion.revisions import RegistrationError, VersionAdapter
+
+try:
+    from reversion import revisions as reversion
+    from reversion.admin import VersionAdmin as ModelAdmin, RollBackRevisionView  # NOQA
+    from reversion.models import Revision, Version  # NOQA
+    from reversion.revisions import create_revision, RegistrationError, VersionAdapter  # NOQA
+    from reversion.signals import post_revision_commit  # NOQA
+
+    revision_manager = reversion.default_revision_manager
+    revision_context = reversion.revision_context_manager
+except ImportError:
+    import reversion
+    from reversion import create_revision  # NOQA
+    from reversion.admin import VersionAdmin as ModelAdmin  # NOQA
+    from reversion.models import Revision, Version, post_revision_commit  # NOQA
+    from reversion.revisions import RegistrationError, VersionAdapter  # NOQA
+
+    revision_manager = reversion.revision
+    revision_context = reversion.revision_context_manager
+
+    class RollBackRevisionView(Exception):
+        pass
 
 
 def register_draft_only(model_class, fields, follow, format):
@@ -8,7 +28,7 @@ def register_draft_only(model_class, fields, follow, format):
     version of the reversion register function that only registers drafts and
     ignores public models
     """
-    revision_manager = reversion.revision
+
     if revision_manager.is_registered(model_class):
         raise RegistrationError(
             "%r has already been registered with Reversion." % model_class)

--- a/cms/utils/reversion_hacks.py
+++ b/cms/utils/reversion_hacks.py
@@ -2,19 +2,19 @@
 
 try:
     from reversion import revisions as reversion
-    from reversion.admin import VersionAdmin as ModelAdmin, RollBackRevisionView  # NOQA
-    from reversion.models import Revision, Version  # NOQA
-    from reversion.revisions import create_revision, RegistrationError, VersionAdapter  # NOQA
-    from reversion.signals import post_revision_commit  # NOQA
+    from reversion.admin import VersionAdmin as ModelAdmin, RollBackRevisionView  # NOQA  # nopyflakes
+    from reversion.models import Revision, Version  # NOQA  # nopyflakes
+    from reversion.revisions import create_revision, RegistrationError, VersionAdapter  # NOQA  # nopyflakes
+    from reversion.signals import post_revision_commit  # NOQA  # nopyflakes
 
     revision_manager = reversion.default_revision_manager
     revision_context = reversion.revision_context_manager
 except ImportError:
     import reversion
-    from reversion import create_revision  # NOQA
-    from reversion.admin import VersionAdmin as ModelAdmin  # NOQA
-    from reversion.models import Revision, Version, post_revision_commit  # NOQA
-    from reversion.revisions import RegistrationError, VersionAdapter  # NOQA
+    from reversion import create_revision  # NOQA  # nopyflakes
+    from reversion.admin import VersionAdmin as ModelAdmin  # NOQA  # nopyflakes
+    from reversion.models import Revision, Version, post_revision_commit  # NOQA  # nopyflakes
+    from reversion.revisions import RegistrationError, VersionAdapter  # NOQA  # nopyflakes
 
     revision_manager = reversion.revision
     revision_context = reversion.revision_context_manager

--- a/cms/utils/reversion_hacks.py
+++ b/cms/utils/reversion_hacks.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import reversion
+from reversion import revisions as reversion
 from reversion.revisions import RegistrationError, VersionAdapter
 
 

--- a/cms/utils/reversion_hacks.py
+++ b/cms/utils/reversion_hacks.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+# This large try / except is to account for reversion 1.10 (top) / 1.8 (bottom) support
+# This will go away in CMS 3.3 when only reversion 1.10 will be supported
 try:
     from reversion import revisions as reversion
     from reversion.admin import VersionAdmin as ModelAdmin, RollBackRevisionView  # NOQA  # nopyflakes

--- a/cms/utils/setup.py
+++ b/cms/utils/setup.py
@@ -13,8 +13,8 @@ def validate_dependencies():
         raise ImproperlyConfigured('django CMS requires django-treebeard. Please install it and add "treebeard" to INSTALLED_APPS.')
 
     if app_is_installed('reversion'):
-        from reversion.admin import VersionAdmin
-        if not hasattr(VersionAdmin, 'get_urls'):
+        from cms.utils.reversion_hacks import ModelAdmin
+        if not hasattr(ModelAdmin, 'get_urls'):
             raise ImproperlyConfigured('django CMS requires newer version of reversion (VersionAdmin must contain get_urls method)')
 
 

--- a/docs/how_to/install.rst
+++ b/docs/how_to/install.rst
@@ -84,10 +84,8 @@ File and image handling
 Revision management
 -------------------
 
-* `django-reversion`_ 1.8.X (with Django 1.6.X and Django 1.7.X) to support
-  versions of your content (If using a different Django version it is a good
-  idea to check the page `Compatible-Django-Versions`_ in the django-reversion
-  wiki in order to make sure that the package versions are compatible.)
+* `django-reversion`_ 1.8.X (Django 1.6) and 1.10 (Django 1.7+) to support
+  versions of your content
 
   .. note::
 

--- a/test_requirements/django-1.6.txt
+++ b/test_requirements/django-1.6.txt
@@ -1,9 +1,6 @@
 -r requirements_base.txt
 django>=1.6,<1.7
 South==1.0.2
-django-reversion<1.8.3
-django-classy-tags>=0.5
-django-sekizai>=0.7
-djangocms-text-ckeditor>=2.8.1
+django-reversion==1.8.7
 django-hvad==1.3
 django-debug-toolbar<=1.3.2

--- a/test_requirements/django-1.7.txt
+++ b/test_requirements/django-1.7.txt
@@ -1,6 +1,6 @@
 -r requirements_base.txt
 django>=1.7,<1.8
-django-reversion==1.10.0
+django-reversion==1.10,<1.11
 django-formtools
 django-hvad==1.4
 django-debug-toolbar<=1.4

--- a/test_requirements/django-1.7.txt
+++ b/test_requirements/django-1.7.txt
@@ -1,9 +1,6 @@
 -r requirements_base.txt
 django>=1.7,<1.8
-django-reversion>=1.8,<1.9
-django-classy-tags>=0.5
+django-reversion==1.10.0
 django-formtools
-django-sekizai>=0.7
-djangocms-text-ckeditor>=2.8.1
 django-hvad==1.4
 django-debug-toolbar<=1.4

--- a/test_requirements/django-1.8.txt
+++ b/test_requirements/django-1.8.txt
@@ -1,9 +1,6 @@
 -r requirements_base.txt
 Django>=1.8,<1.9
-django-reversion>=1.8,<1.9
-django-classy-tags>=0.6.1
+django-reversion==1.10.0
 django-formtools
-django-sekizai>=0.8.2
-djangocms-text-ckeditor>=2.8.1
 django-hvad==1.4
 django-debug-toolbar

--- a/test_requirements/django-1.8.txt
+++ b/test_requirements/django-1.8.txt
@@ -1,6 +1,6 @@
 -r requirements_base.txt
 Django>=1.8,<1.9
-django-reversion==1.10.0
+django-reversion==1.10,<1.11
 django-formtools
 django-hvad==1.4
 django-debug-toolbar

--- a/test_requirements/django-1.9.txt
+++ b/test_requirements/django-1.9.txt
@@ -1,6 +1,6 @@
 -r requirements_base.txt
 https://github.com/django/django/tarball/stable/1.9.x/django.tar.gz#egg=django
-django-reversion==1.10.0
+django-reversion==1.10,<1.11
 django-formtools
 django-hvad==1.5
 django-debug-toolbar

--- a/test_requirements/django-1.9.txt
+++ b/test_requirements/django-1.9.txt
@@ -1,10 +1,6 @@
 -r requirements_base.txt
 https://github.com/django/django/tarball/stable/1.9.x/django.tar.gz#egg=django
-django-reversion>=1.8,<1.9
-django-classy-tags>=0.6.1
-djangocms-text-ckeditor>=2.8.1
-django-hvad==1.5
+django-reversion==1.10.0
 django-formtools
-django-classy-tags>=0.6.1
-django-sekizai>=0.8.2
+django-hvad==1.5
 django-debug-toolbar

--- a/test_requirements/requirements_base.txt
+++ b/test_requirements/requirements_base.txt
@@ -2,13 +2,16 @@ coverage==3.7.1
 python-coveralls==2.5.0
 docopt==0.6.2
 unittest-xml-reporting==1.11.0
-Pillow==2.7.0
-html5lib>=0.90,!=0.9999,!=0.99999
+Pillow==3.0
+html5lib>0.99999
 django-treebeard==3.0
 argparse
 dj-database-url
 selenium
-djangocms-admin-style==0.2.7
+djangocms-admin-style>=1.0
+djangocms-text-ckeditor>=2.8.1
+django-sekizai>=0.9
+django-classy-tags>=0.7
 -e git+git://github.com/divio/djangocms-column.git#egg=djangocms-column
 -e git+git://github.com/divio/djangocms-style.git#egg=djangocms-style
 -e git+git://github.com/divio/djangocms-file.git#egg=djangocms-file


### PR DESCRIPTION
Slowly approaching to full compatibility.
Reversion logic has changed a lot: 1.8 & 1.9+ compatibiliy layer added, to be dropped in 3.3 when we drop Django 1.6/1.7 and can thus focus on reversion 1.10+ 

Fix #4784 
This is a blocker for #4812 (which is complete as far as Django 1.9 is involved)