### PR TITLE
Small documentation fixes

### DIFF
--- a/docs/contributing/documentation.rst
+++ b/docs/contributing/documentation.rst
@@ -102,7 +102,7 @@ Check spelling
 
 Run::
 
-    ``make spelling``
+    make spelling
 
 in the ``docs`` directory to conduct the checks.
 

--- a/docs/contributing/documentation.rst
+++ b/docs/contributing/documentation.rst
@@ -271,4 +271,4 @@ run search-and-replaces when items are moved in the structure.
 
 
 .. _restructuredText: http://docutils.sourceforge.net/docs/ref/rst/introduction.html
-.. _Sphinx: http://sphinx.pocoo.org/
+.. _Sphinx: http://sphinx-doc.org//

--- a/docs/contributing/documentation.rst
+++ b/docs/contributing/documentation.rst
@@ -49,10 +49,10 @@ This allows you to review your changes in your local browser using ``http://loca
 
     ``make install`` is roughly the equivalent of::
 
-    	virtualenv env
+        virtualenv env
         source env/bin/activate
+        cd docs
         pip install -r requirements.txt
-    	cd docs
         make html
 
     ``make run`` runs ``make html``, and serves the built documentation on port 8001 (that is, at

--- a/docs/contributing/index.rst
+++ b/docs/contributing/index.rst
@@ -38,11 +38,6 @@ You can also follow:
 * the `Travis Continuous Integration build reports <https://travis-ci.org/divio/django-cms>`_
 * the `@djangocms`_ Twitter account for general announcements
 
-You can also follow:
-
-* the `Travis Continuous Integration build reports <https://travis-ci.org/divio/django-cms>`_
-* the `@djangocms`_ Twitter account for general announcements
-
 You don't need to be an expert developer to make a valuable contribution - all
 you need is a little knowledge of the system, and a willingness to follow the
 contribution guidelines.

--- a/docs/how_to/contributing.rst
+++ b/docs/how_to/contributing.rst
@@ -84,7 +84,7 @@ integration tests.
 Depending on your contribution, you will write a mix of them.
 
 Let's start with something simple. We'll assume you have set up your environment correctly as
-`described above <start-contributing>`_.
+:ref:`described above <start-contributing>`.
 
 Let's say you want to test the behaviour of the ``CMSPluginBase.render`` method:
 

--- a/docs/topics/commonly_used_plugins.rst
+++ b/docs/topics/commonly_used_plugins.rst
@@ -3,7 +3,7 @@ Some commonly-used plugins
 ##########################
 
 .. warning::
-    In version 3 of the CMS we removed all the plugins from the
+    In version 3 of the CMS we removed all the plugins from the main repository
     into separate repositories to continue their development there.
     you are upgrading from a previous version. Please refer to
     :ref:`Upgrading from previous versions <upgrade-to-3.0>`


### PR DESCRIPTION
Some fixes I have found while reading the docs.
Unfortunately I was not able to run the *make spelling*.

Make with virtualenv caused some access denied errors.

Matthias