### PR TITLE
Prevent duplicate slugs via wizard

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -107,7 +107,7 @@ to our `mailing list <https://groups.google.com/forum/#!forum/django-cms>`_.
 Commercial support
 ******************
 
-This project is backed by `Divio <http://divio.ch/en/commercial-support/>`_.
+This project is backed by `Divio <https://github.com/divio/django-cms#commercial-support>`_.
 If you need help implementing or hosting django CMS, please contact us:
 sales@divio.com.
 

--- a/README.rst
+++ b/README.rst
@@ -107,7 +107,7 @@ to our `mailing list <https://groups.google.com/forum/#!forum/django-cms>`_.
 Commercial support
 ******************
 
-This project is backed by `Divio <https://github.com/divio/django-cms#commercial-support>`_.
+This project is backed by `Divio <http://www.divio.com/>`_.
 If you need help implementing or hosting django CMS, please contact us:
 sales@divio.com.
 

--- a/cms/forms/wizards.py
+++ b/cms/forms/wizards.py
@@ -187,9 +187,11 @@ class CreateCMSPageForm(BaseCMSPageForm):
             parent = None
 
         slug = self.cleaned_data['slug']
-        if not slug:
-            title = self.cleaned_data['title']
-            slug = generate_valid_slug(title, parent, self.language_code)
+        if slug:
+            starting_point = slug
+        else:
+            starting_point = self.cleaned_data['title']
+        slug = generate_valid_slug(starting_point, parent, self.language_code)
         if not slug:
             raise forms.ValidationError("Please provide a valid slug.")
         return slug


### PR DESCRIPTION
Currently, the wizards will auto-generate a unique-slug, unless one is provided, then it will use that verbatim. This PR will force even a provided slug to be unique.