### PR TITLE
Refactor gulp tests:integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ install:
 script:
   - if [ "$FRONTEND" == 1 ] && [ "$UNIT" == 1 ]; then gulp tests:unit; fi;
   - if [ "$FRONTEND" == 1 ] && [ "$LINT" == 1 ]; then gulp lint; fi;
-  - if [ "$FRONTEND" == 1 ] && [ "$INTEGRATION" == 1 ]; then pip install -e .; pip freeze; sh cms/tests/frontend/integration/run_testserver.sh; sleep 60; gulp tests:integration; fi;
+  - if [ "$FRONTEND" == 1 ] && [ "$INTEGRATION" == 1 ]; then pip install -e .; pip freeze; gulp tests:integration; fi;
   - if [ "$FRONTEND" != 1 ]; then coverage run --parallel-mode manage.py test $MIGRATE_OPTION; fi;
   - if [ "$FRONTEND" != 1 ]; then coverage combine; fi;
 

--- a/cms/tests/frontend/integration/helpers/cms.js
+++ b/cms/tests/frontend/integration/helpers/cms.js
@@ -367,7 +367,7 @@ module.exports = function (casperjs) {
                             var amount = 0;
 
                             try {
-                                amount = $.active;
+                                amount = CMS.$.active;
                             } catch (e) {}
 
                             return amount;

--- a/cms/tests/frontend/integration/helpers/cms.js
+++ b/cms/tests/frontend/integration/helpers/cms.js
@@ -376,6 +376,81 @@ module.exports = function (casperjs) {
                         return (remainingAjaxRequests === 0);
                     }).wait(200);
             };
+        },
+
+        /**
+         * @function createJSTreeXPathFromTree
+         * @param {Object[]} tree tree object, see example
+         * @param {Object} [opts]
+         * @param {Object} [opts.topLevel=true] is it the top level?
+         * @example tree
+         *
+         *     [
+         *         {
+         *             name: 'Homepage'
+         *             children: [
+         *                 {
+         *                     name: 'Nested'
+         *                 }
+         *             ]
+         *         },
+         *         {
+         *             name: 'Sibling'
+         *         }
+         *     ]
+         */
+        createJSTreeXPathFromTree: function createJSTreeXPathFromTree(tree, opts) {
+            var xPath = '';
+            var topLevel = opts && typeof opts.topLevel !== 'undefined' ? topLevel : true;
+
+            tree.forEach(function (node, index) {
+                if (index === 0) {
+                    if (topLevel) {
+                        xPath += '//';
+                    } else {
+                        xPath += './';
+                    }
+                    xPath += 'li[./a[contains(@class, "jstree-anchor")][contains(text(), "' + node.name +
+                        '")]${children}]';
+                } else {
+                    xPath += '/following-sibling::li' +
+                        '[./a[contains(@class, "jstree-anchor")][contains(text(), "' + node.name + '")]${children}]';
+                }
+
+                if (node.children) {
+                    xPath = xPath.replace(
+                        '${children}',
+                        '/following-sibling::ul[contains(@class, "jstree-children")]' +
+                        '[' + createJSTreeXPathFromTree(node.children, { topLevel: false }) + ']'
+                    );
+                } else {
+                    xPath = xPath.replace('${children}', '');
+                }
+            });
+
+            return xPath;
+        },
+
+        /**
+         * @function getPasteHelpersXPath
+         * @public
+         * @param {Object} opts
+         * @param {Boolean} visible get visible or hidden helpers
+         * @param {String|Number} [pageId] optional id of the page to filter helpers
+         */
+        getPasteHelpersXPath: function getPasteHelpersXPath(opts) {
+            var xpath = '//*[self::div or self::span][contains(@class, "cms-tree-item-helpers")]';
+            if (opts && opts.visible) {
+                xpath += '[not(contains(@class, "cms-hidden"))]';
+            } else {
+                xpath += '[contains(@class, "cms-hidden")]';
+            }
+            xpath += '[./a[contains(text(), "Paste")]';
+            if (opts && opts.pageId) {
+                xpath += '[contains(@data-id, "' + opts.pageId + '")]';
+            }
+            xpath += ']';
+            return xpath;
         }
     };
 };

