### PR TITLE
Fixes wizard not respecting cms_permissions setting

### DIFF
--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -498,7 +498,7 @@ class PageAdmin(PlaceholderAdminMixin, ModelAdmin):
         Return true if the current user has permission to add a new page.
         """
         if get_cms_setting('PERMISSION'):
-            return permissions.has_page_add_permission(request)
+            return permissions.has_page_add_permission_from_request(request)
         return super(PageAdmin, self).has_add_permission(request)
 
     def has_change_permission(self, request, obj=None):

--- a/cms/cms_toolbars.py
+++ b/cms/cms_toolbars.py
@@ -251,6 +251,7 @@ class BasicToolbar(CMSToolbar):
 
 @toolbar_pool.register
 class PageToolbar(CMSToolbar):
+    _changed_admin_menu = None
     watch_models = [Page]
 
     # Helpers
@@ -443,7 +444,7 @@ class PageToolbar(CMSToolbar):
                                                 question=question % name, on_success=self.toolbar.REFRESH_PAGE)
 
     def change_admin_menu(self):
-        if self.has_page_change_permission():
+        if not self._changed_admin_menu and self.has_page_change_permission():
             admin_menu = self.toolbar.get_or_create_menu(ADMIN_MENU_IDENTIFIER)
             url = admin_reverse('cms_page_changelist')  # cms page admin
             params = {'language': self.toolbar.language}
@@ -451,6 +452,8 @@ class PageToolbar(CMSToolbar):
                 params['page_id'] = self.page.pk
             url = add_url_parameters(url, params)
             admin_menu.add_sideframe_item(_('Pages'), url=url, position=0)
+            # Used to prevent duplicates
+            self._changed_admin_menu = True
 
     def add_page_menu(self):
         if self.page and self.has_page_change_permission():

--- a/cms/cms_wizards.py
+++ b/cms/cms_wizards.py
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
 
 from django.utils.translation import ugettext_lazy as _
-from django.contrib.auth import get_permission_codename
 from django.contrib.sites.models import Site
 
-from cms.models import Page, GlobalPagePermission
+from cms.models import Page
 from cms.utils import permissions
 
 from .wizards.wizard_pool import wizard_pool

--- a/cms/forms/wizards.py
+++ b/cms/forms/wizards.py
@@ -196,7 +196,7 @@ class CreateCMSPageForm(BaseCMSPageForm):
 
     def save(self, **kwargs):
         from cms.api import create_page, add_plugin
-        from cms.cms_wizards import user_has_page_add_permission
+        from cms.utils.permissions import has_page_add_permission
 
         # Check to see if this user has permissions to make this page. We've
         # already checked this when producing a list of wizard entries, but this
@@ -220,9 +220,9 @@ class CreateCMSPageForm(BaseCMSPageForm):
 
         # Before we do this, verify this user has perms to do so.
         if not (self.user.is_superuser or
-                user_has_page_add_permission(self.user, self.page,
+                has_page_add_permission(self.user, self.page,
                                              position=position,
-                                             site=self.page.site_id)):
+                                             site=self.page.site)):
             raise NoPermissionsException(
                 _(u"User does not have permission to add page."))
 

--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -1048,21 +1048,25 @@ class Page(six.with_metaclass(PageMetaClass, MP_Node)):
         return request.user.has_perm(codename)
 
     def has_change_permission(self, request, user=None):
-        opts = self._meta
+        from cms.utils.permissions import has_auth_page_permission
+
         if not user:
             user = request.user
+
         if user.is_superuser:
             return True
-        return (user.has_perm(opts.app_label + '.' + get_permission_codename('change', opts))
+        return (has_auth_page_permission(user, action='change')
                 and self.has_generic_permission(request, "change"))
 
     def has_delete_permission(self, request, user=None):
-        opts = self._meta
+        from cms.utils.permissions import has_auth_page_permission
+
         if not user:
             user = request.user
+
         if user.is_superuser:
             return True
-        return (user.has_perm(opts.app_label + '.' + get_permission_codename('delete', opts))
+        return (has_auth_page_permission(user, action='delete')
                 and self.has_generic_permission(request, "delete"))
 
     def has_publish_permission(self, request, user=None):

--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -3,7 +3,6 @@ from logging import getLogger
 from os.path import join
 
 from django.conf import settings
-from django.contrib.auth import get_permission_codename
 from django.contrib.sites.models import Site
 from django.core.exceptions import ValidationError
 from django.core.urlresolvers import reverse

--- a/cms/tests/test_permmod.py
+++ b/cms/tests/test_permmod.py
@@ -34,7 +34,7 @@ from cms.test_utils.util.context_managers import disable_logger
 from cms.test_utils.util.fuzzy_int import FuzzyInt
 from cms.utils.i18n import force_language
 from cms.utils.page_resolver import get_page_from_path
-from cms.utils.permissions import (has_page_add_permission,
+from cms.utils.permissions import (has_page_add_permission_from_request,
                                    has_page_change_permission,
                                    has_generic_permission)
 
@@ -1163,10 +1163,10 @@ class GlobalPermissionTests(CMSTestCase):
             # for all users, they should have access to site 1
             request = RequestFactory().get(path='/', data={'site__exact': 1})
             # we need a session attribute for current_site(request), which is
-            # used by has_page_add_permission and has_page_change_permission
+            # used by has_page_add_permission_from_request and has_page_change_permission
             request.session = {}
             for user in USERS:
-                # has_page_add_permission and has_page_change_permission both test
+                # has_page_add_permission_from_request and has_page_change_permission both test
                 # for this explicitly, to see if it's a superuser.
                 request.user = user
                 # Note, the query count is inflated by doing additional lookups
@@ -1174,7 +1174,7 @@ class GlobalPermissionTests(CMSTestCase):
                 with self.assertNumQueries(FuzzyInt(6, 7)):
                     # PageAdmin swaps out the methods called for permissions
                     # if the setting is true, it makes use of cms.utils.permissions
-                    self.assertTrue(has_page_add_permission(request))
+                    self.assertTrue(has_page_add_permission_from_request(request))
                     self.assertTrue(has_page_change_permission(request))
                     # internally this calls PageAdmin.has_[add|change|delete]_permission()
                     self.assertEqual({'add': True, 'change': True, 'delete': False},
@@ -1190,14 +1190,14 @@ class GlobalPermissionTests(CMSTestCase):
             with self.assertNumQueries(FuzzyInt(11, 20)):
                 # this user shouldn't have access to site 2
                 request.user = USERS[1]
-                self.assertTrue(not has_page_add_permission(request))
+                self.assertTrue(not has_page_add_permission_from_request(request))
                 self.assertTrue(not has_page_change_permission(request))
                 self.assertEqual({'add': False, 'change': False, 'delete': False},
                                  site._registry[Page].get_model_perms(request))
                 # but, going back to the first user, they should.
                 request = RequestFactory().get('/', data={'site__exact': 2})
                 request.user = USERS[0]
-                self.assertTrue(has_page_add_permission(request))
+                self.assertTrue(has_page_add_permission_from_request(request))
                 self.assertTrue(has_page_change_permission(request))
                 self.assertEqual({'add': True, 'change': True, 'delete': False},
                                  site._registry[Page].get_model_perms(request))
@@ -1208,5 +1208,5 @@ class GlobalPermissionTests(CMSTestCase):
         request = RequestFactory().get('/', data={'target': page.pk})
         request.session = {}
         request.user = user
-        has_perm = has_page_add_permission(request)
+        has_perm = has_page_add_permission_from_request(request)
         self.assertFalse(has_perm)

--- a/cms/tests/test_toolbar.py
+++ b/cms/tests/test_toolbar.py
@@ -146,7 +146,7 @@ class ToolbarTests(ToolbarTestBase):
         # Logo + admin-menu + logout
         self.assertEqual(len(items), 3, items)
         admin_items = toolbar.get_or_create_menu(ADMIN_MENU_IDENTIFIER, 'Test').get_items()
-        self.assertEqual(len(admin_items), 9, admin_items)
+        self.assertEqual(len(admin_items), 10, admin_items)
 
     def test_no_page_superuser(self):
         request = self.get_page_request(None, self.get_superuser(), '/')
@@ -157,7 +157,7 @@ class ToolbarTests(ToolbarTestBase):
         # Logo + edit-mode + admin-menu + logout
         self.assertEqual(len(items), 3)
         admin_items = toolbar.get_or_create_menu(ADMIN_MENU_IDENTIFIER, 'Test').get_items()
-        self.assertEqual(len(admin_items), 10, admin_items)
+        self.assertEqual(len(admin_items), 11, admin_items)
 
     def test_anon(self):
         page = create_page('test', 'nav_playground.html', 'en')
@@ -466,7 +466,7 @@ class ToolbarTests(ToolbarTestBase):
         toolbar.post_template_populate()
         admin = toolbar.get_left_items()[0]
         lang = toolbar.get_left_items()[1]
-        self.assertEqual(len(admin.get_items()), 12)
+        self.assertEqual(len(admin.get_items()), 13)
         self.assertEqual(len(lang.get_items()), len(get_language_tuple(1)))
 
     @override_settings(CMS_PLACEHOLDER_CONF={'col_left': {'name': 'PPPP'}})

--- a/cms/utils/admin.py
+++ b/cms/utils/admin.py
@@ -105,7 +105,7 @@ def render_admin_menu_item(request, page, template=None, language=None):
     from cms.utils import permissions
     languages = get_language_list(page.site_id)
     context = {
-        'has_add_permission': permissions.has_page_add_permission(request),
+        'has_add_permission': permissions.has_page_add_permission_from_request(request),
         'site_languages': languages,
     }
     filtered = 'filtered' in request.GET or 'filtered' in request.POST

--- a/cms/utils/permissions.py
+++ b/cms/utils/permissions.py
@@ -121,10 +121,13 @@ def has_page_add_permission_from_request(request):
     position = request.GET.get('position', None)
     target_page_id = request.GET.get('target', None)
 
-    try:
-        target = Page.objects.get(pk=target_page_id)
-    except Page.DoesNotExist:
-        return False
+    if target_page_id:
+        try:
+            target = Page.objects.get(pk=target_page_id)
+        except Page.DoesNotExist:
+            return False
+    else:
+        target = None
 
     has_add_permission = has_page_add_permission(
         user=request.user,

--- a/cms/utils/permissions.py
+++ b/cms/utils/permissions.py
@@ -151,7 +151,7 @@ def has_page_change_permission(request):
     user = request.user
     site = current_site(request)
     global_change_perm = GlobalPagePermission.objects.user_has_change_permission(
-        request.user, site).exists()
+        user, site).exists()
     return user.is_superuser or (
         has_auth_page_permission(user, action='change')
         and global_change_perm or has_any_page_change_permissions(request))

--- a/cms/utils/permissions.py
+++ b/cms/utils/permissions.py
@@ -123,6 +123,22 @@ def has_any_page_change_permissions(request):
     ).exists()
 
 
+def get_model_permission_codename(model, action):
+    opts = model._meta
+    return opts.app_label + '.' + get_permission_codename(action, opts)
+
+
+def has_auth_page_permission(user, action):
+    """
+    Returns True if the user is a superuser or has
+    the cms.page {action} permission set via django's permission model.
+    """
+    if not user.is_superuser:
+        permission = get_model_permission_codename(Page, action=action)
+        return user.has_perm(permission)
+    return True
+
+
 def has_page_change_permission(request):
     """
     Return true if the current user has permission to change this page.
@@ -132,12 +148,12 @@ def has_page_change_permission(request):
     """
     from cms.utils.helpers import current_site
 
-    opts = Page._meta
+    user = request.user
     site = current_site(request)
     global_change_perm = GlobalPagePermission.objects.user_has_change_permission(
         request.user, site).exists()
-    return request.user.is_superuser or (
-        request.user.has_perm(opts.app_label + '.' + get_permission_codename('change', opts))
+    return user.is_superuser or (
+        has_auth_page_permission(user, action='change')
         and global_change_perm or has_any_page_change_permissions(request))
 
 


### PR DESCRIPTION
Fixes #4905

Based off #4902

* Refactored cms permission utilities to be more dry.
* Have cms wizard use these utilities instead of using it's own.
* Start split between function and function_from_request