### PR TITLE
Update docs to not recommend multiple databases.

### DIFF
--- a/docs/how_to/install.rst
+++ b/docs/how_to/install.rst
@@ -264,7 +264,7 @@ is very well documented on the systems' respective websites.
 To use django CMS efficiently, we recommend:
 
 * Creating a separate set of credentials for django CMS.
-* Creating a separate database for django CMS to use.
+* Creating a new database for django CMS, not reusing an existing one.
 
 .. _PostgreSQL: http://www.postgresql.org/
 .. _MySQL: http://www.mysql.com


### PR DESCRIPTION
I spent the better part of two days trying to get Django set up in a multi-db system because my engineering manager and I understood these docs to mean that Django CMS is recommended to run in a multi-db system. 

On the IRC channel, @rfleschenberg communicated that a multi-db setup is not the recommended default case, and that these documents were meant more to dissuade people with existing Wordpress/Drupal/etc solutions from just connecting their new Django CMS app to their existing database. This seems to be in line with the rest of the "how_to/install" documentation, as there is no implementation or further instruction on setting up a multi-db Django environment within this file.