### PR TITLE
Revision issues with placeholders from multiple sources

### DIFF
--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -609,6 +609,7 @@ class PageAdmin(PlaceholderAdminMixin, ModelAdmin):
                 return False
         return True
 
+    @create_revision()
     def post_add_plugin(self, request, placeholder, plugin):
         if is_installed('reversion') and placeholder.page:
             plugin_name = force_text(plugin_pool.get_plugin(plugin.plugin_type).name)
@@ -625,6 +626,7 @@ class PageAdmin(PlaceholderAdminMixin, ModelAdmin):
             self.cleanup_history(page)
             helpers.make_revision_with_plugins(page, request.user, message)
 
+    @create_revision()
     def post_edit_plugin(self, request, plugin):
         page = plugin.placeholder.page
 
@@ -653,6 +655,7 @@ class PageAdmin(PlaceholderAdminMixin, ModelAdmin):
             self.cleanup_history(page)
             helpers.make_revision_with_plugins(page, request.user, message)
 
+    @create_revision()
     def post_delete_plugin(self, request, plugin):
         plugin_name = force_text(plugin_pool.get_plugin(plugin.plugin_type).name)
         page = plugin.placeholder.page
@@ -667,6 +670,7 @@ class PageAdmin(PlaceholderAdminMixin, ModelAdmin):
                 self.cleanup_history(page)
                 helpers.make_revision_with_plugins(page, request.user, comment)
 
+    @create_revision()
     def post_clear_placeholder(self, request, placeholder):
         page = placeholder.page
         if page:
@@ -1524,23 +1528,6 @@ class PageAdmin(PlaceholderAdminMixin, ModelAdmin):
             return HttpResponse(json.dumps(results), content_type='application/json')
         else:
             return HttpResponseForbidden()
-
-    def add_plugin(self, *args, **kwargs):
-        with create_revision():
-            return super(PageAdmin, self).add_plugin(*args, **kwargs)
-
-    def edit_plugin(self, *args, **kwargs):
-        with create_revision():
-            return super(PageAdmin, self).edit_plugin(*args, **kwargs)
-
-    def delete_plugin(self, *args, **kwargs):
-        with create_revision():
-            return super(PageAdmin, self).delete_plugin(*args, **kwargs)
-
-    def clear_placeholder(self, *args, **kwargs):
-        with create_revision():
-            return super(PageAdmin, self).clear_placeholder(*args, **kwargs)
-
 
 
 admin.site.register(Page, PageAdmin)

--- a/cms/admin/placeholderadmin.py
+++ b/cms/admin/placeholderadmin.py
@@ -554,6 +554,7 @@ class PlaceholderAdminMixin(object):
 
             if parent_id:
                 parent = CMSPlugin.objects.get(pk=parent_id)
+
                 for plugin in top_plugins:
                     plugin.parent = parent
                     plugin.placeholder = placeholder
@@ -569,6 +570,9 @@ class PlaceholderAdminMixin(object):
                     order[copy_idx:0] = top_plugins_pks
                 else:
                     order.extend(top_plugins_pks)
+
+            # Set the plugin variable to point to the newly created plugin.
+            plugin = new_plugins[0][0]
         else:
             # Regular move
             if parent_id:

--- a/cms/admin/placeholderadmin.py
+++ b/cms/admin/placeholderadmin.py
@@ -153,9 +153,9 @@ class PlaceholderAdminMixin(object):
     def _get_attached_admin(self, placeholder):
         model = placeholder._get_attached_model()
 
