### PR TITLE
fixes #5140

### DIFF
--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -840,14 +840,9 @@ class Page(six.with_metaclass(PageMetaClass, MP_Node)):
                 if not publisher_public.parent_id:
                     publisher_public = page._publisher_save_public(publisher_public)
 
-                # query and caching optimization
-
-                if publisher_public.parent_id and not publisher_public.parent:
-                    page.publisher_public.parent = Page.objects.get(pk=page.publisher_public.parent_id)
-
                 # Check if the parent of this page's
                 # public version is published.
-                if page.publisher_public.parent.is_published(language):
+                if publisher_public.parent.is_published(language):
                     public_title = titles_by_page_id.get(page.publisher_public_id)
 
                     if public_title and not public_title.published:

--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -235,8 +235,7 @@ class Page(six.with_metaclass(PageMetaClass, MP_Node)):
             # Ensure we have up to date mptt properties
             public_page = Page.objects.get(pk=moved_page.publisher_public_id)
             # Ensure that the page is in the right position and save it
-            moved_page._publisher_save_public(public_page)
-            public_page = public_page.reload()
+            public_page = moved_page._publisher_save_public(public_page)
             cms_signals.page_moved.send(sender=Page, instance=public_page)
 
             page_utils.check_title_slugs(public_page)
@@ -838,6 +837,13 @@ class Page(six.with_metaclass(PageMetaClass, MP_Node)):
                 publisher_public = page.publisher_public
 
                 if not publisher_public.parent_id:
+                    # This page clearly has a parent because it shows up
+                    # when calling self.get_descendants()
+                    # So this condition can be True when a published page
+                    # is moved under a page that has never been published.
+                    # It's draft version (page) has a reference to the new parent
+                    # but it's live version does not because it was never set
+                    # since it didn't exist when the move happened.
                     publisher_public = page._publisher_save_public(publisher_public)
 
                 # Check if the parent of this page's

--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -270,20 +270,17 @@ class Page(six.with_metaclass(PageMetaClass, MP_Node)):
                     # this looks redundant but it's necessary
                     # for all the descendants of the page being
                     # copied to be set to the correct state.
-                    moved_page.publish(language)
-                else:
+                    moved_page.mark_as_published(language)
+                    moved_page.mark_descendants_as_published(language)
+                elif published:
+                    # page is published but it's parent is not
                     # mark the page being copied (source) as "pending"
                     moved_page.mark_as_pending(language)
                     # mark all descendants of source as "pending"
                     moved_page.mark_descendants_pending(language)
-            else:
-                if published:
-                    moved_page.publish(language)
-                else:
-                    # mark the page being copied (source) as "pending"
-                    moved_page.mark_as_pending(language)
-                    # mark all descendants of source as "pending"
-                    moved_page.mark_descendants_pending(language)
+            elif published:
+                moved_page.mark_as_published(language)
+                moved_page.mark_descendants_as_published(language)
 
         from cms.cache import invalidate_cms_page_cache
         invalidate_cms_page_cache()
@@ -693,50 +690,9 @@ class Page(six.with_metaclass(PageMetaClass, MP_Node)):
 
         # Check if there are some children which are waiting for parents to
         # become published.
-        from cms.models import Title
-        publish_set = list(self.get_descendants().filter(title_set__published=True,
-                                                    title_set__language=language).select_related('publisher_public', 'publisher_public__parent').order_by('depth', 'path'))
-        #prefetch the titles
-        publish_ids = {}
-        for page in publish_set:
-            publish_ids[page.pk] = None
-            if page.publisher_public_id:
-                publish_ids[page.publisher_public.pk] = None
-        titles = Title.objects.filter(page__pk__in=publish_ids.keys(), language=language)
-        for title in titles:
-            publish_ids[title.page_id] = title
+        self.mark_descendants_as_published(language)
 
-        for page in publish_set:
-            if page.pk in publish_ids and publish_ids[page.pk]:
-                page.title_cache = {}
-                page.title_cache[language] = publish_ids[page.pk]
-            if page.publisher_public_id:
-                if not page.publisher_public.parent_id:
-                    page._publisher_save_public(page.publisher_public)
-                #query and caching optimization
-                if page.publisher_public.parent_id and not page.publisher_public.parent:
-                    page.publisher_public.parent = Page.objects.get(pk=page.publisher_public.parent_id)
-                if page.publisher_public.parent_id in publish_ids:
-                    page.publisher_public.parent.title_cache = {}
-                    page.publisher_public.parent.title_cache[language] = publish_ids[page.publisher_public.parent_id]
-                if page.publisher_public.parent and page.publisher_public.parent.is_published(language):
-                    if page.publisher_public_id in publish_ids:
-                        public_title = publish_ids[page.publisher_public_id]
-                    else:
-                        public_title = None
-                    draft_title = publish_ids[page.pk]
-                    if public_title and not public_title.published:
-                        public_title._publisher_keep_state = True
-                        public_title.published = True
-                        public_title.publisher_state = PUBLISHER_STATE_DEFAULT
-                        public_title.save()
-                    if draft_title.publisher_state == PUBLISHER_STATE_PENDING:
-                        draft_title.publisher_state = PUBLISHER_STATE_DEFAULT
-                        draft_title._publisher_keep_state = True
-                        draft_title.save()
-            elif page.get_publisher_state(language) == PUBLISHER_STATE_PENDING:
-                page.publish(language)
-                # fire signal after publishing is done
+        # fire signal after publishing is done
         import cms.signals as cms_signals
 
         cms_signals.post_publish.send(sender=Page, instance=self, language=language)
