### PR TITLE
Reimplement  #4192 

### DIFF
--- a/cms/middleware/toolbar.py
+++ b/cms/middleware/toolbar.py
@@ -51,11 +51,10 @@ class ToolbarMiddleware(object):
     Middleware to set up CMS Toolbar.
     """
 
-    def is_cms_request(self,request):
-        cms_app_name = get_cms_setting('APP_NAME')
+    def is_cms_request(self, request):
         toolbar_hide = get_cms_setting('TOOLBAR_HIDE')
 
-        if not toolbar_hide or not cms_app_name:
+        if not toolbar_hide:
             return True
 
         try:
@@ -63,8 +62,7 @@ class ToolbarMiddleware(object):
         except:
             return False
 
-        return match.app_name == cms_app_name
-
+        return match.app_name in ('pages-root', 'pages-details-by-slug')
 
     def process_request(self, request):
         """

--- a/cms/test_utils/project/nonroot_urls.py
+++ b/cms/test_utils/project/nonroot_urls.py
@@ -15,7 +15,7 @@ urlpatterns = [
 
 urlpatterns += i18n_patterns('',
     url(r'^admin/', include(admin.site.urls)),
-    url(r'^content/', include('cms.urls', app_name=get_cms_setting('APP_NAME'))),
+    url(r'^content/', include('cms.urls')),
 )
 
 

--- a/cms/tests/test_toolbar.py
+++ b/cms/tests/test_toolbar.py
@@ -94,36 +94,38 @@ class ToolbarTestBase(CMSTestCase):
 
 @override_settings(ROOT_URLCONF='cms.test_utils.project.nonroot_urls')
 class ToolbarMiddlewareTest(ClearURLs, ToolbarTestBase):
-    @override_settings(CMS_APP_NAME=None)
     @override_settings(CMS_TOOLBAR_HIDE=False)
     def test_no_app_setted_show_toolbar_in_non_cms_urls(self):
         request = self.get_page_request(None, self.get_anon(), '/')
         self.assertTrue(hasattr(request, 'toolbar'))
 
-    @override_settings(CMS_APP_NAME=None)
     @override_settings(CMS_TOOLBAR_HIDE=False)
     def test_no_app_setted_show_toolbar_in_cms_urls(self):
         page = create_page('foo', 'col_two.html', 'en', published=True)
         request = self.get_page_request(page, self.get_anon())
         self.assertTrue(hasattr(request, 'toolbar'))
 
-    @override_settings(CMS_APP_NAME='cms')
     @override_settings(CMS_TOOLBAR_HIDE=False)
     def test_app_setted_hide_toolbar_in_non_cms_urls_toolbar_hide_unsetted(self):
         request = self.get_page_request(None, self.get_anon(), '/')
         self.assertTrue(hasattr(request, 'toolbar'))
 
-    @override_settings(CMS_APP_NAME='cms')
     @override_settings(CMS_TOOLBAR_HIDE=True)
     def test_app_setted_hide_toolbar_in_non_cms_urls(self):
         request = self.get_page_request(None, self.get_anon(), '/')
         self.assertFalse(hasattr(request, 'toolbar'))
 
-    @override_settings(CMS_APP_NAME='cms')
     def test_app_setted_show_toolbar_in_cms_urls(self):
         page = create_page('foo', 'col_two.html', 'en', published=True)
         request = self.get_page_request(page, self.get_anon())
         self.assertTrue(hasattr(request, 'toolbar'))
+
+    @override_settings(CMS_TOOLBAR_HIDE=True)
+    def test_app_setted_hide_toolbar_in_cms_urls(self):
+        page = create_page('foo', 'col_two.html', 'en', published=True)
+        page = create_page('foo', 'col_two.html', 'en', published=True, parent=page)
+        request = self.get_page_request(page, self.get_anon())
+        self.assertFalse(hasattr(request, 'toolbar'))
 
 
 @override_settings(CMS_PERMISSION=False)

--- a/cms/utils/conf.py
+++ b/cms/utils/conf.py
@@ -62,7 +62,6 @@ DEFAULTS = {
     'TOOLBAR_URL__BUILD': 'build',
     'TOOLBAR_URL__DISABLE': 'toolbar_off',
     'ADMIN_NAMESPACE': 'admin',
-    'APP_NAME': None,
     'TOOLBAR_HIDE': False,
     'WIZARD_DEFAULT_TEMPLATE': constants.TEMPLATE_INHERITANCE_MAGIC,
     'WIZARD_CONTENT_PLUGIN': 'TextPlugin',

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -975,14 +975,8 @@ default
     ``False``
 
 If True, the toolbar is hidden in the pages out django CMS.
-To determine the internal url of django cms, you need to assign CMS_APP_NAME to use when you include ``'cms.urls'``
 
-Example::
-
-    urlpatterns += i18n_patterns('',
-        url(r'^admin/', include(admin.site.urls)),
-        url(r'^content/', include('cms.urls', app_name=settings.CMS_APP_NAME)),
-    )
+.. versionchanged:: 3.2.1: CMS_APP_NAME has been removed as it's not required anymore.
 
 
 CMS_DEFAULT_X_FRAME_OPTIONS


### PR DESCRIPTION
Remove CMS_APP_NAME
Implement the check of #4192 by checking the view names

The previous solution was quite tricky in 1.9. This implementation is a bit more simplistic but it's easier to maintain
If we'll decide to use appname for cms itself, this must be used everywhere but imply a lot of changes