### PR TITLE
sane add plugin cleanup

### DIFF
--- a/cms/admin/forms.py
+++ b/cms/admin/forms.py
@@ -667,12 +667,13 @@ class PluginAddValidationForm(forms.Form):
         from cms.utils.plugins import has_reached_plugin_limit
 
         data = self.cleaned_data
+
+        if self.errors:
+            return data
+
         language = data['plugin_language']
         placeholder = data['placeholder_id']
         parent_plugin = data.get('plugin_parent')
-
-        if self.errors:
-            return self.cleaned_data
 
         if language not in get_language_list():
             message = ugettext("Language must be set to a supported language!")

--- a/cms/admin/forms.py
+++ b/cms/admin/forms.py
@@ -10,16 +10,17 @@ from django.forms.utils import ErrorList
 from django.forms.widgets import HiddenInput
 from django.template.defaultfilters import slugify
 from django.utils.encoding import force_text
-from django.utils.translation import ugettext_lazy as _, get_language
+from django.utils.translation import ugettext, ugettext_lazy as _, get_language
 
 from cms.apphook_pool import apphook_pool
+from cms.exceptions import PluginLimitReached
 from cms.constants import PAGE_TYPES_ID
 from cms.forms.widgets import UserSelectAdminWidget, AppHookSelect, ApplicationConfigSelect
-from cms.models import (Page, PagePermission, PageUser, ACCESS_PAGE, PageUserGroup, Title,
-                        EmptyTitle, GlobalPagePermission)
+from cms.models import (CMSPlugin, Page, PagePermission, PageUser, ACCESS_PAGE, PageUserGroup, Title,
+                        Placeholder, EmptyTitle, GlobalPagePermission)
 from cms.utils.compat.forms import UserCreationForm
 from cms.utils.conf import get_cms_setting
-from cms.utils.i18n import get_language_tuple
+from cms.utils.i18n import get_language_list, get_language_tuple
 from cms.utils.mail import mail_page_user_change
 from cms.utils.page import is_valid_page_slug
 from cms.utils.page_resolver import is_valid_url
@@ -644,3 +645,63 @@ class PageUserGroupForm(GenericCmsPermissionForm):
             group.save()
         save_permissions(self.cleaned_data, group)
         return group
+
+
+class PluginAddValidationForm(forms.Form):
+    placeholder_id = forms.ModelChoiceField(
+        queryset=Placeholder.objects.all(),
+        required=True,
+    )
+    plugin_language = forms.CharField(required=True)
+    plugin_parent = forms.ModelChoiceField(
+        CMSPlugin.objects.all(),
+        required=False,
+    )
+    plugin_position = forms.IntegerField(required=False)
+
+    def __init__(self, *args, **kwargs):
+        self.plugin_type = kwargs.pop('plugin_type')
+        super(PluginAddValidationForm, self).__init__(*args, **kwargs)
+
+    def clean(self):
+        from cms.utils.plugins import has_reached_plugin_limit
+
+        data = self.cleaned_data
+        language = data['plugin_language']
+        placeholder = data['placeholder_id']
+        parent_plugin = data.get('plugin_parent')
+
+        if self.errors:
+            return self.cleaned_data
+
+        if language not in get_language_list():
+            message = ugettext("Language must be set to a supported language!")
+            self.add_error('plugin_language', message)
+            return self.cleaned_data
+
+        if parent_plugin:
+            if parent_plugin.language != language:
+                message = ugettext("Parent plugin language must be same as language!")
+                self.add_error('plugin_language', message)
+                return self.cleaned_data
+
+            if parent_plugin.placeholder_id != placeholder.pk:
+                message = ugettext("Parent plugin placeholder must be same as placeholder!")
+                self.add_error('placeholder_id', message)
+                return self.cleaned_data
+
+        if placeholder.page:
+            template = placeholder.page.get_template()
+        else:
+            template = None
+
+        try:
+            has_reached_plugin_limit(
+                placeholder,
+                self.plugin_type,
+                language,
+                template=template
+            )
+        except PluginLimitReached as error:
+            self.add_error(None, force_text(error))
+        return self.cleaned_data