@@ -764,8 +720,8 @@ class Page(six.with_metaclass(PageMetaClass, MP_Node)):
         if hasattr(self, 'title_cache'):
             self.title_cache[language] = title
         public_title.published = False
-
         public_title.save()
+
         public_page = self.publisher_public
         public_placeholders = public_page.get_placeholders()
         for pl in public_placeholders:
@@ -783,6 +739,27 @@ class Page(six.with_metaclass(PageMetaClass, MP_Node)):
 
         return True
 
+    def mark_as_pending(self, language):
+        public = self.get_public_object()
+
+        if public:
+            state = public.get_publisher_state(language)
+            # keep the same state
+            # only set the page as unpublished
+            public.set_publisher_state(
+                language,
+                state=state,
+                published=False
+            )
+
+        draft = self.get_draft_object()
+
+        if draft and draft.is_published(language) and draft.get_publisher_state(
+                language) == PUBLISHER_STATE_DEFAULT:
+            # Only change the state if the draft page is published
+            # and it's state is the default (0)
+            draft.set_publisher_state(language, state=PUBLISHER_STATE_PENDING)
+
     def mark_descendants_pending(self, language):
         assert self.publisher_is_draft
 
@@ -795,26 +772,98 @@ class Page(six.with_metaclass(PageMetaClass, MP_Node)):
             for child in descendants:
                 child.mark_as_pending(language)
 
-    def mark_as_pending(self, language):
+    def mark_as_published(self, language):
         from cms.models import Title
 
         public = self.get_public_object()
 
         if public:
             try:
+                public_published = public.is_published(language)
+            except Title.DoesNotExist:
+                public_published = False
+
+            if public_published:
                 public.set_publisher_state(
                     language,
-                    PUBLISHER_STATE_PENDING,
-                    published=False
+                    state=PUBLISHER_STATE_DEFAULT,
+                    published=True
                 )
-            except Title.DoesNotExist:
-                return
 
         draft = self.get_draft_object()
 