-        if model and self.admin_site.is_registered(model):
-            return self.admin_site._registry[model]
-        return None
+        if not model:
+            return
+        return self.admin_site._registry.get(model)
 
     def get_urls(self):
         """

--- a/cms/test_utils/project/placeholderapp/admin.py
+++ b/cms/test_utils/project/placeholderapp/admin.py
@@ -1,6 +1,10 @@
 from cms.admin.placeholderadmin import PlaceholderAdminMixin, FrontendEditableAdminMixin
-from cms.test_utils.project.placeholderapp.models import (Example1, MultilingualExample1,
-                                                          TwoPlaceholderExample, CharPksExample)
+from cms.test_utils.project.placeholderapp.models import (
+    Example1, MultilingualExample1,
+    TwoPlaceholderExample, CharPksExample
+)
+from cms.test_utils.project.placeholderapp.exceptions import PlaceholderHookException
+
 from django.contrib import admin
 from hvad.admin import TranslatableAdmin
 
@@ -11,6 +15,12 @@ class ExampleAdmin(FrontendEditableAdminMixin, PlaceholderAdminMixin, admin.Mode
 
 class CharPksAdmin(FrontendEditableAdminMixin, PlaceholderAdminMixin, admin.ModelAdmin):
     frontend_editable_fields = ("char_1",)
+
+    def post_copy_plugins(self, *args, **kwargs):
+        raise PlaceholderHookException('copy plugin hook has been called.')
+
+    def post_move_plugin(self, *args, **kwargs):
+        raise PlaceholderHookException('move plugin hook has been called.')
 
 
 class TwoPlaceholderExampleAdmin(PlaceholderAdminMixin, admin.ModelAdmin):

--- a/cms/test_utils/project/placeholderapp/exceptions.py
+++ b/cms/test_utils/project/placeholderapp/exceptions.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+
+
+class PlaceholderHookException(Exception):
+    """
+    Simple exception to signal to the tests that a placeholder
+    hook has been run.
+    """
+    pass

--- a/cms/tests/test_reversion_tests.py
+++ b/cms/tests/test_reversion_tests.py
@@ -2,18 +2,22 @@
 from __future__ import with_statement
 import shutil
 from os.path import join
+from cms.api import add_plugin, create_page
 from cms.utils.conf import get_cms_setting
 from cms.utils.urlutils import admin_reverse
 
 from djangocms_text_ckeditor.models import Text
 from django.conf import settings
+from django.contrib import admin
 from django.contrib.contenttypes.models import ContentType
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.utils.encoding import force_text
 
 from cms.api import create_page
-from cms.models import Page, Title, Placeholder
+from cms.models import Page, Title, Placeholder, StaticPlaceholder
 from cms.models.pluginmodel import CMSPlugin
 from cms.test_utils.project.fileapp.models import FileModel
+from cms.test_utils.project.placeholderapp.models import Example1
 from cms.test_utils.testcases import CMSTestCase, TransactionCMSTestCase, URL_CMS_PAGE, URL_CMS_PAGE_CHANGE, URL_CMS_PAGE_ADD, \
     URL_CMS_PLUGIN_ADD, URL_CMS_PLUGIN_EDIT, URL_CMS_PAGE_DELETE
 from cms.utils.reversion_hacks import Revision, reversion, Version
@@ -36,6 +40,7 @@ class BasicReversionTestCase(CMSTestCase):
 
 
 class ReversionTestCase(TransactionCMSTestCase):
+
     def setUp(self):
         u = self._create_user("test", True, True)
 
@@ -76,6 +81,169 @@ class ReversionTestCase(TransactionCMSTestCase):
             page.publish('en')
 
         self.user = u
+
+    def get_example_admin(self):
+        admin.autodiscover()
+        return admin.site._registry[Example1]
+
+    def get_page_admin(self):
+        admin.autodiscover()
+        return admin.site._registry[Page]
+
+    def get_staticplaceholder_admin(self):
+        admin.autodiscover()
+        return admin.site._registry[Page]
+
+    def get_post_request(self, data):
+        return self.get_request(post_data=data)
+
+    def test_revision_on_plugin_move(self):
+        from cms.plugin_pool import plugin_pool
+
+        placeholder_c_type = ContentType.objects.get_for_model(Placeholder)
+        placeholder_versions = Version.objects.filter(content_type=placeholder_c_type)
+
+        LinkPluginModel = plugin_pool.get_plugin('LinkPlugin').model
+        link_plugin_c_type = ContentType.objects.get_for_model(LinkPluginModel)
+
+        # three placeholder types
+        # native - native CMS placeholder (created using a placeholder tag)
+        # manual - Manual placeholder (created using a PlaceholderField)
+        # static - Static placeholder (created using the staticplaceholder tag)
+
+        native_placeholder_page = create_page('test page', 'col_two.html', u'en')
+        native_placeholder = native_placeholder_page.placeholders.get(slot='col_sidebar')
+        native_placeholder_pk = native_placeholder.pk
+        native_placeholder_admin = self.get_page_admin()
+        native_placeholder_versions = placeholder_versions.filter(object_id_int=native_placeholder_pk)
+        native_placeholder_versions_initial_count = native_placeholder_versions.count()
+
+        example = Example1.objects.create(
+            char_1='one',
+            char_2='two',
+            char_3='tree',
+            char_4='four',
+        )
+        manual_placeholder = example.placeholder
+        manual_placeholder_admin = self.get_example_admin()
+
+        static_placeholder_obj = StaticPlaceholder.objects.create(
+            name='static',
+            code='static',
+            site_id=1,
+        )
+        static_placeholder = static_placeholder_obj.draft
+        static_placeholder_admin = self.get_staticplaceholder_admin()
+
+        data = {
+            'placeholder': native_placeholder,
+            'plugin_type': 'LinkPlugin',
+            'language': 'en',
+        }
+
+        # Add plugin to feature
+        link_plugin = add_plugin(**data)
+        link_plugin_pk = link_plugin.pk
+        link_plugin_versions = Version.objects.filter(
+            content_type=link_plugin_c_type,
+            object_id_int=link_plugin_pk,
+        )
+        link_plugin_versions_initial_count = link_plugin_versions.count()
+
+        # move plugin to manual placeholder
+        request = self.get_post_request({
+            'placeholder_id': manual_placeholder.pk,
+            'plugin_id': link_plugin_pk,
+        })
+        response = native_placeholder_admin.move_plugin(request)
+        self.assertEqual(response.status_code, 200)
+
+        # Verify a new version for the native placeholder has been created
+        self.assertEqual(
+            native_placeholder_versions.count(),
+            native_placeholder_versions_initial_count + 1,
+        )
+
+        # Assert revision comment was set correctly
+        self.assertEqual(
+            Revision.objects.latest('pk').comment,
+            'Moved plugins to %s' % force_text(manual_placeholder),
+        )
+
+        # move plugin back to native
+        request = self.get_post_request({
+            'placeholder_id': native_placeholder_pk,
+            'plugin_id': link_plugin_pk,
+        })
+        response = manual_placeholder_admin.move_plugin(request)
+        self.assertEqual(response.status_code, 200)
+
+        # assert a new version for the native placeholder has been created
+        self.assertEqual(
+            native_placeholder_versions.count(),
+            native_placeholder_versions_initial_count + 2,
+        )
+
+        # assert a new version for the link plugin has been created
+        self.assertEqual(
+            link_plugin_versions.count(),
+            link_plugin_versions_initial_count + 1,
+        )
+
+        # assert revision comment was set correctly
+        self.assertEqual(
+            Revision.objects.latest('pk').comment,
+            'Moved plugins to %s' % force_text(native_placeholder),
+        )
+
+        # move plugin to static placeholder
+        request = self.get_post_request({
+            'placeholder_id': static_placeholder.pk,
+            'plugin_id': link_plugin_pk,
+        })
+        response = native_placeholder_admin.move_plugin(request)
+        self.assertEqual(response.status_code, 200)
+
+        # assert a new version for the native placeholder has been created
+        self.assertEqual(
+            native_placeholder_versions.count(),
+            native_placeholder_versions_initial_count + 3,
+        )
+
+        # assert revision comment was set correctly
+        self.assertEqual(
+            Revision.objects.latest('pk').comment,
+            'Moved plugins to %s' % force_text(static_placeholder),
+        )
+
+        # move plugin back to native
+        request = self.get_post_request({
+            'placeholder_id': native_placeholder.pk,
+            'plugin_id': link_plugin_pk,
+        })
+        response = static_placeholder_admin.move_plugin(request)
+        self.assertEqual(response.status_code, 200)
+
+        # assert a new version for the native placeholder has been created
+        self.assertEqual(
+            native_placeholder_versions.count(),
+            native_placeholder_versions_initial_count + 4,
+        )
+
+        # assert a new version for the link plugin has been created
+        self.assertEqual(
+            link_plugin_versions.count(),
+            link_plugin_versions_initial_count + 2,
+        )
+
+        # assert revision comment was set correctly
+        self.assertEqual(
+            Revision.objects.latest('pk').comment,
+            'Moved plugins to %s' % force_text(native_placeholder),
+        )
+
+    def test_revision_on_plugin_copy(self):
+        pass
 
     def test_revert(self):
         """

