### PR TITLE
Render Menus from current site fix

### DIFF
--- a/cms/cms_menus.py
+++ b/cms/cms_menus.py
@@ -12,6 +12,7 @@ from cms.utils.page_resolver import get_page_queryset
 from cms.utils.moderator import get_title_queryset, use_draft
 from menus.base import Menu, NavigationNode, Modifier
 from menus.menu_pool import menu_pool
+from django.contrib.sites.models import Site
 
 
 def get_visible_page_objects(request, pages, site=None):
@@ -176,7 +177,7 @@ def page_to_node(page, home, cut):
 class CMSMenu(Menu):
     def get_nodes(self, request):
         page_queryset = get_page_queryset(request)
-        site = current_site(request)
+        site = Site.objects.get_current()
         lang = get_language_from_request(request)
 
         filters = {


### PR DESCRIPTION
current_site(request) returns the site selected in the page admin
dropdown.
This leads to a bug where for example site 1 is rendered
with the menu from site 2, if site 2 is selected in the
field-site-select dropdown