--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -610,7 +610,9 @@ class PageAdmin(PlaceholderAdminMixin, ModelAdmin):
         return True
 
     @create_revision()
-    def post_add_plugin(self, request, placeholder, plugin):
+    def post_add_plugin(self, request, plugin):
+        placeholder = plugin.placeholder
+
         if is_installed('reversion') and placeholder.page:
             plugin_name = force_text(plugin_pool.get_plugin(plugin.plugin_type).name)
             message = _(u"%(plugin_name)s plugin added to %(placeholder)s") % {

--- a/cms/admin/placeholderadmin.py
+++ b/cms/admin/placeholderadmin.py
@@ -34,7 +34,6 @@ from cms.utils import (
     get_language_from_request,
     permissions,
 )
-from cms.utils.compat.dj import force_unicode
 from cms.utils.i18n import get_language_list, force_language
 from cms.utils.plugins import (
     requires_reload,
@@ -247,14 +246,14 @@ class PlaceholderAdminMixin(object):
         """
         for required in ['placeholder_id', 'plugin_type', 'plugin_language']:
             if required not in request.GET:
-                return HttpResponseBadRequest(force_unicode(
+                return HttpResponseBadRequest(force_text(
                     _("Invalid request, missing '%s' parameter") % required
                 ))
         plugin_type = request.GET['plugin_type']
         try:
             plugin_class = plugin_pool.get_plugin(plugin_type)
         except KeyError:
-            return HttpResponseBadRequest(force_unicode(
+            return HttpResponseBadRequest(force_text(
                 _("Invalid plugin type '%s'") % plugin_type
             ))
 

--- a/cms/admin/placeholderadmin.py
+++ b/cms/admin/placeholderadmin.py
@@ -103,7 +103,7 @@ class FrontendEditableAdminMixin(object):
                 'message': force_text(_("You do not have permission to edit this item"))
             }
             return render(request, 'admin/cms/page/plugin/error_form.html', context)
-            # Dinamically creates the form class with only `field_name` field
+            # Dynamically creates the form class with only `field_name` field
         # enabled
         form_class = self.get_form(request, obj, fields=fields)
         if not cancel_clicked and request.method == 'POST':

--- a/cms/admin/placeholderadmin.py
+++ b/cms/admin/placeholderadmin.py
@@ -237,19 +237,19 @@ class PlaceholderAdminMixin(object):
         Shows the add plugin form and saves it on POST.
 
         Requires the following GET parameters:
-
             - placeholder_id
             - plugin_type
             - plugin_language
             - plugin_parent (optional)
             - plugin_position (optional)
         """
-        for required in ['placeholder_id', 'plugin_type', 'plugin_language']:
-            if required not in request.GET:
-                return HttpResponseBadRequest(force_text(
-                    _("Invalid request, missing '%s' parameter") % required
+        plugin_type = request.GET.get('plugin_type')
+
+        if not plugin_type:
+            return HttpResponseBadRequest(force_text(
+                    _("Invalid request, missing plugin_type parameter")
                 ))
-        plugin_type = request.GET['plugin_type']
+
         try:
             plugin_class = plugin_pool.get_plugin(plugin_type)
         except KeyError:

--- a/cms/admin/placeholderadmin.py
+++ b/cms/admin/placeholderadmin.py
@@ -211,7 +211,7 @@ class PlaceholderAdminMixin(object):
             return False
         return True
 
-    def post_add_plugin(self, request, placeholder, plugin):
+    def post_add_plugin(self, request, plugin):
         pass
 
     def post_copy_plugins(self, request, source_placeholder, target_placeholder, plugins):
@@ -260,7 +260,11 @@ class PlaceholderAdminMixin(object):
 
         plugin_admin = plugin_class(admin_site=self.admin_site)
 
-        return plugin_admin.add_view(request)
+        response = plugin_admin.add_view(request)
+
+        if request.method == "POST" and plugin_admin.object_successfully_changed:
+            self.post_add_plugin(request, plugin_admin.saved_object)
+        return response
 
     @method_decorator(require_POST)
     @xframe_options_sameorigin

--- a/cms/plugin_base.py
+++ b/cms/plugin_base.py
@@ -340,14 +340,6 @@ class CMSPluginBase(six.with_metaclass(CMSPluginBaseMetaclass, admin.ModelAdmin)
             'admin/cms/plugin/close_modal.html', {'is_popup': True}
         )
 
-    def response_add(self, request, obj, post_url_continue=None):
-        if admin.options.IS_POPUP_VAR in request.POST:
-            # prevent Django from rendering it's popup_close html
-            # Django's template assumes certain js functions
-            # and so will throw an error when adding plugins.
-            return self.render_close_modal()
-        return super(CMSPluginBase, self).response_add(request, obj, post_url_continue)
-
     def response_post_save_add(self, request, obj):
         """
         Always redirect to index. Usually CMS Plugins aren't registered with
@@ -408,6 +400,12 @@ class CMSPluginBase(six.with_metaclass(CMSPluginBaseMetaclass, admin.ModelAdmin)
         New version will be created in admin.views.edit_plugin
         """
         self.object_successfully_changed = True
+
+        if admin.options.IS_POPUP_VAR in request.POST:
+            # prevent Django from rendering it's popup_close html
+            # Django's template assumes certain js functions
+            # and so will throw an error when adding plugins.
+            return self.render_close_modal()
 
         post_url_continue = reverse('admin:cms_page_edit_plugin',
                 args=(obj._get_pk_val(),),

--- a/cms/plugin_base.py
+++ b/cms/plugin_base.py
@@ -365,13 +365,16 @@ class CMSPluginBase(six.with_metaclass(CMSPluginBaseMetaclass, admin.ModelAdmin)
         # When adding an object, it won't have a position
         if not obj.position:
             if obj.parent_id:
-                obj.position = CMSPlugin.objects.filter(
+                position = CMSPlugin.objects.filter(
                     parent_id=obj.parent_id
                 ).count()
             else:
-                obj.position = CMSPlugin.objects.filter(
-                    placeholder_id=obj.placeholder_id
+                position = CMSPlugin.objects.filter(
+                    parent__isnull=True,
+                    language=obj.language,
+                    placeholder_id=obj.placeholder_id,
                 ).count()
+            obj.position = position
 
         # remember the saved object
         self.saved_object = obj

--- a/cms/plugin_base.py
+++ b/cms/plugin_base.py
@@ -335,15 +335,26 @@ class CMSPluginBase(six.with_metaclass(CMSPluginBaseMetaclass, admin.ModelAdmin)
             request, form_url, extra_context
         )
 
-    def response_post_save_add(self, request, obj):
-        """
-        Always redirect to index. Usually CMS Plugins aren't registred with
-        an admin site directly and the add_view is accessed via frontend
-        editing.
-        """
+    def render_close_modal(self):
         return render_to_response(
             'admin/cms/plugin/close_modal.html', {'is_popup': True}
         )
+
+    def response_add(self, request, obj, post_url_continue=None):
+        if admin.options.IS_POPUP_VAR in request.POST:
+            # prevent Django from rendering it's popup_close html
+            # Django's template assumes certain js functions
+            # and so will throw an error when adding plugins.
+            return self.render_close_modal()
+        return super(CMSPluginBase, self).response_add(request, obj, post_url_continue)
+
+    def response_post_save_add(self, request, obj):
+        """
+        Always redirect to index. Usually CMS Plugins aren't registered with
+        an admin site directly and the add_view is accessed via frontend
+        editing.
+        """
+        return self.render_close_modal()
 
     def save_model(self, request, obj, form, change):
         """

--- a/cms/plugin_base.py
+++ b/cms/plugin_base.py
@@ -3,14 +3,10 @@ import json
 import re
 import warnings
 
-from django.http import HttpResponse
-from django.http import HttpResponseBadRequest
+from django.http import HttpResponse, HttpResponseBadRequest
 from django.http import HttpResponseForbidden
-from django.shortcuts import get_object_or_404, render_to_response
+from django.shortcuts import render_to_response
 
-from cms.utils import get_language_list
-from cms.exceptions import PluginLimitReached
-from cms.models import Placeholder
 from django import forms
 from django.contrib import admin
 from django.core.exceptions import ImproperlyConfigured
@@ -272,7 +268,7 @@ class CMSPluginBase(six.with_metaclass(CMSPluginBaseMetaclass, admin.ModelAdmin)
         )
 
         if not form.is_valid():
-            return HttpResponse(form.errors.as_text())
+            return HttpResponseBadRequest(form.errors.as_text())
 
         placeholder = form.cleaned_data['placeholder_id']
 

--- a/cms/test_utils/project/nonroot_urls.py
+++ b/cms/test_utils/project/nonroot_urls.py
@@ -21,11 +21,7 @@ urlpatterns = [
 
 urlpatterns += i18n_patterns(
     url(r'^admin/', include(admin.site.urls)),
-    url(r'^content/', include(
-        'cms.urls',
-        app_name=get_cms_setting('APP_NAME'),
-        namespace=get_cms_setting('APP_NAME')
-    )),
+    url(r'^content/', include('cms.urls')),
     url(r'^example/$', example_view, name='example_view'),
 )
 

--- a/cms/tests/frontend/unit/cms.modal.test.js
+++ b/cms/tests/frontend/unit/cms.modal.test.js
@@ -589,9 +589,11 @@ describe('CMS.Modal', function () {
                 modal = new CMS.Modal({
                     modalDuration: 0
                 });
+                $('html').removeClass('cms-modal-maximized');
                 modal.ui.window = $('<div style="width: 2000px; height: 2000px;"></div>').prependTo(fixture.el);
                 // have to show the modal so the css values can be retrieved
                 modal.ui.modal.show();
+                modal.ui.modal.addClass('cms-modal-open');
                 done();
             });
         });
@@ -601,6 +603,8 @@ describe('CMS.Modal', function () {
         });
 
         it('fits the modal to the screen if there is enough space', function () {
+            spyOn($.fn, 'css').and.returnValue(0);
+
             expect(modal._calculateNewPosition({})).toEqual({
                 width: 1700,
                 height: 1700,
@@ -608,10 +612,14 @@ describe('CMS.Modal', function () {
                 left: 1000
             });
 
+            $.fn.css.and.callThrough();
+
             modal.ui.window.css({
                 width: 1500,
                 height: 1500
             });
+
+            $.fn.css.and.returnValue(0);
 
             expect(modal._calculateNewPosition({})).toEqual({
                 width: 1200,

--- a/cms/tests/test_management.py
+++ b/cms/tests/test_management.py
@@ -11,7 +11,6 @@ from django.test.utils import override_settings
 from django.utils.six.moves import StringIO
 
 from cms.api import create_page, add_plugin, create_title
-from cms.management.commands.cms import Command as CMSCommand
 from cms.management.commands.subcommands.list import plugin_report
 from cms.models import Page, StaticPlaceholder
 from cms.models.placeholdermodel import Placeholder
@@ -44,17 +43,26 @@ class ManagementTestCase(CMSTestCase):
             out = StringIO()
             create_page('Hello Title', "nav_playground.html", "en", apphook=APPHOOK)
             self.assertEqual(Page.objects.filter(application_urls=APPHOOK).count(), 1)
-            command = CMSCommand()
-            command.stdout = out
-            command.handle("list", "apphooks", interactive=False)
-            self.assertEqual(out.getvalue(), "SampleApp\n")
+            management.call_command(
+                "cms",
+                "list",
+                "apphooks",
+                interactive=False,
+                stdout=out,
+            )
+            self.assertEqual(out.getvalue(), "SampleApp (draft)\n")
 
     def test_uninstall_apphooks_without_apphook(self):
         with apphooks():
             out = StringIO()
-            command = CMSCommand()
-            command.stdout = out
-            command.handle("uninstall", "apphooks", APPHOOK, interactive=False)
+            management.call_command(
+                "cms",
+                "uninstall",
+                "apphooks",
+                APPHOOK,
+                interactive=False,
+                stdout=out,
+            )
             self.assertEqual(out.getvalue(), "no 'SampleApp' apphooks found\n")
 
     def test_fix_tree(self):
@@ -78,9 +86,14 @@ class ManagementTestCase(CMSTestCase):
             out = StringIO()
             create_page('Hello Title', "nav_playground.html", "en", apphook=APPHOOK)
             self.assertEqual(Page.objects.filter(application_urls=APPHOOK).count(), 1)
-            command = CMSCommand()
-            command.stdout = out
-            command.handle("uninstall", "apphooks", APPHOOK, interactive=False)
+            management.call_command(
+                "cms",
+                "uninstall",
+                "apphooks",
+                APPHOOK,
+                interactive=False,
+                stdout=out,
+            )
             self.assertEqual(out.getvalue(), "1 'SampleApp' apphooks uninstalled\n")
             self.assertEqual(Page.objects.filter(application_urls=APPHOOK).count(), 0)
 

--- a/cms/tests/test_placeholder.py
+++ b/cms/tests/test_placeholder.py
@@ -1068,8 +1068,11 @@ class PlaceholderAdminTest(PlaceholderAdminTestBase):
                 self.assertEqual(response.status_code, 302)
                 response = admin_instance.add_plugin(request)  # second
                 self.assertEqual(response.status_code, 400)
-                self.assertEqual(response.content,
-                                 b"This placeholder already has the maximum number (1) of allowed Text plugins.")
+                self.assertEqual(
+                    response.content,
+                    b"* __all__\n  * This placeholder already has the "
+                    b"maximum number (1) of allowed Text plugins."
+                )
 
     def test_global_limit_on_plugin_move(self):
         admin_instance = self.get_admin()
@@ -1097,7 +1100,7 @@ class PlaceholderAdminTest(PlaceholderAdminTestBase):
                 self.assertEqual(response.status_code, 400)
                 self.assertEqual(
                     response.content,
-                    "This placeholder already has the maximum number of plugins (2)."
+                    b"This placeholder already has the maximum number of plugins (2)."
                 )
 
     def test_type_limit_on_plugin_move(self):

--- a/cms/tests/test_placeholder.py
+++ b/cms/tests/test_placeholder.py
@@ -1042,7 +1042,10 @@ class PlaceholderAdminTest(PlaceholderAdminTestBase):
                 self.assertEqual(response.status_code, 200)
                 response = admin_instance.add_plugin(request)  # third
                 self.assertEqual(response.status_code, 400)
-                self.assertEqual(response.content, b"This placeholder already has the maximum number of plugins (2).")
+                self.assertEqual(
+                    response.content,
+                    b"* __all__\n  * This placeholder already has the maximum number of plugins (2).",
+                )
 
     def test_type_limit(self):
         placeholder = self.get_placeholder()
@@ -1092,7 +1095,10 @@ class PlaceholderAdminTest(PlaceholderAdminTestBase):
                 request = self.get_post_request({'placeholder_id': target_placeholder.pk, 'plugin_id': plugin_3.pk})
                 response = admin_instance.move_plugin(request) # third
                 self.assertEqual(response.status_code, 400)
-                self.assertEqual(response.content, b"This placeholder already has the maximum number of plugins (2).")
+                self.assertEqual(
+                    response.content,
+                    "This placeholder already has the maximum number of plugins (2)."
+                )
 
     def test_type_limit_on_plugin_move(self):
         admin_instance = self.get_admin()

--- a/cms/tests/test_plugins.py
+++ b/cms/tests/test_plugins.py
@@ -40,7 +40,7 @@ from cms.test_utils.project.pluginapp.plugins.validation.cms_plugins import (
 from cms.test_utils.testcases import (
     CMSTestCase, URL_CMS_PAGE, URL_CMS_PLUGIN_MOVE, URL_CMS_PAGE_ADD,
     URL_CMS_PLUGIN_ADD, URL_CMS_PLUGIN_EDIT, URL_CMS_PAGE_CHANGE,
-    URL_CMS_PLUGIN_REMOVE, URL_CMS_PAGE_PUBLISH, URL_CMS_PLUGIN_DELETE, URL_CMS_PLUGINS_COPY)
+    URL_CMS_PLUGIN_REMOVE, URL_CMS_PAGE_PUBLISH, URL_CMS_PLUGINS_COPY)
 from cms.test_utils.util.fuzzy_int import FuzzyInt
 from cms.toolbar.toolbar import CMSToolbar
 from cms.utils.conf import get_cms_setting

--- a/cms/tests/test_plugins.py
+++ b/cms/tests/test_plugins.py
@@ -280,47 +280,6 @@ class PluginsTestCase(PluginsTestBaseCase):
         self.assertTrue('/edit-plugin/%s/'% column.pk, text_breadcrumbs[1]['url'])
         self.assertTrue('/edit-plugin/%s/'% text_plugin.pk, text_breadcrumbs[2]['url'])
 
-    def test_add_cancel_plugin(self):
-        """
-        Test that you can cancel a new plugin before editing and
-        that the plugin is removed.
-        """
-        # add a new text plugin
-        page_data = self.get_new_page_data()
-        self.client.post(URL_CMS_PAGE_ADD, page_data)
-        page = Page.objects.all()[0]
-        plugin_data = {
-            'plugin_type': "TextPlugin",
-            'plugin_language': settings.LANGUAGES[0][0],
-            'placeholder_id': page.placeholders.get(slot="body").pk,
-            'plugin_parent': '',
-        }
-        response = self.client.post(URL_CMS_PLUGIN_ADD, plugin_data)
-        self.assertEqual(response.status_code, 200)
-        pk = CMSPlugin.objects.all()[0].pk
-        expected = {
-            "url": URL_CMS_PLUGIN_EDIT + "%s/" % pk,
-            "breadcrumb": [
-                {
-                    "url": URL_CMS_PLUGIN_EDIT + "%s/" % pk,
-                    "title": "Text"
-                }
-            ],
-            'delete': URL_CMS_PLUGIN_DELETE % pk
-        }
-        output = json.loads(response.content.decode('utf8'))
-        self.assertEqual(output, expected)
-        # now click cancel instead of editing
-        response = self.client.get(output['url'])
-        self.assertEqual(response.status_code, 200)
-        data = {
-            "body": "Hello World",
-            "_cancel": True,
-        }
-        response = self.client.post(output['url'], data)
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(0, Text.objects.count())
-
     def test_extract_images_from_text(self):
         img_path = os.path.join(os.path.dirname(__file__), 'data', 'image.jpg')
         with open(img_path, 'rb') as fobj:


### PR DESCRIPTION
Fixes for #4381

* modify the signature for post_add_plugin to not require a placeholder
* removed force_unicode as it's no longer needed after 1.8
* fixes bug on plugin position calculation
* fixes some failing tests
* fixes potential corrupt parent/child relationships
* moved add check logic to form

**FE**
@vxsx so seems I can't get this to work with ckeditor.
We use a ``POST`` request [here](https://github.com/divio/djangocms-text-ckeditor/blob/master/djangocms_text_ckeditor/static/djangocms_text_ckeditor/ckeditor_plugins/cmsplugins/plugin.js#L197) instead of  ``GET`` request.
I tried changing it but then another issue comes up which is that the js expects the response to have things like url key and such, instead the response is a full html page that should be rendered in the modal.


**BE**
@divio/django-cms-core I would like your feedback on this, specially @ojii.