### PR TITLE
don't fail on other tests if test po fails

### DIFF
--- a/cms/tests/test_po.py
+++ b/cms/tests/test_po.py
@@ -54,6 +54,10 @@ class PoTest(TestCase):
             shutil.copytree(SOURCE_DIR, os.path.join(tmpdir, 'locale'))
             olddir = os.getcwd()
             os.chdir(tmpdir)
-            ok, stderr = compile_messages()
-            os.chdir(olddir)
+            try:
+                ok, stderr = compile_messages()
+            except Exception, e:
+                ok, stderr = False, "{}: {} ({})".format(type(e), e, tmpdir)
+            finally:
+                os.chdir(olddir)
         self.assertTrue(ok, stderr)


### PR DESCRIPTION
previously if this test failed, it would leave the current directory
in a inconstant state (pointing to a temporary directory that is
deleted).
This caused the following error on many tests in the testsuite:

cwd = os.getcwd()
OSError: [Errno 2] No such file or directory

After this fix the testsuite still fails, but only on the actual tests that still have problems.