-        if draft and draft.is_published(language) and draft.get_publisher_state(
-                language) == PUBLISHER_STATE_DEFAULT:
-            draft.set_publisher_state(language, PUBLISHER_STATE_PENDING)
+        if draft.get_publisher_state(language) == PUBLISHER_STATE_PENDING:
+            draft.set_publisher_state(language, PUBLISHER_STATE_DEFAULT)
+
+    def mark_descendants_as_published(self, language):
+        if not self.publisher_is_draft:
+            raise PublicIsUnmodifiable('The public instance cannot be published. Use draft.')
+
+        # Check if there are some children which are waiting for parents to
+        # become published.
+        from cms.models import Title
+
+        # List of published draft pages
+        publish_set = list(
+            self.get_descendants()
+            .filter(title_set__published=True, title_set__language=language)
+            .select_related('publisher_public', 'publisher_public__parent')
+            .order_by('depth', 'path')
+        )
+
+        # prefetch the titles
+        page_ids = []
+
+        for page in publish_set:
+            if not page.pk in page_ids:
+                page_ids.append(page.pk)
+
+            publisher_id = page.publisher_public_id
+
+            if publisher_id and not publisher_id in page_ids:
+                page_ids.append(publisher_id)
+
+        titles = Title.objects.filter(page__pk__in=page_ids, language=language)
+        titles_by_page_id = {}
+
+        for title in titles:
+            titles_by_page_id[title.page_id] = title
+
+        for page in publish_set:
+            if page.pk in titles_by_page_id:
+                page.title_cache = {language: titles_by_page_id[page.pk]}
+
+            if page.publisher_public_id:
+                # Page has a public version
+                publisher_public = page.publisher_public
+
+                if not publisher_public.parent_id:
+                    publisher_public = page._publisher_save_public(publisher_public)
+
+                # query and caching optimization
+
+                if publisher_public.parent_id and not publisher_public.parent:
+                    page.publisher_public.parent = Page.objects.get(pk=page.publisher_public.parent_id)
+
+                # Check if the parent of this page's
+                # public version is published.
+                if page.publisher_public.parent.is_published(language):
+                    public_title = titles_by_page_id.get(page.publisher_public_id)
+
+                    if public_title and not public_title.published:
+                        public_title._publisher_keep_state = True
+                        public_title.published = True
+                        public_title.publisher_state = PUBLISHER_STATE_DEFAULT
+                        public_title.save()
+
+                    draft_title = titles_by_page_id[page.pk]
+
+                    if draft_title.publisher_state == PUBLISHER_STATE_PENDING:
+                        draft_title.publisher_state = PUBLISHER_STATE_DEFAULT
+                        draft_title._publisher_keep_state = True
+                        draft_title.save()
+            elif page.get_publisher_state(language) == PUBLISHER_STATE_PENDING:
+                page.publish(language)
 
     def revert(self, language):
         """Revert the draft version to the same state as the public version
@@ -1311,6 +1360,7 @@ class Page(six.with_metaclass(PageMetaClass, MP_Node)):
                         obj = obj.move(next_sibling.publisher_public, pos="left")
             else:
                 obj.save()
+        return obj
 
     def move(self, target, pos=None):
         super(Page, self).move(target, pos)

--- a/cms/tests/test_publisher.py
+++ b/cms/tests/test_publisher.py
@@ -783,29 +783,41 @@ class PublishingTests(TestCase):
 
     def test_prepublish_descendants(self):
         page = self.create_page("Page", published=True)
-        child = self.create_page("Child", parent=page, published=False)
-        gchild2 = self.create_page("Grandchild2", parent=child, published=False)
-        self.create_page("Grandchild3", parent=child, published=True)
-        gchild = self.create_page("Grandchild", published=True)
-        gchild = gchild.reload()
-        child = child.reload()
-        gchild.move_page(target=child, position='last-child')
-        gchild.reload()
-        gchild.publish('en')
-        self.assertFalse(child.is_published('en'))
-        self.assertTrue(gchild.is_published('en'))
-        self.assertEqual(gchild.get_publisher_state('en'), PUBLISHER_STATE_PENDING)
-        child = child.reload()
-        child.publish('en')
-        gchild2 = gchild2.reload()
-        gchild2.publish('en')
-        self.assertTrue(child.is_published("en"))
-        self.assertTrue(gchild.is_published("en"))
-        self.assertEqual(gchild.get_publisher_state('en', force_reload=True), PUBLISHER_STATE_DEFAULT)
-        gchild = gchild.reload()
-        gchild2 = gchild2.reload()
-        self.assertEqual(gchild.path[4:], gchild.publisher_public.path[4:])
-        self.assertEqual(gchild.depth, gchild.publisher_public.depth)
+        child_1 = self.create_page("Child", parent=page, published=False)
+        child_1_2 = self.create_page("Grandchild2", parent=child_1, published=False)
+        child_1_3 = self.create_page("Grandchild3", parent=child_1, published=True)
+
+        # Reload "Child" page because it's tree attributes changed when adding
+        # children to it above.
+        child_1 = child_1.reload()
+
+        # Create the first child of "Child" page as a published root node
+        child_1_1 = self.create_page("Grandchild", published=True)
+        # Move first child to "Child"
+        child_1_1.move_page(target=child_1, position='last-child')
+        # Publish first child
+        child_1_1.publish('en')
+
+        # Assert "Child" page is not published (we never published it)
+        self.assertFalse(child_1.is_published('en'))
+        # Assert "first child" is published (we published above)
+        self.assertTrue(child_1_1.is_published('en'))
+        # Assert "first child" is in pending state because
+        # it's parent the "Child" page is not published.
+        self.assertEqual(child_1_1.get_publisher_state('en'), PUBLISHER_STATE_PENDING)
+
+        # Publish "Child page"
+        child_1.publish('en')
+        # Publish "second child"
+        child_1_2.publish('en')
+
+        self.assertTrue(child_1.is_published("en"))
+        self.assertTrue(child_1_1.is_published("en"))
+        # Assert "first child" is no longer in pending state
+        # and instead is in published state.
+        self.assertEqual(child_1_1.get_publisher_state('en', force_reload=True), PUBLISHER_STATE_DEFAULT)
+        self.assertEqual(child_1_1.path[4:], child_1_1.publisher_public.path[4:])
+        self.assertEqual(child_1_1.depth, child_1_1.publisher_public.depth)
 
     def test_republish_multiple_root(self):
         # TODO: The paths do not match expected behaviour

--- a/cms/tests/test_publisher.py
+++ b/cms/tests/test_publisher.py
@@ -785,7 +785,8 @@ class PublishingTests(TestCase):
         page = self.create_page("Page", published=True)
         child_1 = self.create_page("Child", parent=page, published=False)
         child_1_2 = self.create_page("Grandchild2", parent=child_1, published=False)
-        child_1_3 = self.create_page("Grandchild3", parent=child_1, published=True)
+
+        self.create_page("Grandchild3", parent=child_1, published=True)
 
         # Reload "Child" page because it's tree attributes changed when adding
         # children to it above.


### PR DESCRIPTION
* Fixed #5140
* Fixed bug where an unpublished child page would be set to pending if it's parent was unpublished.
* Refactored move_page to no longer publish pages.
  instead it now calls ``mark_as_published`` and ``mark_descendants_as_published``.
  This is to avoid executing the whole publication logic on page move which can result in many
  inconsistencies.
* Refactored the logic from ``publish()`` that updates the state of descendant pages
  into a new method called ``mark_descendants_as_published``.
  This is to allow other actions like moving a page to benefit from this operation without
  calling ``publish()``. The refactor removed a lot of dead code.