### PR TITLE
Revision issues with placeholders from multiple sources

### DIFF
--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -604,6 +604,7 @@ class PageAdmin(PlaceholderAdminMixin, ModelAdmin):
             self.cleanup_history(placeholder.page)
             helpers.make_revision_with_plugins(placeholder.page, request.user, message)
 
+    @create_revision()
     def post_copy_plugins(self, request, source_placeholder, target_placeholder, plugins):
         page = target_placeholder.page
         if page and is_installed('reversion'):
@@ -613,9 +614,9 @@ class PageAdmin(PlaceholderAdminMixin, ModelAdmin):
 
     def post_edit_plugin(self, request, plugin):
         page = plugin.placeholder.page
-        if page:
-            # if reversion is installed, save version of the page plugins
-            if is_installed('reversion') and page:
+
+        # if reversion is installed, save version of the page plugins
+        if page and is_installed('reversion'):
                 plugin_name = force_text(plugin_pool.get_plugin(plugin.plugin_type).name)
                 message = _(
                     u"%(plugin_name)s plugin edited at position %(position)s in %(placeholder)s") % {
@@ -626,11 +627,18 @@ class PageAdmin(PlaceholderAdminMixin, ModelAdmin):
                 self.cleanup_history(page)
                 helpers.make_revision_with_plugins(page, request.user, message)
 
+    @create_revision()
     def post_move_plugin(self, request, source_placeholder, target_placeholder, plugin):
-        page = target_placeholder.page
+        # order matters.
+        # We give priority to the target page but fallback to the source.
+        # This comes into play when moving plugins between static placeholders
+        # and non static placeholders.
+        page = target_placeholder.page or source_placeholder.page
+
         if page and is_installed('reversion'):
+            message = _(u"Moved plugins to %(placeholder)s") % {'placeholder': target_placeholder}
             self.cleanup_history(page)
-            helpers.make_revision_with_plugins(page, request.user, _(u"Plugins were moved"))
+            helpers.make_revision_with_plugins(page, request.user, message)
 
     def post_delete_plugin(self, request, plugin):
         plugin_name = force_text(plugin_pool.get_plugin(plugin.plugin_type).name)
@@ -1414,17 +1422,9 @@ class PageAdmin(PlaceholderAdminMixin, ModelAdmin):
         with create_revision():
             return super(PageAdmin, self).add_plugin(*args, **kwargs)
 
-    def copy_plugins(self, *args, **kwargs):
-        with create_revision():
-            return super(PageAdmin, self).copy_plugins(*args, **kwargs)
-
     def edit_plugin(self, *args, **kwargs):
         with create_revision():
             return super(PageAdmin, self).edit_plugin(*args, **kwargs)
-
-    def move_plugin(self, *args, **kwargs):
-        with create_revision():
-            return super(PageAdmin, self).move_plugin(*args, **kwargs)
 
     def delete_plugin(self, *args, **kwargs):
         with create_revision():

--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -596,6 +596,7 @@ class PageAdmin(PlaceholderAdminMixin, ModelAdmin):
                 return False
         return True
 
+    @create_revision()
     def post_add_plugin(self, request, placeholder, plugin):
         if is_installed('reversion') and placeholder.page:
             plugin_name = force_text(plugin_pool.get_plugin(plugin.plugin_type).name)
@@ -612,6 +613,7 @@ class PageAdmin(PlaceholderAdminMixin, ModelAdmin):
             self.cleanup_history(page)
             helpers.make_revision_with_plugins(page, request.user, message)
 
+    @create_revision()
     def post_edit_plugin(self, request, plugin):
         page = plugin.placeholder.page
 
@@ -640,6 +642,7 @@ class PageAdmin(PlaceholderAdminMixin, ModelAdmin):
             self.cleanup_history(page)
             helpers.make_revision_with_plugins(page, request.user, message)
 
+    @create_revision()
     def post_delete_plugin(self, request, plugin):
         plugin_name = force_text(plugin_pool.get_plugin(plugin.plugin_type).name)
         page = plugin.placeholder.page
@@ -654,6 +657,7 @@ class PageAdmin(PlaceholderAdminMixin, ModelAdmin):
                 self.cleanup_history(page)
                 helpers.make_revision_with_plugins(page, request.user, comment)
 
+    @create_revision()
     def post_clear_placeholder(self, request, placeholder):
         page = placeholder.page
         if page:
@@ -1417,23 +1421,6 @@ class PageAdmin(PlaceholderAdminMixin, ModelAdmin):
             return HttpResponse(json.dumps(results), content_type='application/json')
         else:
             return HttpResponseForbidden()
-
-    def add_plugin(self, *args, **kwargs):
-        with create_revision():
-            return super(PageAdmin, self).add_plugin(*args, **kwargs)
-
-    def edit_plugin(self, *args, **kwargs):
-        with create_revision():
-            return super(PageAdmin, self).edit_plugin(*args, **kwargs)
-
-    def delete_plugin(self, *args, **kwargs):
-        with create_revision():
-            return super(PageAdmin, self).delete_plugin(*args, **kwargs)
-
-    def clear_placeholder(self, *args, **kwargs):
-        with create_revision():
-            return super(PageAdmin, self).clear_placeholder(*args, **kwargs)
-
 
 
 admin.site.register(Page, PageAdmin)

--- a/cms/admin/placeholderadmin.py
+++ b/cms/admin/placeholderadmin.py
@@ -383,7 +383,8 @@ class PlaceholderAdminMixin(object):
         # informed of the operation.
         target_placeholder_admin = self._get_attached_admin(target_placeholder)
 
-        if target_placeholder_admin:
+        if (target_placeholder_admin and
+                target_placeholder_admin.model != self.model):
             target_placeholder_admin.post_copy_plugins(
                 request,
                 source_placeholder=source_placeholder,
@@ -521,14 +522,18 @@ class PlaceholderAdminMixin(object):
 
         if move_a_copy:  # "paste"
             if plugin.plugin_type == "PlaceholderPlugin":
-                inst, _plugin = plugin.get_plugin_instance()
-                source_plugins = inst.placeholder_ref.get_plugins()
-                new_plugins = copy_plugins.copy_plugins_to(
-                    source_plugins, placeholder, language)
+                parent_id = None
+                inst = plugin.get_plugin_instance()[0]
+                plugins = inst.placeholder_ref.get_plugins()
             else:
-                source_plugins = [plugin] + list(plugin.get_descendants())
-                new_plugins = copy_plugins.copy_plugins_to(
-                    source_plugins, placeholder, language, parent_id)
+                plugins = [plugin] + list(plugin.get_descendants())
+
+            new_plugins = copy_plugins.copy_plugins_to(
+                plugins,
+                placeholder,
+                language,
+                parent_plugin_id=parent_id,
+            )
 
             top_plugins = []
             top_parent = new_plugins[0][0].parent_id
@@ -583,15 +588,15 @@ class PlaceholderAdminMixin(object):
                 plugin.save()
                 plugin = plugin.move(sibling, pos='right')
 
+            plugins = [plugin] + list(plugin.get_descendants())
+
             # Don't neglect the children
-            for child in [plugin] + list(plugin.get_descendants()):
+            for child in plugins:
                 child.placeholder = placeholder
                 child.language = language
                 child.save()
 
         reorder_plugins(placeholder, parent_id, language, order)
-
-        self.post_move_plugin(request, source_placeholder, placeholder, plugin)
 
         # When this is executed we are in the admin class of the source placeholder
         # It can be a page or a model with a placeholder field.
@@ -601,13 +606,28 @@ class PlaceholderAdminMixin(object):
         # informed of the operation.
         target_placeholder_admin = self._get_attached_admin(placeholder)
 
-        if target_placeholder_admin:
-            target_placeholder_admin.post_move_plugin(
-                request,
-                source_placeholder=source_placeholder,
-                target_placeholder=placeholder,
-                plugins=plugin,
-            )
+        if move_a_copy:  # "paste"
+            self.post_copy_plugins(request, source_placeholder, placeholder, plugins)
+
+            if (target_placeholder_admin and
+                    target_placeholder_admin.model != self.model):
+                target_placeholder_admin.post_copy_plugins(
+                    request,
+                    source_placeholder=source_placeholder,
+                    target_placeholder=placeholder,
+                    plugins=plugins,
+                )
+        else:
+            self.post_move_plugin(request, source_placeholder, placeholder, plugin)
+
+            if (target_placeholder_admin and
+                    target_placeholder_admin.model != self.model):
+                target_placeholder_admin.post_move_plugin(
+                    request,
+                    source_placeholder=source_placeholder,
+                    target_placeholder=placeholder,
+                    plugin=plugin,
+                )
 
         try:
             language = request.toolbar.toolbar_language

--- a/cms/admin/placeholderadmin.py
+++ b/cms/admin/placeholderadmin.py
@@ -145,6 +145,14 @@ class FrontendEditableAdminMixin(object):
 
 
 class PlaceholderAdminMixin(object):
+
+    def _get_attached_admin(self, placeholder):
+        model = placeholder._get_attached_model()
+
+        if model and self.admin_site.is_registered(model):
+            return self.admin_site._registry[model]
+        return None
+
     def get_urls(self):
         """
         Register the plugin specific urls (add/edit/copy/remove/move)
@@ -364,7 +372,25 @@ class PlaceholderAdminMixin(object):
                     'language': plugin.language, 'placeholder_id': plugin.placeholder_id
                 }
             )
+
         self.post_copy_plugins(request, source_placeholder, target_placeholder, plugins)
+
+        # When this is executed we are in the admin class of the source placeholder
+        # It can be a page or a model with a placeholder field.
+        # Because of this we need to get the admin class instance of the
+        # target placeholder and call post_copy_plugins() on it.
+        # By doing this we make sure that both the source and target are
+        # informed of the operation.
+        target_placeholder_admin = self._get_attached_admin(target_placeholder)
+
+        if target_placeholder_admin:
+            target_placeholder_admin.post_copy_plugins(
+                request,
+                source_placeholder=source_placeholder,
+                target_placeholder=target_placeholder,
+                plugins=plugins,
+            )
+
         json_response = {'plugin_list': reduced_list, 'reload': reload_required}
         return HttpResponse(json.dumps(json_response), content_type='application/json')
 
@@ -566,6 +592,22 @@ class PlaceholderAdminMixin(object):
         reorder_plugins(placeholder, parent_id, language, order)
 
         self.post_move_plugin(request, source_placeholder, placeholder, plugin)
+
+        # When this is executed we are in the admin class of the source placeholder
+        # It can be a page or a model with a placeholder field.
+        # Because of this we need to get the admin class instance of the
+        # target placeholder and call post_move_plugin() on it.
+        # By doing this we make sure that both the source and target are
+        # informed of the operation.
+        target_placeholder_admin = self._get_attached_admin(placeholder)
+
+        if target_placeholder_admin:
+            target_placeholder_admin.post_move_plugin(
+                request,
+                source_placeholder=source_placeholder,
+                target_placeholder=placeholder,
+                plugins=plugin,
+            )
 
         try:
             language = request.toolbar.toolbar_language


### PR DESCRIPTION
![cmsplaceholders](https://cloud.githubusercontent.com/assets/994951/12394439/d4c0d0b2-bdc9-11e5-93d6-3acde71f889c.png)

Breakdown:

**Feature** - Native cms placeholder (created using the ``placeholder`` tag)
**Newsblog_Base_Top** - Manual placeholder (created using a ``PlaceholderField``)
**Newsblog_Base_Sidebar** - Manual placeholder (created using a ``PlaceholderField``)
**Footer** - Static placeholder (created using the ``staticplaceholder`` tag)

This pr fixes the following issues:

* No revision history created when moving a plugin from **Newsblog_Base_Top** (manual) to **Feature** (native).
* No revision history created when moving a plugin from **Feature** (native) to  **Newsblog_Base_Top** (manual) or to **Footer** (static).
* Revision history marked a plugin as moved when copying a plugin.
* Moved plugin action revision creation to the post_ methods to avoid clashes with other
``create_revision`` decorators being used.
* Improved revision message when moving plugin.
* Improved code in move a plugin logic to avoid issues with overriding variables.