--- a/cms/tests/frontend/integration/pagetree-no-permission.js
+++ b/cms/tests/frontend/integration/pagetree-no-permission.js
@@ -77,6 +77,7 @@ casper.test.begin('Pages can be copied and pasted when CMS_PERMISSION=False', fu
                 .waitForUrl(/page/) // need to wait for reload
                 .wait(1000)
                 .waitUntilVisible('.cms-pagetree')
+                .wait(3000)
                 .then(cms.waitUntilAllAjaxCallsFinish())
                 .then(function () {
                     test.assertExists(
@@ -92,6 +93,7 @@ casper.test.begin('Pages can be copied and pasted when CMS_PERMISSION=False', fu
                         'Second page was copied into itself'
                     );
                 })
+                .then(cms.expandPageTree())
                 .then(function () {
                     this.click('.js-cms-tree-item-copy[data-id="' + secondPageId + '"]');
                 })
@@ -112,6 +114,7 @@ casper.test.begin('Pages can be copied and pasted when CMS_PERMISSION=False', fu
                 .waitForUrl(/page/) // need to wait for reload
                 .wait(1000)
                 .waitUntilVisible('.cms-pagetree', cms.expandPageTree())
+                .wait(3000)
                 .waitUntilVisible('.cms-pagetree', function () {
                     test.assertExists(
                         xPath(createJSTreeXPathFromTree([{
@@ -139,6 +142,7 @@ casper.test.begin('Pages can be copied and pasted when CMS_PERMISSION=False', fu
                 })
                 .wait(1000)
                 .waitUntilVisible('.cms-pagetree', cms.waitUntilAllAjaxCallsFinish())
+                .wait(3000)
                 .then(function () {
                     test.assertExists(
                         xPath(createJSTreeXPathFromTree([{
@@ -257,6 +261,7 @@ casper.test.begin('Pages can be copied and pasted when CMS_PERMISSION=False', fu
                 .waitForUrl(/page/) // need to wait for reload
                 .wait(1000)
                 .waitUntilVisible('.cms-pagetree', cms.expandPageTree())
+                .wait(3000)
                 .waitUntilVisible('.cms-pagetree', function () {
                     test.assertExists(
                         xPath(createJSTreeXPathFromTree([
@@ -309,6 +314,7 @@ casper.test.begin('Pages can be copied and pasted when CMS_PERMISSION=False', fu
                 })
                 .wait(1000)
                 .waitUntilVisible('.cms-pagetree')
+                .wait(3000)
                 .then(function () {
                     test.assertExists(
                         xPath(createJSTreeXPathFromTree([

--- a/cms/tests/frontend/integration/pagetree-no-permission.js
+++ b/cms/tests/frontend/integration/pagetree-no-permission.js
@@ -1,0 +1,383 @@
+/* global window */
+'use strict';
+
+var globals = require('./settings/globals');
+var casperjs = require('casper');
+var cms = require('./helpers/cms')(casperjs);
+var xPath = casperjs.selectXPath;
+var createJSTreeXPathFromTree = cms.createJSTreeXPathFromTree;
+var getPasteHelpersXPath = cms.getPasteHelpersXPath;
+
+casper.test.setUp(function (done) {
+    casper.start()
+        .then(cms.login())
+        .run(done);
+});
+
+casper.test.tearDown(function (done) {
+    casper.start()
+        .then(cms.logout())
+        .run(done);
+});
+
+casper.test.begin('Pages can be copied and pasted when CMS_PERMISSION=False', function (test) {
+    casper.start()
+        .then(cms.addPage({ title: 'Homepage' }))
+        .then(cms.addPage({ title: 'Second', parent: 'Homepage' }))
+        .thenOpen(globals.baseUrl)
+        .then(cms.openSideframe())
+        // switch to sideframe
+        .withFrame(0, function () {
+            var secondPageId;
+            casper.waitUntilVisible('.cms-pagetree')
+                .then(cms.expandPageTree())
+                .then(function () {
+                    test.assertExists(
+                        xPath(createJSTreeXPathFromTree([{
+                            name: 'Homepage',
+                            children: [{
+                                name: 'Second'
+                            }]
+                        }])),
+                        'Second page is nested into the Homepage'
+                    );
+
+                    secondPageId = cms.getPageId('Second');
+
+                    this.click('.js-cms-tree-item-copy[data-id="' + secondPageId + '"]');
+                })
+                // wait until paste buttons show up
+                .waitUntilVisible('.cms-tree-item-helpers', function () {
+                    test.assertElementCount(
+                        xPath(getPasteHelpersXPath({
+                            visible: true
+                        })),
+                        3,
+                        'Three possible paste targets'
+                    );
+                })
+                // click on it again
+                .then(function () {
+                    this.click('.js-cms-tree-item-copy[data-id="' + secondPageId + '"]');
+                    test.assertElementCount(
+                        xPath(getPasteHelpersXPath({
+                            visible: true
+                        })),
+                        0,
+                        'Paste buttons hide when clicked on copy again'
+                    );
+                    // open them again
+                    this.click('.js-cms-tree-item-copy[data-id="' + secondPageId + '"]');
+                })
+                // then try to paste into itself
+                .then(function () {
+                    this.click('.cms-tree-item-helpers a[data-id="' + secondPageId + '"]');
+                })
+                .waitForResource(/copy-page/)
+                .waitForUrl(/page/) // need to wait for reload
+                .wait(1000)
+                .waitUntilVisible('.cms-pagetree')
+                .then(cms.waitUntilAllAjaxCallsFinish())
+                .then(function () {
+                    test.assertExists(
+                        xPath(createJSTreeXPathFromTree([{
+                            name: 'Homepage',
+                            children: [{
+                                name: 'Second',
+                                children: [{
+                                    name: 'Second'
+                                }]
+                            }]
+                        }])),
+                        'Second page was copied into itself'
+                    );
+                })
+                .then(function () {
+                    this.click('.js-cms-tree-item-copy[data-id="' + secondPageId + '"]');
+                })
+                // wait until paste buttons show up
+                .waitUntilVisible('.cms-tree-item-helpers', function () {
+                    this.click('.cms-tree-item-helpers a[data-id="' + cms.getPageId('Homepage') + '"]');
+                })
+                // try to copy into parent
+                .then(function () {
+                    this.click('.js-cms-tree-item-copy[data-id="' + secondPageId + '"]');
+                })
+                // wait until paste buttons show up
+                .waitUntilVisible('.cms-tree-item-helpers', function () {
+                    // click on "Paste" to homepage
+                    this.click('.cms-tree-item-helpers a[data-id="' + cms.getPageId('Homepage') + '"]');
+                })
+                .waitForResource(/copy-page/)
+                .waitForUrl(/page/) // need to wait for reload
+                .wait(1000)
+                .waitUntilVisible('.cms-pagetree', cms.expandPageTree())
+                .waitUntilVisible('.cms-pagetree', function () {
+                    test.assertExists(
+                        xPath(createJSTreeXPathFromTree([{
+                            name: 'Homepage',
+                            children: [
+                                {
+                                    name: 'Second',
+                                    children: [{
+                                        name: 'Second'
+                                    }]
+                                },
+                                {
+                                    name: 'Second',
+                                    children: [{
+                                        name: 'Second'
+                                    }]
+                                }
+                            ]
+                        }])),
+                        'Second page was copied into the homepage'
+                    );
+                })
+                .thenEvaluate(function () {
+                    window.location.reload();
+                })
+                .wait(1000)
+                .waitUntilVisible('.cms-pagetree', cms.waitUntilAllAjaxCallsFinish())
+                .then(function () {
+                    test.assertExists(
+                        xPath(createJSTreeXPathFromTree([{
+                            name: 'Homepage',
+                            children: [
+                                {
+                                    name: 'Second',
+                                    children: [{
+                                        name: 'Second'
+                                    }]
+                                },
+                                {
+                                    name: 'Second',
+                                    children: [{
+                                        name: 'Second'
+                                    }]
+                                }
+                            ]
+                        }])),
+                        'Second page was copied into the homepage'
+                    );
+                })
+                // try to copy into root
+                .then(function () {
+                    this.click('.js-cms-tree-item-copy[data-id="' + secondPageId + '"]');
+                })
+                // wait until paste buttons show up
+                .waitUntilVisible('.cms-tree-item-helpers', function () {
+                    // click on "Paste" to root
+                    this.click('.cms-tree-item-helpers a[href="#root"]');
+                })
+                .waitForResource(/copy-page/)
+                .waitForUrl(/page/) // need to wait for reload
+                .wait(1000)
+                .waitUntilVisible('.cms-pagetree')
+                .then(cms.waitUntilAllAjaxCallsFinish())
+                .then(cms.expandPageTree())
+                .waitUntilVisible('.cms-pagetree', function () {
+                    test.assertExists(
+                        xPath(createJSTreeXPathFromTree([
+                            {
+                                name: 'Homepage',
+                                children: [
+                                    {
+                                        name: 'Second',
+                                        children: [{
+                                            name: 'Second'
+                                        }]
+                                    },
+                                    {
+                                        name: 'Second',
+                                        children: [{
+                                            name: 'Second'
+                                        }]
+                                    }
+                                ]
+                            },
+                            {
+                                name: 'Second',
+                                children: [{
+                                    name: 'Second'
+                                }]
+                            }
+                        ])),
+                        'Second page was copied into the root'
+                    );
+                })
+                .thenEvaluate(function () {
+                    window.location.reload();
+                })
+                .wait(1000)
+                .waitUntilVisible('.cms-pagetree')
+                .then(cms.waitUntilAllAjaxCallsFinish())
+                .then(cms.expandPageTree())
+                .then(function () {
+                    test.assertExists(
+                        xPath(createJSTreeXPathFromTree([
+                            {
+                                name: 'Homepage',
+                                children: [
+                                    {
+                                        name: 'Second',
+                                        children: [{
+                                            name: 'Second'
+                                        }]
+                                    },
+                                    {
+                                        name: 'Second',
+                                        children: [{
+                                            name: 'Second'
+                                        }]
+                                    }
+                                ]
+                            },
+                            {
+                                name: 'Second',
+                                children: [{
+                                    name: 'Second'
+                                }]
+                            }
+                        ])),
+                        'Second page was copied into the root'
+                    );
+                })
+                // then try to copy sibling into a sibling (homepage into sibling "second" page)
+                .then(function () {
+                    this.click('.js-cms-tree-item-copy[data-id="' + cms.getPageId('Homepage') + '"]');
+                })
+                // wait until paste buttons show up
+                .waitUntilVisible('.cms-tree-item-helpers', function () {
+                    // click on "Paste" to top level "second" page
+                    var pages = cms._getPageIds('Second');
+                    this.click('.cms-tree-item-helpers a[data-id="' + pages[pages.length - 2] + '"]');
+                })
+                .waitForResource(/copy-page/)
+                .waitForUrl(/page/) // need to wait for reload
+                .wait(1000)
+                .waitUntilVisible('.cms-pagetree', cms.expandPageTree())
+                .waitUntilVisible('.cms-pagetree', function () {
+                    test.assertExists(
+                        xPath(createJSTreeXPathFromTree([
+                            {
+                                name: 'Homepage',
+                                children: [
+                                    {
+                                        name: 'Second',
+                                        children: [{
+                                            name: 'Second'
+                                        }]
+                                    },
+                                    {
+                                        name: 'Second',
+                                        children: [{
+                                            name: 'Second'
+                                        }]
+                                    }
+                                ]
+                            },
+                            {
+                                name: 'Second',
+                                children: [
+                                    { name: 'Second' },
+                                    {
+                                        name: 'Homepage',
+                                        children: [
+                                            {
+                                                name: 'Second',
+                                                children: [{
+                                                    name: 'Second'
+                                                }]
+                                            },
+                                            {
+                                                name: 'Second',
+                                                children: [{
+                                                    name: 'Second'
+                                                }]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ])),
+                        'Homepage was copied into last "Second" page'
+                    );
+                })
+                .thenEvaluate(function () {
+                    window.location.reload();
+                })
+                .wait(1000)
+                .waitUntilVisible('.cms-pagetree')
+                .then(function () {
+                    test.assertExists(
+                        xPath(createJSTreeXPathFromTree([
+                            {
+                                name: 'Homepage',
+                                children: [
+                                    {
+                                        name: 'Second',
+                                        children: [{
+                                            name: 'Second'
+                                        }]
+                                    },
+                                    {
+                                        name: 'Second',
+                                        children: [{
+                                            name: 'Second'
+                                        }]
+                                    }
+                                ]
+                            },
+                            {
+                                name: 'Second',
+                                children: [
+                                    { name: 'Second' },
+                                    {
+                                        name: 'Homepage',
+                                        children: [
+                                            {
+                                                name: 'Second',
+                                                children: [{
+                                                    name: 'Second'
+                                                }]
+                                            },
+                                            {
+                                                name: 'Second',
+                                                children: [{
+                                                    name: 'Second'
+                                                }]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ])),
+                        'Homepage was copied into last "Second" page'
+                    );
+                })
+
+                // then try to copy a page into own child
+                .then(function () {
+                    this.click('.js-cms-tree-item-copy[data-id="' + cms.getPageId('Homepage') + '"]');
+                })
+                // wait until paste buttons show up
+                .waitUntilVisible('.cms-tree-item-helpers', function () {
+                    // click on "Paste" to the Direct child of Homepage
+                    this.click('.cms-tree-item-helpers a[data-id="' + secondPageId + '"]');
+                })
+                .waitUntilVisible('.error', function () {
+                    test.assertSelectorHasText(
+                        '.error',
+                        'Error: Moving parent inside child',
+                        'Error should show up if you try to paste a page into it\'s child'
+                    );
+                });
+        })
+        // remove two top level pages
+        .then(cms.removePage())
+        .then(cms.removePage())
+        .run(function () {
+            test.done();
+        });
+});

--- a/cms/tests/frontend/integration/pagetree.js
+++ b/cms/tests/frontend/integration/pagetree.js
@@ -8,6 +8,8 @@ var globals = require('./settings/globals');
 var casperjs = require('casper');
 var cms = require('./helpers/cms')(casperjs);
 var xPath = casperjs.selectXPath;
+var createJSTreeXPathFromTree = cms.createJSTreeXPathFromTree;
+var getPasteHelpersXPath = cms.getPasteHelpersXPath;
 
 var closeWizard = function () {
     return function () {
@@ -17,80 +19,6 @@ var closeWizard = function () {
         })
         .waitWhileVisible('.cms-modal');
     };
-};
-
-/**
- * @function createJSTreeXPathFromTree
- * @param {Object[]} tree tree object, see example
- * @param {Object} [opts]
- * @param {Object} [opts.topLevel=true] is it the top level?
- * @example tree
- *
- *     [
- *         {
- *             name: 'Homepage'
- *             children: [
- *                 {
- *                     name: 'Nested'
- *                 }
- *             ]
- *         },
- *         {
- *             name: 'Sibling'
- *         }
- *     ]
- */
-var createJSTreeXPathFromTree = function (tree, opts) {
-    var xPath = '';
-    var topLevel = opts && typeof opts.topLevel !== 'undefined' ? topLevel : true;
-
-    tree.forEach(function (node, index) {
-        if (index === 0) {
-            if (topLevel) {
-                xPath += '//';
-            } else {
-                xPath += './';
-            }
-            xPath += 'li[./a[contains(@class, "jstree-anchor")][contains(text(), "' + node.name + '")]${children}]';
-        } else {
-            xPath += '/following-sibling::li' +
-                '[./a[contains(@class, "jstree-anchor")][contains(text(), "' + node.name + '")]${children}]';
-        }
-
-        if (node.children) {
-            xPath = xPath.replace(
-                '${children}',
-                '/following-sibling::ul[contains(@class, "jstree-children")]' +
-                '[' + createJSTreeXPathFromTree(node.children, { topLevel: false }) + ']'
-            );
-        } else {
-            xPath = xPath.replace('${children}', '');
-        }
-    });
-
-    return xPath;
-};
-
-/**
- * @function getPasteHelpersXPath
- * @public
- * @param {Object} opts
- * @param {Boolean} visible get visible or hidden helpers
- * @param {String|Number} [pageId] optional id of the page to filter helpers
- */
-var getPasteHelpersXPath = function (opts) {
-    var xpath = '//*[self::div or self::span][contains(@class, "cms-tree-item-helpers")]';
-    if (opts && opts.visible) {
-        xpath += '[not(contains(@class, "cms-hidden"))]';
-    } else {
-        xpath += '[contains(@class, "cms-hidden")]';
-    }
-    xpath += '[./a[contains(text(), "Paste")]';
-    if (opts && opts.pageId) {
-        xpath += '[contains(@data-id, "' + opts.pageId + '")]';
-    }
-    xpath += ']';
-    return xpath;
 };
 
 casper.test.setUp(function (done) {

--- a/docs/contributing/testing.rst
+++ b/docs/contributing/testing.rst
@@ -197,17 +197,19 @@ Then install minimum required dependencies::
     pip install test_requirements/django-1.8.txt
     pip install -e .
 
-Now you'll be able to run a test server with this command::
-
-    rm -f testdb.sqlite; python testserver.py
-
-Note, that the last command would take over your shell and remove SQLite
-database and run migrations on the new one. Take a look inside `testserver.py`
-or `.travis.yml` if you need to customise the test server settings.
-
-The integration test suite itself can be run against the test server in a separate shell::
+Now you'll be able to run a tests with this command::
 
     gulp tests:integration
+
+The command will start a server, wait for a minute for the migrations to run
+and will run integration tests against it.  It will use ``testdb.sqlite`` as the
+database. If you want to start with a clean state you could use ``--clean``
+argument.
+
+Some tests require different server configuration, so it is possible that the
+server will stop, and another variation will start with different arguments.
+Take a look inside `testserver.py` if you need to customise the test server
+settings.
 
 While debugging you can use the ``--tests`` parameter as well in order to run test
 suites separately.::
@@ -215,7 +217,15 @@ suites separately.::
     gulp tests:integration --tests=pagetree
     gulp tests:integration --tests=loginAdmin,toolbar
 
+If specified tests require different servers they will be grouped to speed
+things up, so the order might not be the same as you specify in the argument.
 
+When running locally, it sometimes helps to visualise the tests output. For that
+you can install casper-summoner utility (``npm install -g casper-summoner``),
+and run the tests with additional ``--screenshots`` argument. It will create
+``screenshots`` folder with screenshots of almost every step of each test.
+Subsequent runs will override the existing files. Note that this is experimental
+and may change in the future.
 
 *************
 Writing tests

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -49,6 +49,7 @@ blog
 boilerplates
 cacheable
 callables
+casper
 changelist
 checkboxes
 clickable
@@ -178,6 +179,7 @@ sideframe
 Sikora
 sitemap
 sitemaps
+screenshots
 slugified
 Spalletti
 stefanw

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -411,7 +411,6 @@ gulp.task('tests:integration', function (done) {
                 });
                 var serverPid;
 
-
                 return integrationTests.startServer(serverArgs)
                     .then(function (pid) {
                         serverPid = pid;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -20,6 +20,8 @@ var KarmaServer = require('karma').Server;
 var child_process = require('child_process');
 var spawn = require('child_process').spawn;
 var terminate = require('terminate');
+var Promise = require('bluebird'); // jshint ignore:line
+var _ = require('lodash');
 
 var argv = require('minimist')(process.argv.slice(2));
 
@@ -98,6 +100,47 @@ var JS_BUNDLES = {
     ]
 };
 
+var INTEGRATION_TESTS = [
+    [
+        'loginAdmin',
+        'toolbar',
+        'addFirstPage',
+        'wizard',
+        'editMode',
+        'sideframe',
+        'createContent',
+        'users',
+        'addNewUser',
+        'newPage',
+        'pageControl',
+        'modal',
+        'permissions',
+        'logout',
+        'clipboard'
+    ],
+    [
+        'pageTypes',
+        'switchLanguage',
+        'editContent',
+        'editContentTools',
+        'publish',
+        'loginToolbar',
+        'changeSettings'
+    ],
+    [
+        'pagetree',
+        'disableToolbar',
+        'dragndrop',
+        'history',
+        'revertLive',
+        'narrowScreen',
+        {
+            serverArgs: '--CMS_PERMISSION=False',
+            file: 'pagetree-no-permission'
+        }
+    ]
+];
+
 // #####################################################################################################################
 // #TASKS#
 gulp.task('sass', function () {
@@ -172,113 +215,234 @@ gulp.task('tests:unit:watch', function () {
     server.start();
 });
 
-// gulp tests:integration --tests=loginAdmin,toolbar
+var integrationTests = {
+    /**
+     * Runs pyhon testserver.py and sleeps for a minute to let it run migrations.
+     * Respects `clean` cli argument to remove the existing local database.
+     *
+     * @method startServer
+     * @param {String} args plain string of arguments to be passed to testserver.py
+     * @returns {Promise} fullfilled when sleep ends
+     */
+    startServer: function startServer(args) {
+        return new Promise(function (resolve) {
+            if (argv && argv.clean) {
+                child_process.execSync('rm -rf testdb.sqlite');
+            }
+            var server = spawn('python', ['testserver.py', args]);
+            gutil.log('Starting a server');
+            server.stdout.on('data', function (data) {
+                console.log(data.toString().slice(0, -1));
+            });
+
+            server.stderr.on('data', function (data) {
+                gutil.log('Server: ', data.toString().slice(0, -1));
+            });
+
+            var sleep = spawn('sleep', ['60']);
+
+            sleep.on('close', function () {
+                resolve(server.pid);
+            });
+        });
+    },
+
+    /**
+     * Prepares files for consumption by casper. Input given
+     * as array of buckets, buckets being array of strings (file names) or
+     * objects (filename + custom server args). Converts strings to objects
+     * with { file: originalString, serverArgs: '' }
+     *
+     * @method prepareBuckets
+     * @returns {Array<Array<Object>>} modified buckets
+     * @example
+     * input:
+     * [
+     *     [ 'file1', 'file2' ],
+     *     [ 'file3', { file: 'file4', serverArgs: '--something' } ]
+     * ]
+     *
+     * output:
+     * [
+     *     [ { file: 'file1', serverArgs: '' }, { file: 'file2', serverArgs: '' } ],
+     *     [ { file: 'file3', serverArgs: '' }, { file: 'file4', serverArgs: '--something' } ]
+     * ]
+     */
+    prepareBuckets: function prepareBuckets() {
+        return INTEGRATION_TESTS.map(function (bucket) {
+            return bucket.map(function (test) {
+                if (typeof test === 'object') {
+                    return test;
+                }
+
+                return {
+                    file: test,
+                    serverArgs: ''
+                };
+            });
+        });
+    },
+
+    /**
+     * Prepares files for testing. Respects INTEGRATION_TESTS_BUCKET env
+     * variable (on travis we run tests in separate jobs to speed up the whole suite)
+     * and cli arguments. If there are multiple tests that require same server (same server arguments)
+     * it would group them together for speed.
+     *
+     * @method prepareFiles
+     * @returns {Promise} immediately resolved with prepared files object
+     * @example {
+     *     "": [ { file: 'path1', serverArgs: "" } ],
+     *     "--something": [ { file: 'path2', serverArgs: "--something" } ]
+     * }
+     */
+    prepareFiles: function prepareFiles() {
+        var buckets = this.prepareBuckets();
+
+        var files = [];
+
+        // on travis we split up integration tests into three buckets,
+        // and set which bucket will be used through environment variable
+        switch (process.env.INTEGRATION_TESTS_BUCKET) {
+            case '1':
+            case '2':
+            case '3':
+                files = buckets[Number(process.env.INTEGRATION_TESTS_BUCKET) - 1];
+                break;
+            default:
+                files = buckets.reduce(function (memo, bucket) {
+                    return memo.concat(bucket);
+                }, []);
+        }
+
+        var pre = [{
+            file: PROJECT_PATH.tests + '/integration/setup.js'
+        }];
+
+        var fileNames;
+        if (argv && argv.tests) {
+            fileNames = argv.tests.split(',');
+            gutil.log('Running tests for ' + fileNames.join(', '));
+            files = fileNames.map(function (fileName) {
+                return _.find(files, function (file) {
+                    return file.file === fileName;
+                });
+            });
+        }
+
+        var tests = files.map(function (file) {
+            return _.merge({}, file, {
+                file: PROJECT_PATH.tests + '/integration/' + file.file + '.js'
+            });
+        });
+
+        var groupedTests = _.mapValues(_.groupBy(tests, 'serverArgs'), function (testsArray) {
+            return pre.concat(testsArray);
+        });
+
+        return Promise.resolve(groupedTests);
+    },
+
+    /**
+     * Runs casperjs process with tests passed as arguments to it and logs output.
+     *
+     * @method runTests
+     * @param {String[]} tests paths to tests
+     * @returns {Promise} resolves with casper exit code (0 or 1)
+     */
+    runTests: function (tests) {
+        return new Promise(function (resolve) {
+            var casperChild = spawn('./node_modules/.bin/casperjs', ['test', '--web-security=no'].concat(tests));
+
+            casperChild.stdout.on('data', function (data) {
+                gutil.log('CasperJS:', data.toString().slice(0, -1));
+            });
+
+            casperChild.on('close', function (code) {
+                resolve(code);
+            });
+        });
+    },
+
+    /**
+     * When used --screenshots it will generate instrumented files that captures the
+     * screenshot of current state on every step. Useful for local debugging.
+     * Requires you to install casper-sumomner (npm install -g casper-summoner).
+     *
+     * @method createScreenshotFiles
+     * @param {String[]} tests array of paths to instrument
+     * @returns {String[]} array of paths to instrumented tests
+     */
+    createScreenshotFiles: function (tests) {
+        if (argv && argv.screenshots) {
+            child_process.execSync('casper-summoner ' + tests.join(' '));
+            tests = tests.map(function (file) {
+                return file.replace('.js', '.summoned.js');
+            });
+        }
+
+        return tests;
+    },
+
+    /**
+     * Cleans up instrunented tests
+     *
+     * @method removeScreenshotFiles
+     * @see createScreenshotFiles
+     * @param {String[]} tests array of paths to instrumented tests
+     */
+    removeScreenshotFiles: function (tests) {
+        if (argv && argv.screenshots) {
+            child_process.execSync('rm ' + tests.join(' '));
+        }
+    }
+};
+
+// gulp tests:integration [--clean] [--screenshots] [--tests=loginAdmin,toolbar]
 gulp.task('tests:integration', function (done) {
     process.env.PHANTOMJS_EXECUTABLE = './node_modules/.bin/phantomjs';
 
-    var buckets = [
-        [
-            'loginAdmin',
-            'toolbar',
-            'addFirstPage',
-            'wizard',
-            'editMode',
-            'sideframe',
-            'createContent',
-            'users',
-            'addNewUser',
-            'newPage',
-            'pageControl',
-            'modal',
-            'permissions',
-            'logout',
-            'clipboard'
-        ],
-        [
-            'pageTypes',
-            'switchLanguage',
-            'editContent',
-            'editContentTools',
-            'publish',
-            'loginToolbar',
-            'changeSettings'
-        ],
-        [
-            'pagetree',
-            'disableToolbar',
-            'dragndrop',
-            'history',
-            'revertLive',
-            'narrowScreen'
-        ]
-    ];
+    var serverPid;
 
-    var files = [];
+    integrationTests
+        .prepareFiles()
+        .then(function (groupedTests) {
+            return Promise.reduce(Object.keys(groupedTests), function (items, serverArgs) {
+                var tests = groupedTests[serverArgs].map(function (obj) {
+                    return obj.file;
+                });
 
-    // on travis we split up integration tests into three buckets,
-    // and set which bucket will be used through environment variable
-    switch (process.env.INTEGRATION_TESTS_BUCKET) {
-        case '1':
-        case '2':
-        case '3':
-            files = buckets[Number(process.env.INTEGRATION_TESTS_BUCKET) - 1];
-            break;
-        default:
-            files = buckets.reduce(function (memo, bucket) {
-                return memo.concat(bucket);
+                return integrationTests.startServer(serverArgs)
+                    .then(function (pid) {
+                        serverPid = pid;
+                        tests = integrationTests.createScreenshotFiles(tests);
+                    })
+                    .then(function () {
+                        return integrationTests.runTests(tests).tap(function () {
+                            integrationTests.removeScreenshotFiles(tests);
+                        });
+                    })
+                    .then(function (exitCode) {
+                        return new Promise(function (resolve, reject) {
+                            terminate(serverPid, function () {
+                                items.push(exitCode);
+                                if (exitCode === 0) {
+                                    resolve(items);
+                                } else {
+                                    reject('Failure');
+                                }
+                            });
+                        });
+                    });
             }, []);
-    }
-
-    var pre = ['setup'];
-
-    if (argv && argv.tests) {
-        files = argv.tests.split(',');
-        gutil.log('Running tests for ' + files.join(', '));
-    }
-
-    var tests = pre.concat(files).map(function (file) {
-        return PROJECT_PATH.tests + '/integration/' + file + '.js';
-    });
-
-    // npm install -g casper-summoner
-    if (argv && argv.screenshots) {
-        child_process.execSync('casper-summoner ' + tests.join(' '));
-        tests = tests.map(function (file) {
-            return file.replace('.js', '.summoned.js');
+        })
+        .then(function () {
+            done(0);
+        })
+        .catch(function (e) {
+            console.log(e);
+            done(1);
         });
-    }
-
-    child_process.execSync('rm -rf testdb.sqlite');
-    // child_process.execSync('pkill -f testserver');
-    var server = spawn('python', ['testserver.py']);
-    gutil.log('Starting a server');
-    server.stdout.on('data', function (data) {
-        console.log(data.toString().slice(0, -1));
-    });
-
-    server.stderr.on('data', function (data) {
-        gutil.log('Server: ', data.toString().slice(0, -1));
-    });
-
-    var sleep = spawn('sleep', ['40']);
-
-    sleep.on('close', function () {
-        var casperChild = spawn('./node_modules/.bin/casperjs', ['test', '--web-security=no'].concat(tests));
-
-        casperChild.stdout.on('data', function (data) {
-            gutil.log('CasperJS:', data.toString().slice(0, -1));
-        });
-
-        casperChild.on('close', function (code) {
-            if (argv && argv.screenshots) {
-                child_process.execSync('rm ' + tests.join(' '));
-            }
-
-            terminate(server.pid, function (err, status) {
-                done(code);
-            });
-        });
-    });
 });
 
 Object.keys(JS_BUNDLES).forEach(function (bundleName) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -402,8 +402,6 @@ var integrationTests = {
 gulp.task('tests:integration', function (done) {
     process.env.PHANTOMJS_EXECUTABLE = './node_modules/.bin/phantomjs';
 
-    var serverPid;
-
     integrationTests
         .prepareFiles()
         .then(function (groupedTests) {
@@ -411,6 +409,8 @@ gulp.task('tests:integration', function (done) {
                 var tests = groupedTests[serverArgs].map(function (obj) {
                     return obj.file;
                 });
+                var serverPid;
+
 
                 return integrationTests.startServer(serverArgs)
                     .then(function (pid) {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -9643,11 +9643,6 @@
                     }
                   }
                 },
-                "ansi-styles": {
-                  "version": "2.1.0",
-                  "from": "ansi-styles@^2.1.0",
-                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
-                },
                 "ansi": {
                   "version": "0.3.1",
                   "from": "ansi@~0.3.1",
@@ -9657,6 +9652,11 @@
                   "version": "2.0.0",
                   "from": "ansi-regex@^2.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                },
+                "ansi-styles": {
+                  "version": "2.1.0",
+                  "from": "ansi-styles@^2.1.0",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                 },
                 "are-we-there-yet": {
                   "version": "1.0.6",
@@ -9733,15 +9733,15 @@
                   "from": "dashdash@>=1.10.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.12.2.tgz"
                 },
-                "debug": {
-                  "version": "2.2.0",
-                  "from": "debug@~2.2.0",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
-                },
                 "deep-extend": {
                   "version": "0.4.1",
                   "from": "deep-extend@~0.4.0",
                   "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
+                },
+                "debug": {
+                  "version": "2.2.0",
+                  "from": "debug@~2.2.0",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
                 },
                 "delayed-stream": {
                   "version": "1.0.0",
@@ -9898,15 +9898,15 @@
                   "from": "json-stringify-safe@~5.0.1",
                   "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                 },
-                "jsprim": {
-                  "version": "1.2.2",
-                  "from": "jsprim@^1.2.2",
-                  "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz"
-                },
                 "jsonpointer": {
                   "version": "2.0.0",
                   "from": "jsonpointer@2.0.0",
                   "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
+                },
+                "jsprim": {
+                  "version": "1.2.2",
+                  "from": "jsprim@^1.2.2",
+                  "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz"
                 },
                 "lodash._basetostring": {
                   "version": "3.0.1",
@@ -10023,15 +10023,15 @@
                   "from": "semver@~5.1.0",
                   "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
                 },
-                "sntp": {
-                  "version": "1.0.9",
-                  "from": "sntp@1.x.x",
-                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-                },
                 "sshpk": {
                   "version": "1.7.3",
                   "from": "sshpk@^1.7.0",
                   "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.3.tgz"
+                },
+                "sntp": {
+                  "version": "1.0.9",
+                  "from": "sntp@1.x.x",
+                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
@@ -13512,6 +13512,11 @@
           }
         }
       }
+    },
+    "shelljs": {
+      "version": "0.6.0",
+      "from": "shelljs@latest",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.0.tgz"
     }
   }
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,11 @@
 {
   "name": "djangoCMS",
   "dependencies": {
+    "bluebird": {
+      "version": "3.3.4",
+      "from": "bluebird@latest",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.3.4.tgz"
+    },
     "browserslist-saucelabs": {
       "version": "0.2.5",
       "from": "browserslist-saucelabs@>=0.2.3 <0.3.0",
@@ -9648,11 +9653,6 @@
                   "from": "ansi@~0.3.1",
                   "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz"
                 },
-                "ansi-regex": {
-                  "version": "2.0.0",
-                  "from": "ansi-regex@^2.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                },
                 "ansi-styles": {
                   "version": "2.1.0",
                   "from": "ansi-styles@^2.1.0",
@@ -9668,15 +9668,15 @@
                   "from": "asn1@>=0.2.3 <0.3.0",
                   "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
                 },
-                "assert-plus": {
-                  "version": "0.2.0",
-                  "from": "assert-plus@^0.2.0",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
-                },
                 "async": {
                   "version": "1.5.2",
                   "from": "async@^1.4.0",
                   "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+                },
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "ansi-regex@^2.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 },
                 "aws-sign2": {
                   "version": "0.6.0",
@@ -9687,6 +9687,11 @@
                   "version": "1.0.2",
                   "from": "bl@~1.0.0",
                   "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.2.tgz"
+                },
+                "assert-plus": {
+                  "version": "0.2.0",
+                  "from": "assert-plus@^0.2.0",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
                 },
                 "block-stream": {
                   "version": "0.0.8",
@@ -9733,15 +9738,15 @@
                   "from": "dashdash@>=1.10.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.12.2.tgz"
                 },
-                "debug": {
-                  "version": "2.2.0",
-                  "from": "debug@~2.2.0",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
-                },
                 "deep-extend": {
                   "version": "0.4.1",
                   "from": "deep-extend@~0.4.0",
                   "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
+                },
+                "debug": {
+                  "version": "2.2.0",
+                  "from": "debug@~2.2.0",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
                 },
                 "delayed-stream": {
                   "version": "1.0.0",
@@ -9848,15 +9853,15 @@
                   "from": "inherits@*",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
-                "ini": {
-                  "version": "1.3.4",
-                  "from": "ini@~1.3.0",
-                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
-                },
                 "is-my-json-valid": {
                   "version": "2.12.4",
                   "from": "is-my-json-valid@^2.12.4",
                   "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.4.tgz"
+                },
+                "ini": {
+                  "version": "1.3.4",
+                  "from": "ini@~1.3.0",
+                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
                 },
                 "is-property": {
                   "version": "1.0.2",
@@ -9873,15 +9878,15 @@
                   "from": "isarray@0.0.1",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
-                "isstream": {
-                  "version": "0.1.2",
-                  "from": "isstream@~0.1.2",
-                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
-                },
                 "jodid25519": {
                   "version": "1.0.2",
                   "from": "jodid25519@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
+                },
+                "isstream": {
+                  "version": "0.1.2",
+                  "from": "isstream@~0.1.2",
+                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
                 },
                 "jsbn": {
                   "version": "0.1.0",
@@ -9918,30 +9923,30 @@
                   "from": "lodash._createpadding@^3.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz"
                 },
-                "lodash._root": {
-                  "version": "3.0.0",
-                  "from": "lodash._root@^3.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.0.tgz"
-                },
                 "lodash.pad": {
                   "version": "3.3.0",
                   "from": "lodash.pad@^3.0.0",
                   "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.3.0.tgz"
+                },
+                "lodash._root": {
+                  "version": "3.0.0",
+                  "from": "lodash._root@^3.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.0.tgz"
                 },
                 "lodash.padleft": {
                   "version": "3.1.1",
                   "from": "lodash.padleft@^3.0.0",
                   "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.1.tgz"
                 },
-                "lodash.padright": {
-                  "version": "3.1.1",
-                  "from": "lodash.padright@^3.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz"
-                },
                 "lodash.repeat": {
                   "version": "3.2.0",
                   "from": "lodash.repeat@^3.0.0",
                   "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.2.0.tgz"
+                },
+                "lodash.padright": {
+                  "version": "3.1.1",
+                  "from": "lodash.padright@^3.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz"
                 },
                 "mime-db": {
                   "version": "1.21.0",
@@ -10043,15 +10048,15 @@
                   "from": "stringstream@~0.0.4",
                   "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
                 },
-                "strip-ansi": {
-                  "version": "3.0.0",
-                  "from": "strip-ansi@^3.0.0",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
-                },
                 "strip-json-comments": {
                   "version": "1.0.4",
                   "from": "strip-json-comments@~1.0.4",
                   "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
+                },
+                "strip-ansi": {
+                  "version": "3.0.0",
+                  "from": "strip-ansi@^3.0.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
                 },
                 "supports-color": {
                   "version": "2.0.0",
@@ -10073,15 +10078,15 @@
                   "from": "tough-cookie@~2.2.0",
                   "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
                 },
-                "tunnel-agent": {
-                  "version": "0.4.2",
-                  "from": "tunnel-agent@~0.4.1",
-                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
-                },
                 "tweetnacl": {
                   "version": "0.13.3",
                   "from": "tweetnacl@>=0.13.0 <1.0.0",
                   "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
+                },
+                "tunnel-agent": {
+                  "version": "0.4.2",
+                  "from": "tunnel-agent@~0.4.1",
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
                 },
                 "uid-number": {
                   "version": "0.0.6",
@@ -12869,6 +12874,11 @@
           }
         }
       }
+    },
+    "lodash": {
+      "version": "4.8.2",
+      "from": "lodash@latest",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.8.2.tgz"
     },
     "minimist": {
       "version": "1.1.1",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -9733,15 +9733,15 @@
                   "from": "dashdash@>=1.10.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.12.2.tgz"
                 },
-                "deep-extend": {
-                  "version": "0.4.1",
-                  "from": "deep-extend@~0.4.0",
-                  "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
-                },
                 "debug": {
                   "version": "2.2.0",
                   "from": "debug@~2.2.0",
                   "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
+                },
+                "deep-extend": {
+                  "version": "0.4.1",
+                  "from": "deep-extend@~0.4.0",
+                  "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
                 },
                 "delayed-stream": {
                   "version": "1.0.0",
@@ -10023,15 +10023,15 @@
                   "from": "semver@~5.1.0",
                   "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
                 },
-                "sshpk": {
-                  "version": "1.7.3",
-                  "from": "sshpk@^1.7.0",
-                  "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.3.tgz"
-                },
                 "sntp": {
                   "version": "1.0.9",
                   "from": "sntp@1.x.x",
                   "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                },
+                "sshpk": {
+                  "version": "1.7.3",
+                  "from": "sshpk@^1.7.0",
+                  "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.3.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
@@ -13513,10 +13513,61 @@
         }
       }
     },
-    "shelljs": {
-      "version": "0.6.0",
-      "from": "shelljs@latest",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.0.tgz"
+    "terminate": {
+      "version": "1.0.8",
+      "from": "terminate@latest",
+      "resolved": "https://registry.npmjs.org/terminate/-/terminate-1.0.8.tgz",
+      "dependencies": {
+        "ps-tree": {
+          "version": "1.0.1",
+          "from": "ps-tree@1.0.1",
+          "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.0.1.tgz",
+          "dependencies": {
+            "event-stream": {
+              "version": "3.3.2",
+              "from": "event-stream@>=3.3.0 <3.4.0",
+              "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.2.tgz",
+              "dependencies": {
+                "through": {
+                  "version": "2.3.8",
+                  "from": "through@>=2.3.1 <2.4.0",
+                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+                },
+                "duplexer": {
+                  "version": "0.1.1",
+                  "from": "duplexer@>=0.1.1 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
+                },
+                "from": {
+                  "version": "0.1.3",
+                  "from": "from@>=0.0.0 <1.0.0",
+                  "resolved": "https://registry.npmjs.org/from/-/from-0.1.3.tgz"
+                },
+                "map-stream": {
+                  "version": "0.1.0",
+                  "from": "map-stream@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz"
+                },
+                "pause-stream": {
+                  "version": "0.0.11",
+                  "from": "pause-stream@0.0.11",
+                  "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz"
+                },
+                "split": {
+                  "version": "0.3.3",
+                  "from": "split@>=0.3.0 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz"
+                },
+                "stream-combiner": {
+                  "version": "0.0.4",
+                  "from": "stream-combiner@>=0.0.4 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "djangoCMS",
   "private": true,
   "devDependencies": {
+    "bluebird": "^3.3.4",
     "browserslist-saucelabs": "^0.2.3",
     "casperjs": "^1.1.0-beta5",
     "gulp": "3.9.0",
@@ -28,6 +29,7 @@
     "karma-phantomjs-launcher": "^1.0.0",
     "karma-phantomjs-shim": "^1.1.2",
     "karma-sauce-launcher": "^0.3.0",
+    "lodash": "^4.8.2",
     "minimist": "1.1.1",
     "phantomjs-prebuilt": "^2.1.5",
     "shelljs": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "karma-sauce-launcher": "^0.3.0",
     "minimist": "1.1.1",
     "phantomjs-prebuilt": "^2.1.5",
-    "shelljs": "^0.6.0"
+    "shelljs": "^0.6.0",
+    "terminate": "^1.0.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "devDependencies": {
     "browserslist-saucelabs": "^0.2.3",
+    "casperjs": "^1.1.0-beta5",
     "gulp": "3.9.0",
     "gulp-autoprefixer": "2.3.1",
     "gulp-concat": "^2.6.0",
@@ -29,6 +30,6 @@
     "karma-sauce-launcher": "^0.3.0",
     "minimist": "1.1.1",
     "phantomjs-prebuilt": "^2.1.5",
-    "casperjs": "^1.1.0-beta5"
+    "shelljs": "^0.6.0"
   }
 }

--- a/testserver.py
+++ b/testserver.py
@@ -13,7 +13,6 @@ if '--CMS_PERMISSION=False' in sys.argv:
     permission = False
 
 gettext = noop_gettext
-print sys.argv
 
 HELPER_SETTINGS = dict(
     CMS_PERMISSION=permission,

--- a/testserver.py
+++ b/testserver.py
@@ -7,11 +7,16 @@ import sys
 def noop_gettext(s):
     return s
 
-gettext = noop_gettext
+permission = True
 
+if '--CMS_PERMISSION=False' in sys.argv:
+    permission = False
+
+gettext = noop_gettext
+print sys.argv
 
 HELPER_SETTINGS = dict(
-    CMS_PERMISSION=True,
+    CMS_PERMISSION=permission,
     LANGUAGES=(
         ('en', u'English'),
         ('de', u'Deutsch'),


### PR DESCRIPTION
This PR starts the process of removing old selenium tests and replacing them with casperjs test

- refactors gulp tests:integration
     - starts the server from gulp
     - adds possibility to run different servers (with different options)
     - adds `--clean` option to remove the testdb before starting the server (cleanup crashed state when developing locally)
- documents changes (also documents `--screenshots`) 
- adds a tests for copying and pasting pages (for https://github.com/divio/django-cms/issues/5111) (which is mostly a copy paste from pagetree.js with small adaptions, so no need to review that one too hard)
- fixes small bug in cms helpers