### PR TITLE
limit branches to build on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ branches:
   only:
     - master
     - develop
+    - release/3.2.x
+    - support/3.1.x
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,11 @@ addons:
     packages:
     - enchant
 
+branches:
+  only:
+    - master
+    - develop
+
 env:
   global:
     - secure: NWiSBCHFB6LbTMget2qLIdqZlx0zeu3j+Y7Lsqb8kuYXyT2IUBGFVedcGWuGv/9Mzypb80EQWtVTokA3/3QIbesqr29uG95pMPHiYWLdnTO6UHcLMcNXiSzhBGdRDZ40iHSVv2dDHs4GNwGOH5+UCA0z3j7SWmChuFbNXh+Vsqw=


### PR DESCRIPTION
This limits travis to only build the master and develop branches. All
other code should be covered by the pull-request builds.

This should roughly halve the load on the travis buildserver.

We could consider adding the ``support/*`` branches here as well (see [travis docs about branches](https://docs.travis-ci.com/user/customizing-the-build/#Using-regular-expressions) ).