### PR TITLE
fixes incorrect language on placeholder text for redirect field

### DIFF
--- a/cms/forms/fields.py
+++ b/cms/forms/fields.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-import six
-
 from django import forms
 from django.contrib.admin.widgets import RelatedFieldWidgetWrapper
 from django.forms.fields import EMPTY_VALUES
@@ -86,5 +84,5 @@ class PageSmartLinkField(forms.CharField):
 
     def widget_attrs(self, widget):
         attrs = super(PageSmartLinkField, self).widget_attrs(widget)
-        attrs.update({'placeholder_text': six.text_type(self.placeholder_text)})
+        attrs.update({'placeholder_text': self.placeholder_text})
         return attrs


### PR DESCRIPTION
``widget_attrs`` is called when the field is instantiated which means it picks up the language of the project (``LANGUAGE_CODE``) instead of the thread language.