### PR TITLE
[WiP] Skip reverse descriptor

### DIFF
--- a/cms/models/managers.py
+++ b/cms/models/managers.py
@@ -68,7 +68,9 @@ class PageManager(PublisherManager):
         plugins = plugin_pool.get_all_plugins()
         for plugin in plugins:
             cmsplugin = plugin.model
-            if hasattr(cmsplugin, 'search_fields'):
+            if (hasattr(cmsplugin, 'search_fields') and
+                    cmsplugin.cmsplugin_ptr.field.rel.related_name and
+                    cmsplugin.cmsplugin_ptr.field.rel.related_name != '+'):
                 for field in cmsplugin.search_fields:
                     qp |= Q(**{
                         'placeholders__cmsplugin__{0}_{1}__{2}__icontains'.format(

--- a/cms/models/managers.py
+++ b/cms/models/managers.py
@@ -70,8 +70,10 @@ class PageManager(PublisherManager):
             cmsplugin = plugin.model
             if hasattr(cmsplugin, 'search_fields'):
                 for field in cmsplugin.search_fields:
-                    qp |= Q(**{'placeholders__cmsplugin__%s__%s__icontains' % \
-                               (cmsplugin.__name__.lower(), field): q})
+                    qp |= Q(**{
+                        'placeholders__cmsplugin__{0}_{1}__{2}__icontains'.format(
+                            cmsplugin._meta.app_label, cmsplugin._meta.model_name, field
+                        ): q})
         if language:
             qt &= Q(title_set__language=language)
             qp &= Q(cmsplugin__language=language)

--- a/cms/models/pluginmodel.py
+++ b/cms/models/pluginmodel.py
@@ -55,7 +55,9 @@ class PluginModelBase(ModelBase):
         if 'cmsplugin_ptr' not in attrs:
             for field  in new_class._meta.fields:
                 if field.name == 'cmsplugin_ptr':
-                    field.rel.related_name = '+'
+                    field.rel.related_name = '{0}_{1}'.format(
+                        new_class._meta.app_label, new_class._meta.model_name
+                    )
 
         # if there is a RenderMeta in attrs, use this one
         # else try to use the one from the superclass (if present)

--- a/cms/models/pluginmodel.py
+++ b/cms/models/pluginmodel.py
@@ -48,6 +48,15 @@ class PluginModelBase(ModelBase):
         # create a new class (using the super-metaclass)
         new_class = super(PluginModelBase, cls).__new__(cls, name, bases, attrs)
 
+        # Set the one-to-one parent-child field to not create the reverse
+        # related descriptor to avoid name clashes for plugins with the same
+        # fieldnames. Skip this check if the parent-child field has been explicitly
+        # defined in the plugin subclass
+        if 'cmsplugin_ptr' not in attrs:
+            for field  in new_class._meta.fields:
+                if field.name == 'cmsplugin_ptr':
+                    field.rel.related_name = '+'
+
         # if there is a RenderMeta in attrs, use this one
         # else try to use the one from the superclass (if present)
         meta = attr_meta or getattr(new_class, '_render_meta', None)
@@ -57,6 +66,7 @@ class PluginModelBase(ModelBase):
             field.editable = False
         # set a new BoundRenderMeta to prevent leaking of state
         new_class._render_meta = BoundRenderMeta(meta)
+
         return new_class
 
 

--- a/cms/tests/test_plugins.py
+++ b/cms/tests/test_plugins.py
@@ -828,21 +828,19 @@ class PluginsTestCase(PluginsTestBaseCase):
         text_plugin = api.add_plugin(ph, "TextPlugin", "en", body="Hello World")
         link_plugins = []
         for i in range(0, 10):
-            text_plugin = Text.objects.get(pk=text_plugin.pk)
             link_plugins.append(api.add_plugin(ph, "LinkPlugin", "en",
                                                target=text_plugin,
                                                name="A Link %d" % i,
                                                url="http://django-cms.org"))
-            text_plugin.text.body += '<img src="/static/cms/img/icons/plugins/link.png" alt="Link - %s" id="plugin_obj_%d" title="Link - %s" />' % (
+            text_plugin.body += '<img src="/static/cms/img/icons/plugins/link.png" alt="Link - %s" id="plugin_obj_%d" title="Link - %s" />' % (
                 link_plugins[-1].name,
                 link_plugins[-1].pk,
                 link_plugins[-1].name,
             )
         text_plugin.save()
-        txt = text_plugin.text
         ph = Placeholder.objects.get(pk=ph.pk)
-        txt.body = '\n'.join(['<img id="plugin_obj_%d" src=""/>' % l.cmsplugin_ptr_id for l in link_plugins])
-        txt.save()
+        text_plugin.body = '\n'.join(['<img id="plugin_obj_%d" src=""/>' % l.cmsplugin_ptr_id for l in link_plugins])
+        text_plugin.save()
         text_plugin = self.reload(text_plugin)
 
         with self.assertNumQueries(2):


### PR DESCRIPTION
Fix #5030 by setting ``related_name='+'`` on the OneToOne relation between ``CMSPlugin`` superclass and its child classes

Currently one tests fails which uses the ``search`` function in ``PageManager`` https://github.com/divio/django-cms/blob/develop/cms/models/managers.py#L50-L81 which is apparently built on top of  reverse descriptor... Is this really something in use nowadays?
If not we can deprecate the this in 3.2.2 and remove in 3.3