### PR TITLE
allow plugins to disable caching dynamically

### DIFF
--- a/cms/plugin_base.py
+++ b/cms/plugin_base.py
@@ -329,6 +329,9 @@ class CMSPluginBase(six.with_metaclass(CMSPluginBaseMetaclass, admin.ModelAdmin)
             reload_required = options.get('requires_reload', False)
         return reload_required
 
+    def get_use_cache(self, context, instance, placeholder):
+        return self.cache
+
     def get_plugin_urls(self):
         """
         Return URL patterns for which the plugin wants to register

--- a/cms/plugin_rendering.py
+++ b/cms/plugin_rendering.py
@@ -186,8 +186,14 @@ def render_placeholder(placeholder, context_to_copy, name_fallback="Placeholder"
     context['edit'] = edit
     result = render_to_string("cms/toolbar/content.html", context)
     changes = watcher.get_changes()
-    if placeholder and not edit and placeholder.cache_placeholder and get_cms_setting('PLACEHOLDER_CACHE') and use_cache:
-        set_placeholder_cache(placeholder, lang, content={'content': result, 'sekizai': changes})
+    if placeholder and not edit and placeholder.cache_placeholder and get_cms_setting('PLACEHOLDER_CACHE'):
+        for p in plugins:
+            if not use_cache:
+                break
+            instance, plugin = p.get_plugin_instance()
+            use_cache = plugin.get_use_cache(context, instance, placeholder)
+        if use_cache:
+            set_placeholder_cache(placeholder, lang, content={'content': result, 'sekizai': changes})
     context.pop()
     return result
 


### PR DESCRIPTION
Currently one has to decide whether to cache the plugin's content while declaring the plugin, but sometimes, some of my plugins must disable caching depending on the given context.

I therefore have added a method ``get_use_cache(context, instance, placeholder)`` which can be overridden by a plugin and be used to disable plugin caching dynamically.

This PR is prove of concept, if it will be accepted, I'll add documentation and a unit test.