--- a/cms/tests/test_reversion_tests.py
+++ b/cms/tests/test_reversion_tests.py
@@ -249,8 +249,7 @@ class ReversionTestCase(TransactionCMSTestCase):
             # Expects response to be a JSON response
             # with a structure like so:
             # {"urls": {"edit_plugin": "/en/admin/placeholderapp/example1/edit-plugin/3/"}
-
-            data = json.loads(response.content)
+            data = json.loads(response.content.decode('utf-8'))
             return data['urls']['edit_plugin'].split('/')[-2]
 
         placeholder_c_type = ContentType.objects.get_for_model(Placeholder)

--- a/cms/tests/test_reversion_tests.py
+++ b/cms/tests/test_reversion_tests.py
@@ -93,7 +93,7 @@ class ReversionTestCase(TransactionCMSTestCase):
 
     def get_staticplaceholder_admin(self):
         admin.autodiscover()
-        return admin.site._registry[Page]
+        return admin.site._registry[StaticPlaceholder]
 
     def get_post_request(self, data):
         return self.get_request(post_data=data)

--- a/cms/tests/test_reversion_tests.py
+++ b/cms/tests/test_reversion_tests.py
@@ -111,8 +111,8 @@ class ReversionTestCase(TransactionCMSTestCase):
         # manual - Manual placeholder (created using a PlaceholderField)
         # static - Static placeholder (created using the staticplaceholder tag)
 
