### PR TITLE
Removed usage of django.conf.urls.patterns() (again).

### DIFF
--- a/cms/wizards/urls.py
+++ b/cms/wizards/urls.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from .views import WizardCreateView
 
 
-urlpatterns = patterns('',  # NOQA
+urlpatterns = [
     url(r"^create/$",
         WizardCreateView.as_view(), name="cms_wizard_create"),
-)
+]

--- a/docs/how_to/apphooks.rst
+++ b/docs/how_to/apphooks.rst
@@ -55,12 +55,13 @@ a page and open the advanced settings tab. Select your new apphook under
 If you attached the app to a page with the url ``/hello/world/`` and the app has
 a ``urls.py`` that looks like this::
 
-    from django.conf.urls import *
+    from django.conf.urls import url
+    from sampleapp.views import main_view, sample_view
 
-    urlpatterns = patterns('sampleapp.views',
-        url(r'^$', 'main_view', name='app_main'),
-        url(r'^sublevel/$', 'sample_view', name='app_sublevel'),
-    )
+    urlpatterns = [
+        url(r'^$', main_view, name='app_main'),
+        url(r'^sublevel/$', sample_view, name='app_sublevel'),
+    ]
 
 The ``main_view`` should now be available at ``/hello/world/`` and the
 ``sample_view`` has the URL ``/hello/world/sublevel/``.
@@ -308,9 +309,7 @@ will look like this::
 
     class OscarApp(CMSApp):
         name = _("Oscar")
-        urls = [
-            patterns('', *application.urls[0])
-        ]
+        urls = application.urls[0]
         exclude_permissions = ['dashboard']
 
 .. _django-oscar: https://github.com/tangentlabs/django-oscar

--- a/docs/how_to/custom_plugins.rst
+++ b/docs/how_to/custom_plugins.rst
@@ -776,7 +776,6 @@ Example::
             urlpatterns = [
                 url(r'^create_alias/$', self.create_alias, name='cms_create_alias'),
             ]
-            urlpatterns = patterns('', *urlpatterns)
             return urlpatterns
 
         def create_alias(self, request):
@@ -873,4 +872,3 @@ For Django migrations add this:
             run_before = [
                 ('cms', '0004_auto_20140924_1038')
             ]
-

--- a/docs/introduction/namespaced_apphooks.rst
+++ b/docs/introduction/namespaced_apphooks.rst
@@ -243,13 +243,13 @@ And the template (``faq/templates/faq/index.html``):
 
 .. code-block:: python
 
-    from django.conf.urls import patterns, url
+    from django.conf.urls import url
     from . import views
 
 
-    urlpatterns = patterns('',
+    urlpatterns = [
         url(r'^$', views.IndexView.as_view(), name='index'),
-    )
+    ]
 
 Finally, lets add ``faq`` to ``INSTALLED_APPS`` and create a migrations:
 


### PR DESCRIPTION
This function is deprecated in Django 1.8 and isn't necessary.
Some usage has bee introduced since fb6da2cb9a5152f373d31c37836079b18f83acf5.