### PR TITLE
Use session DB backend in manage.py to ease test

### DIFF
--- a/cms/tests/test_cache.py
+++ b/cms/tests/test_cache.py
@@ -64,12 +64,12 @@ class CacheTestCase(CMSTestCase):
             'django.middleware.cache.FetchFromCacheMiddleware'
         ]
         middleware = [mw for mw in settings.MIDDLEWARE_CLASSES if mw not in exclude]
-        with self.settings(CMS_PAGE_CACHE=False, MIDDLEWARE_CLASSES=middleware, SESSION_ENGINE="django.contrib.sessions.backends.cache",):
+        with self.settings(CMS_PAGE_CACHE=False, MIDDLEWARE_CLASSES=middleware):
             with self.assertNumQueries(FuzzyInt(13, 17)):
                 self.client.get('/en/')
             with self.assertNumQueries(FuzzyInt(5, 9)):
                 self.client.get('/en/')
-        with self.settings(CMS_PAGE_CACHE=False, MIDDLEWARE_CLASSES=middleware, CMS_PLACEHOLDER_CACHE=False, SESSION_ENGINE="django.contrib.sessions.backends.cache",):
+        with self.settings(CMS_PAGE_CACHE=False, MIDDLEWARE_CLASSES=middleware, CMS_PLACEHOLDER_CACHE=False):
             with self.assertNumQueries(FuzzyInt(7, 11)):
                 self.client.get('/en/')
 
@@ -135,7 +135,7 @@ class CacheTestCase(CMSTestCase):
         ]
         mw_classes = [mw for mw in settings.MIDDLEWARE_CLASSES if mw not in exclude]
 
-        with self.settings(MIDDLEWARE_CLASSES=mw_classes, SESSION_ENGINE="django.contrib.sessions.backends.cache",):
+        with self.settings(MIDDLEWARE_CLASSES=mw_classes):
 
             # Silly to do these tests if this setting isn't True
             page_cache_setting = get_cms_setting('PAGE_CACHE')
@@ -212,7 +212,7 @@ class CacheTestCase(CMSTestCase):
         ]
         mw_classes = [mw for mw in settings.MIDDLEWARE_CLASSES if mw not in exclude]
 
-        with self.settings(MIDDLEWARE_CLASSES=mw_classes, SESSION_ENGINE="django.contrib.sessions.backends.cache",):
+        with self.settings(MIDDLEWARE_CLASSES=mw_classes):
 
             # Silly to do these tests if this setting isn't True
             page_cache_setting = get_cms_setting('PAGE_CACHE')

--- a/cms/tests/test_cache.py
+++ b/cms/tests/test_cache.py
@@ -64,12 +64,12 @@ class CacheTestCase(CMSTestCase):
             'django.middleware.cache.FetchFromCacheMiddleware'
         ]
         middleware = [mw for mw in settings.MIDDLEWARE_CLASSES if mw not in exclude]
-        with self.settings(CMS_PAGE_CACHE=False, MIDDLEWARE_CLASSES=middleware):
+        with self.settings(CMS_PAGE_CACHE=False, MIDDLEWARE_CLASSES=middleware, SESSION_ENGINE="django.contrib.sessions.backends.cache",):
             with self.assertNumQueries(FuzzyInt(13, 17)):
                 self.client.get('/en/')
             with self.assertNumQueries(FuzzyInt(5, 9)):
                 self.client.get('/en/')
-        with self.settings(CMS_PAGE_CACHE=False, MIDDLEWARE_CLASSES=middleware, CMS_PLACEHOLDER_CACHE=False):
+        with self.settings(CMS_PAGE_CACHE=False, MIDDLEWARE_CLASSES=middleware, CMS_PLACEHOLDER_CACHE=False, SESSION_ENGINE="django.contrib.sessions.backends.cache",):
             with self.assertNumQueries(FuzzyInt(7, 11)):
                 self.client.get('/en/')
 
@@ -135,7 +135,7 @@ class CacheTestCase(CMSTestCase):
         ]
         mw_classes = [mw for mw in settings.MIDDLEWARE_CLASSES if mw not in exclude]
 
-        with self.settings(MIDDLEWARE_CLASSES=mw_classes):
+        with self.settings(MIDDLEWARE_CLASSES=mw_classes, SESSION_ENGINE="django.contrib.sessions.backends.cache",):
 
             # Silly to do these tests if this setting isn't True
             page_cache_setting = get_cms_setting('PAGE_CACHE')
@@ -212,7 +212,7 @@ class CacheTestCase(CMSTestCase):
         ]
         mw_classes = [mw for mw in settings.MIDDLEWARE_CLASSES if mw not in exclude]
 
-        with self.settings(MIDDLEWARE_CLASSES=mw_classes):
+        with self.settings(MIDDLEWARE_CLASSES=mw_classes, SESSION_ENGINE="django.contrib.sessions.backends.cache",):
 
             # Silly to do these tests if this setting isn't True
             page_cache_setting = get_cms_setting('PAGE_CACHE')

--- a/manage.py
+++ b/manage.py
@@ -183,7 +183,7 @@ if __name__ == '__main__':
                 'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
             }
         },
-        SESSION_ENGINE="django.contrib.sessions.backends.cache",
+        SESSION_ENGINE="django.contrib.sessions.backends.db",
         CACHE_MIDDLEWARE_ANONYMOUS_ONLY=True,
         DEBUG=True,
         DATABASE_SUPPORTS_TRANSACTIONS=True,

--- a/manage.py
+++ b/manage.py
@@ -166,6 +166,10 @@ if __name__ == '__main__':
                     return 'notmigrations'
 
             dynamic_configs['MIGRATION_MODULES'] = DisableMigrations()
+    if 'test' in sys.argv:
+        SESSION_ENGINE = "django.contrib.sessions.backends.cache"
+    else:
+        SESSION_ENGINE = "django.contrib.sessions.backends.db"
 
     app_manage.main(
         ['cms', 'menus'],
@@ -183,7 +187,7 @@ if __name__ == '__main__':
                 'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
             }
         },
-        SESSION_ENGINE="django.contrib.sessions.backends.db",
+        SESSION_ENGINE=SESSION_ENGINE,
         CACHE_MIDDLEWARE_ANONYMOUS_ONLY=True,
         DEBUG=True,
         DATABASE_SUPPORTS_TRANSACTIONS=True,


### PR DESCRIPTION
cache backend is pretty frustrating for testing the cms using the integrated manage.py. This changes the session backend to db