-        native_placeholder_page = create_page('test page', 'col_two.html', u'en')
-        native_placeholder = native_placeholder_page.placeholders.get(slot='col_sidebar')
+        native_placeholder_page = create_page('test page', 'simple.html', u'en')
+        native_placeholder = native_placeholder_page.placeholders.get(slot='placeholder')
         native_placeholder_pk = native_placeholder.pk
         native_placeholder_admin = self.get_page_admin()
         native_placeholder_versions = placeholder_versions.filter(object_id_int=native_placeholder_pk)
@@ -158,13 +158,13 @@ class ReversionTestCase(TransactionCMSTestCase):
         response = native_placeholder_admin.move_plugin(request)
         self.assertEqual(response.status_code, 200)
 
-        # Verify a new version for the native placeholder has been created
+        # assert a new version for the native placeholder has been created
         self.assertEqual(
             native_placeholder_versions.count(),
             native_placeholder_versions_initial_count + 1,
         )
 
-        # Assert revision comment was set correctly
+        # assert revision comment was set correctly
         self.assertEqual(
             Revision.objects.latest('pk').comment,
             'Moved plugins to %s' % force_text(manual_placeholder),
@@ -264,8 +264,8 @@ class ReversionTestCase(TransactionCMSTestCase):
         # manual - Manual placeholder (created using a PlaceholderField)
         # static - Static placeholder (created using the staticplaceholder tag)
 
-        native_placeholder_page = create_page('test page', 'col_two.html', u'en')
-        native_placeholder = native_placeholder_page.placeholders.get(slot='col_sidebar')
+        native_placeholder_page = create_page('test page', 'simple.html', u'en')
+        native_placeholder = native_placeholder_page.placeholders.get(slot='placeholder')
         native_placeholder_pk = native_placeholder.pk
         native_placeholder_admin = self.get_page_admin()
         native_placeholder_versions = placeholder_versions.filter(object_id_int=native_placeholder_pk)
@@ -299,7 +299,6 @@ class ReversionTestCase(TransactionCMSTestCase):
         link_plugin_versions = Version.objects.filter(
             content_type=link_plugin_c_type,
         )
-        link_plugin_versions_initial_count = link_plugin_versions.count()
 
         # copy plugin from manual to native placeholder
         request = self.get_post_request({
@@ -309,11 +308,13 @@ class ReversionTestCase(TransactionCMSTestCase):
             'move_a_copy': 'true',
         })
         response = manual_placeholder_admin.move_plugin(request)
+
         self.assertEqual(response.status_code, 200)
 
+        # Point to the newly created text plugin
         link_plugin_pk = get_plugin_id_from_response(response)
 
-        # Verify a new version for the native placeholder has been created
+        # assert a new version for the native placeholder has been created
         self.assertEqual(
             native_placeholder_versions.count(),
             native_placeholder_versions_initial_count + 1,
@@ -322,7 +323,7 @@ class ReversionTestCase(TransactionCMSTestCase):
         # assert a new version for the link plugin has been created
         self.assertEqual(
             link_plugin_versions.filter(object_id_int=link_plugin_pk).count(),
-            link_plugin_versions_initial_count + 1,
+            1,
         )
 
         # Assert revision comment was set correctly
@@ -339,16 +340,16 @@ class ReversionTestCase(TransactionCMSTestCase):
             'move_a_copy': 'true',
         })
         response = native_placeholder_admin.move_plugin(request)
