### PR TITLE
fixes integrity errors in revert plugins

### DIFF
--- a/cms/admin/views.py
+++ b/cms/admin/views.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from django.db import transaction, IntegrityError
 from django.http import Http404
 from django.shortcuts import get_object_or_404
 
@@ -16,6 +17,7 @@ def revert_plugins(request, version_id, obj):
     titles = []
     others = []
     page = obj
+
     for rev in revs:
         obj = rev.object
         if obj.__class__ == Placeholder:
@@ -30,9 +32,12 @@ def revert_plugins(request, version_id, obj):
             titles.append(obj)
         else:
             others.append(rev)
+
     if not page.has_change_permission(request):
         raise Http404
+
     current_plugins = list(CMSPlugin.objects.filter(placeholder__page=page))
+
     for pk, placeholder in placeholders.items():
         # admin has already created the placeholders/ get them instead
         try:
@@ -40,10 +45,17 @@ def revert_plugins(request, version_id, obj):
         except Placeholder.DoesNotExist:
             placeholders[pk].save()
             page.placeholders.add(placeholders[pk])
+
+    # The list isn't sorted so childs could be inserted before parents which
+    # will lead to integrity errors. Sort the list by path here and we will
+    # get an integrity-error-free insertion order.
+    cms_plugin_list.sort(key=lambda pl: pl.path)
+
     for plugin in cms_plugin_list:
         # connect plugins to the correct placeholder
         plugin.placeholder = placeholders[plugin.placeholder_id]
         plugin.save(no_signals=True)
+
     for plugin in cms_plugin_list:
         plugin.save()
         for p in plugin_list:
@@ -54,6 +66,10 @@ def revert_plugins(request, version_id, obj):
             if old.pk == plugin.pk:
                 plugin.save()
                 current_plugins.remove(old)
+
+    # TODO: the same rule for the next block (others) applies here, this should be wrapped in an atomic block
+    # see https://docs.djangoproject.com/en/1.9/topics/db/transactions/#controlling-transactions-explicitly
+    # block "Avoid catching exceptions inside atomic!"
     for title in titles:
         title.page = page
         try:
@@ -61,7 +77,18 @@ def revert_plugins(request, version_id, obj):
         except:
             title.pk = Title.objects.get(page=page, language=title.language).pk
             title.save()
+
+    # There could objs in the list of others that have no parents. Unknown
+    # how this could happen. But it will be catched here and skipped.
     for other in others:
-        other.object.save()
+        try:
+            # The call has to be wrapped in an inner atomic block because we are already
+            # in an outer atomic block and every database exception will mark the
+            # current block invalid. Now we can rollback just this single query.
+            with transaction.atomic():
+                other.object.save()
+        except IntegrityError:
+            pass
+
     for plugin in current_plugins:
         plugin.delete()


### PR DESCRIPTION
While trying to recover a deleted page I encountered several integrity errors.

First error was raised because the plugin list wasn't ordered by path so child plugins were inserted before parent plugins (parent id constraint failed). I solved this by sorting the list by path before inserting.

The second problem occurred while inserting the "others"-list. I didn't really get why this is happening and don't know whether this it is the right way to catch the error and just ignore it.

I would appreciate if someone would review my pull request. It doesn't need to be merged but it was easier to show the problems by solving it than by just explaining it.

Problem was found in django-cms 3.1 on django 1.7 but checked against django-cms 3.2. It happened there too. But the data was from django-cms 3.1 so maybe the problem has its source in the way the versions are created and this will be solved by 3.2.