### PR TITLE
Fix ExtensionToolbar when language is removed but titles still exists…

### DIFF
--- a/cms/extensions/toolbar.py
+++ b/cms/extensions/toolbar.py
@@ -2,7 +2,7 @@
 from cms.utils.urlutils import admin_reverse
 from cms.api import get_page_draft
 from cms.toolbar_base import CMSToolbar
-from cms.utils import get_cms_setting
+from cms.utils import get_cms_setting, get_language_list
 from cms.utils.permissions import has_page_change_permission
 from django.core.urlresolvers import NoReverseMatch
 
@@ -125,7 +125,7 @@ class ExtensionToolbar(CMSToolbar):
         if language:
             titles = page.get_title_obj(language),
         else:
-            titles = page.title_set.all()
+            titles = page.title_set.filter(language__in=get_language_list(page.site_id))
         # Titles
         for title in titles:
             try:


### PR DESCRIPTION
…. See nephila/djangocms-page-meta#34