### PR TITLE
Fix user lookup in page permission admin

### DIFF
--- a/cms/templates/admin/cms/page/change_form.html
+++ b/cms/templates/admin/cms/page/change_form.html
@@ -103,6 +103,10 @@
 </form>
 </div>
 
+{% block admin_change_form_document_ready %}
+{{ block.super }}
+{% endblock %}
+
 {% for url in unihandecode_urls %}<script src="{{ url }}" type="text/javascript"></script>{% endfor %}
 {% if unihandecode_urls %}
 <script>


### PR DESCRIPTION
Make sure that related lookup fields get initialized in page permission admin. This fixes #4842.