### PR TITLE
Add missing permission name

### DIFF
--- a/cms/migrations/0015_auto_20160404_1908.py
+++ b/cms/migrations/0015_auto_20160404_1908.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
+from django.db import migrations, models
+
+
+def forwards(apps, schema_editor):
+    page_model = apps.get_model('cms', 'Page')
+    page_ctype = ContentType.objects.get_for_model(page_model)
+    Permission.objects.filter(
+        name='',
+        codename='change_page', content_type=page_ctype).update(name='Can change page')
+
+
+def backwards(apps, schema_editor):
+    # Do nothing, but allow backward migrations
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('cms', '0014_auto_20151111_2359'),
+        ('contenttypes', '__latest__'),
+    ]
+
+    operations = [
+        migrations.RunPython(forwards, backwards)
+    ]

--- a/cms/tests/test_toolbar.py
+++ b/cms/tests/test_toolbar.py
@@ -304,7 +304,9 @@ class ToolbarTests(ToolbarTestBase):
     def test_show_toolbar_to_staff(self):
         page = create_page("toolbar-page", "nav_playground.html", "en",
                            published=True)
-        request = self.get_page_request(page, self.get_staff(), '/')
+        staff = self.get_staff()
+        assert staff.user_permissions.get().name == 'Can change page'
+        request = self.get_page_request(page, staff, '/')
         toolbar = CMSToolbar(request)
         self.assertTrue(toolbar.show_toolbar)
 


### PR DESCRIPTION
Permission cms.change_page is missing name when created in migration 0010.
Added migration which update value of that Permission.