### PR TITLE
Fix cache settings

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -404,3 +404,10 @@ Please see Install/2.4 release notes *before* attempting to upgrade to version 2
 - Fix JS error when using PageSelectWidget
 - Fix whitespace markup issues in draft mode
 - Detect plugin migrations layout in tests
+
+
+=== 3.0.17 (unreleased) ===
+
+- Fix ExtensionToolbar when language is removed but titles still exists…
+- Fix PageSelectWidget JS syntax
+- Fix cache settings

--- a/cms/test_utils/cli.py
+++ b/cms/test_utils/cli.py
@@ -257,9 +257,9 @@ def configure(db_url, **extra):
         CMS_PERMISSION=True,
         CMS_PUBLIC_FOR='all',
         CMS_CACHE_DURATIONS={
-            'menus': 0,
-            'content': 0,
-            'permissions': 0,
+            'menus': 60,
+            'content': 60,
+            'permissions': 60,
         },
         CMS_APPHOOKS=[],
         CMS_PLUGIN_PROCESSORS=tuple(),

--- a/cms/utils/conf.py
+++ b/cms/utils/conf.py
@@ -40,7 +40,6 @@ DEFAULTS = {
     # Whether to use raw ID lookups for users when PERMISSION is True
     'RAW_ID_USERS': False,
     'PUBLIC_FOR': 'all',
-    'CONTENT_CACHE_DURATION': 60,
     'APPHOOKS': [],
     'TOOLBARS': [],
     'SITE_CHOICES_CACHE_KEY': 'CMS:site_choices',
@@ -67,11 +66,14 @@ DEFAULTS = {
 
 
 def get_cache_durations():
-    return {
-        'menus': getattr(settings, 'MENU_CACHE_DURATION', 60 * 60),
-        'content': get_cms_setting('CONTENT_CACHE_DURATION'),
+    """
+    Returns the setting: CMS_CACHE_DURATIONS or the defaults.
+    """
+    return getattr(settings, 'CMS_CACHE_DURATIONS', {
+        'menus': 60 * 60,
+        'content': 60,
         'permissions': 60 * 60,
-    }
+    })
 
 
 @default('CMS_MEDIA_ROOT')

--- a/test_requirements/requirements_base.txt
+++ b/test_requirements/requirements_base.txt
@@ -4,7 +4,7 @@ docopt==0.6.2
 unittest-xml-reporting==1.9.0
 sphinx
 Pillow==2.5.3
-django-classy-tags>=0.5
+django-classy-tags>=0.5,<0.7.1
 html5lib>=0.90,<0.9999
 django-mptt>=0.6,<0.7
 django-sekizai>=0.7


### PR DESCRIPTION
Fix #4931 
Fix #4969 

I set non-zero cache values into ``cli.py`` as due to the bug, cache was active through all the tests, so the correct cache values must be set to get the tests running