### PR TITLE
Fixes ToolbarMiddleware.is_cms_request logic

### DIFF
--- a/cms/middleware/toolbar.py
+++ b/cms/middleware/toolbar.py
@@ -62,7 +62,7 @@ class ToolbarMiddleware(object):
         except:
             return False
 
-        return match.app_name in ('pages-root', 'pages-details-by-slug')
+        return match.url_name in ('pages-root', 'pages-details-by-slug')
 
     def process_request(self, request):
         """


### PR DESCRIPTION
`is_cms_request` was checking on app_name instead of url_name, which caused this issue (https://github.com/divio/django-cms/issues/5013), and many more I assume.