### PR TITLE
Fixes ToolbarMiddleware.is_cms_request logic

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,8 @@
+=== 3.2.2 (unreleased) ===
+
+- Fix a bug where "ToolbarMiddleware" would process all requests, instead of only cms page requests.
+
+
 === 3.2.1 (2016-01-29) ===
 
 - Add support for Django 1.9 (with some deprecation warnings).

--- a/README.rst
+++ b/README.rst
@@ -24,11 +24,11 @@ Open source enterprise content management system based on the django framework.
 .. ATTENTION:: To propose features, always open pull requests on the **develop** branch.
    It's the branch for features that will go into the next django CMS feature release.
 
+   For fixes for 3.2.x releases, please work on **support/3.2.x** which contains
+   the next patch release for 3.2.x series.
+
    For fixes for 3.1.x releases, please work on **support/3.1.x** which contains
    the next patch release for 3.1.x series.
-
-   For fixes for 3.0.x releases, please work on **support/3.0.x** which contains
-   the next patch release for 3.0.x series.
 
    The **master** branch is the current stable release, the one released on PyPI.
    Changes based on **master** will not be accepted.

--- a/cms/middleware/toolbar.py
+++ b/cms/middleware/toolbar.py
@@ -62,7 +62,7 @@ class ToolbarMiddleware(object):
         except:
             return False
 
-        return match.app_name in ('pages-root', 'pages-details-by-slug')
+        return match.url_name in ('pages-root', 'pages-details-by-slug')
 
     def process_request(self, request):
         """

--- a/test_requirements/requirements_base.txt
+++ b/test_requirements/requirements_base.txt
@@ -26,4 +26,4 @@ sphinx
 sphinxcontrib-spelling
 pyflakes
 pyenchant
-
+mock>=1.3.0,<2.0.0


### PR DESCRIPTION
`is_cms_request` was checking on app_name instead of url_name, which caused this issue (https://github.com/divio/django-cms/issues/5013), and many more I assume.

Will add tests.