+
         self.assertEqual(response.status_code, 200)
 
+        # Point to the newly created text plugin
         link_plugin_pk = get_plugin_id_from_response(response)
 
         # assert revision count remains the same
         self.assertEqual(
             placeholder_versions.count(),
-            # We use 2 because there's two placeholders
-            # in the native placeholder page
-            placeholder_versions_initial_count + 2,
+            placeholder_versions_initial_count + 1,
         )
 
         # copy plugin from manual to static placeholder
@@ -359,16 +360,16 @@ class ReversionTestCase(TransactionCMSTestCase):
             'move_a_copy': 'true',
         })
         response = manual_placeholder_admin.move_plugin(request)
+
         self.assertEqual(response.status_code, 200)
 
+        # Point to the newly created text plugin
         link_plugin_pk = get_plugin_id_from_response(response)
 
         # assert revision count remains the same
         self.assertEqual(
             placeholder_versions.count(),
-            # We use 2 because there's two placeholders
-            # in the native placeholder page
-            placeholder_versions_initial_count + 2,
+            placeholder_versions_initial_count + 1,
         )
 
         # copy plugin from static to manual placeholder
@@ -384,9 +385,7 @@ class ReversionTestCase(TransactionCMSTestCase):
         # assert revision count remains the same
         self.assertEqual(
             placeholder_versions.count(),
-            # We use 2 because there's two placeholders
-            # in the native placeholder page
-            placeholder_versions_initial_count + 2,
+            placeholder_versions_initial_count + 1,
         )
 
         # copy plugin from static to native placeholder
@@ -397,11 +396,13 @@ class ReversionTestCase(TransactionCMSTestCase):
             'move_a_copy': 'true',
         })
         response = static_placeholder_admin.move_plugin(request)
+
         self.assertEqual(response.status_code, 200)
 
+        # Point to the newly created text plugin
         link_plugin_pk = get_plugin_id_from_response(response)
 
-        # Verify a new version for the native placeholder has been created
+        # assert a new version for the native placeholder has been created
         self.assertEqual(
             native_placeholder_versions.count(),
             native_placeholder_versions_initial_count + 2,
@@ -410,10 +411,10 @@ class ReversionTestCase(TransactionCMSTestCase):
         # assert a new version for the link plugin has been created
         self.assertEqual(
             link_plugin_versions.filter(object_id_int=link_plugin_pk).count(),
-            link_plugin_versions_initial_count + 1,
+            1,
         )
 
-        # Assert revision comment was set correctly
+        # assert revision comment was set correctly
         self.assertEqual(
             Revision.objects.latest('pk').comment,
             'Copied plugins to %s' % force_text(native_placeholder),

--- a/cms/tests/test_reversion_tests.py
+++ b/cms/tests/test_reversion_tests.py
@@ -14,7 +14,6 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.utils.encoding import force_text
 
-from cms.api import create_page
 from cms.models import Page, Title, Placeholder, StaticPlaceholder
 from cms.models.pluginmodel import CMSPlugin
 from cms.test_utils.project.fileapp.models import FileModel


### PR DESCRIPTION
![cmsplaceholders](https://cloud.githubusercontent.com/assets/994951/12394439/d4c0d0b2-bdc9-11e5-93d6-3acde71f889c.png)

Breakdown:

**Feature** - Native cms placeholder (created using the ``placeholder`` tag)
**Newsblog_Base_Top** - Manual placeholder (created using a ``PlaceholderField``)
**Newsblog_Base_Sidebar** - Manual placeholder (created using a ``PlaceholderField``)
**Footer** - Static placeholder (created using the ``staticplaceholder`` tag)

This pr fixes the following issues:

* No revision history created when moving a plugin from **Newsblog_Base_Top** (manual) to **Feature** (native).
* No revision history created when moving a plugin from **Feature** (native) to  **Newsblog_Base_Top** (manual) or to **Footer** (static).
* Revision history marked a plugin as moved when copying a plugin.
* Moved plugin action revision creation to the post_ methods to avoid clashes with other
``create_revision`` decorators being used.
* Improved revision message when moving plugin.
* Improved code in move a plugin logic to avoid issues with overriding variables.
