### PR TITLE
Migrate toolbar tests

### DIFF
--- a/cms/test_utils/project/templates/integration/simple.html
+++ b/cms/test_utils/project/templates/integration/simple.html
@@ -1,0 +1,11 @@
+{% load cms_tags sekizai_tags %}
+{% render_block "css" %}
+<style>
+	/* Add some padding so that the placeholder menu will be shown in the page  */
+	body { padding-top: 300px; }
+</style>
+
+{% cms_toolbar %}
+{% placeholder "placeholder" %}
+{% render_block "js" %}
+

--- a/cms/tests/frontend/integration/helpers/cms.js
+++ b/cms/tests/frontend/integration/helpers/cms.js
@@ -121,10 +121,11 @@ module.exports = function (casperjs) {
         },
 
         /**
-         * _modifyPageAdvancedSettings
-         *
+         * @function _modifyPageAdvancedSettings
          * @private
-         * @param opts
+         * @param {Object} opts options
+         * @param {String} opts.page page name (will take first one in the tree)
+         * @param {Object} opts.fields { fieldName: value, ... }
          */
         _modifyPageAdvancedSettings: function _modifyPageAdvancedSettings(opts) {
             var that = this;
@@ -147,6 +148,12 @@ module.exports = function (casperjs) {
             };
         },
 
+        /**
+         * @function addApphookToPage
+         * @param {Object} opts options
+         * @param {String} opts.page page name (will take first one in the tree)
+         * @param {String} opts.apphook app name
+         */
         addApphookToPage: function addApphookToPage(opts) {
             return this._modifyPageAdvancedSettings({
                 page: opts.page,
@@ -156,6 +163,12 @@ module.exports = function (casperjs) {
             });
         },
 
+        /**
+         * @function setPageTemplate
+         * @param {Object} opts options
+         * @param {String} opts.page page name (will take first one in the tree)
+         * @param {String} opts.tempalte template file name (e.g. simple.html)
+         */
         setPageTemplate: function setPageTemplate(opts) {
             return this._modifyPageAdvancedSettings({
                 page: opts.page,
@@ -165,6 +178,11 @@ module.exports = function (casperjs) {
             });
         },
 
+        /**
+         * @function publishPage
+         * @param {Object} opts options
+         * @param {String} opts.page page name (will take first one in the tree)
+         */
         publishPage: function publishPage(opts) {
             var that = this;
             return function () {

--- a/cms/tests/frontend/integration/toolbar-login-apphooks.js
+++ b/cms/tests/frontend/integration/toolbar-login-apphooks.js
@@ -67,3 +67,88 @@ casper.test.begin('User Login (via Toolbar) through apphooked page', function (t
             test.done();
         });
 });
+
+casper.test.begin('User Login (via Toolbar) through apphooked object page', function (test) {
+    var appObjectUrl;
+    var appObjectId;
+
+    casper
+        .start()
+        .then(cms.login())
+        .thenOpen(apphookedPageUrl)
+
+        // add app object
+        .waitForSelector('.cms-render-model-add', function () {
+            this.mouse.doubleclick('.cms-render-model-add');
+        })
+        .waitUntilVisible('.cms-modal')
+        .withFrame(0, function () {
+            casper.waitForSelector('#example1_form', function () {
+                this.fill('#example1_form', {
+                    char_1: '1',
+                    char_2: '2',
+                    char_3: '3',
+                    char_4: '4',
+                    date_field: this.evaluate(function () {
+                        var today = new Date();
+                        var date = today.getDate();
+                        if (date < 10) {
+                            date = '0' + date;
+                        }
+                        var month = today.getMonth() + 1;
+                        if (month < 10) {
+                            month = '0' + month;
+                        }
+                        return today.getFullYear() + '-' + month + '-' + date;
+                    })
+                });
+            });
+        })
+        .then(function () {
+            this.click('.cms-modal-buttons .cms-btn-action');
+        })
+        .waitForResource(/add/)
+        .waitForUrl(/detail/)
+        .waitForSelector('.cms-ready', function () {
+            appObjectUrl = this.getCurrentUrl() + '?edit';
+            appObjectId = this.getCurrentUrl().replace('8000', '').replace(/\D/g, '');
+        })
+        .then(cms.logout())
+        .then(function () {
+            this.open(appObjectUrl);
+        })
+        .waitForSelector('.cms-toolbar-expanded', function () {
+            test.assertSelectorHasText(
+                '.page_title',
+                'Apphooked page',
+                'Apphooked page was created and published'
+            );
+            test.assertExists('.cms-toolbar .cms-form-login', 'The toolbar login form is available');
+
+            this.fill('.cms-form-login', { username: 'totally', password: 'wrong' }, true);
+        })
+        .waitForSelector('.cms-error')
+        .waitUntilVisible('.cms-messages', function () {
+            test.assertSelectorHasText(
+                '.cms-messages',
+                'Please check your credentials and try again.',
+                'Error is displayed'
+            );
+
+            this.fill('.cms-form-login', globals.credentials, true);
+        })
+        .waitForSelector('.cms-ready', function () {
+            test.assertExists('.cms-toolbar-item-navigation', 'Login via the toolbar done');
+            test.assertExists('.cms-render-model-add', 'Apphook object page is correct');
+        })
+        .then(function () {
+            this.open(globals.baseUrl + 'admin/placeholderapp/example1/' + appObjectId + '/delete/');
+        })
+        .waitForSelector('form input[type="submit"]', function () {
+            this.click('form input[type="submit"]');
+        })
+        .waitForSelector('.success')
+        .run(function () {
+            test.done();
+        });
+});

--- a/cms/tests/frontend/integration/toolbar-login-apphooks.js
+++ b/cms/tests/frontend/integration/toolbar-login-apphooks.js
@@ -1,0 +1,69 @@
+'use strict';
+
+// #############################################################################
+// User login via the CMS toolbar on apphooked pages
+
+var globals = require('./settings/globals');
+var cms = require('./helpers/cms')();
+
+casper.test.setUp(function (done) {
+    casper.start()
+        .then(cms.login())
+        .then(cms.addPage({ title: 'First page' }))
+        .then(cms.addPage({ title: 'Apphooked page' }))
+        .then(cms.addApphookToPage({
+            page: 'Apphooked page',
+            apphook: 'Example1App'
+        }))
+        .then(cms.setPageTemplate({
+            page: 'Apphooked page',
+            template: 'simple.html'
+        }))
+        .then(cms.publishPage({
+            page: 'Apphooked page'
+        }))
+        .then(cms.logout())
+        .run(done);
+});
+
+casper.test.tearDown(function (done) {
+    casper.start()
+        .then(cms.removePage())
+        .then(cms.removePage())
+        .then(cms.logout())
+        .run(done);
+});
+
+var apphookedPageUrl = globals.baseUrl + 'apphooked-page/?edit';
+
+casper.test.begin('User Login (via Toolbar) through apphooked page', function (test) {
+    casper
+        .start(apphookedPageUrl)
+        .waitForSelector('.cms-toolbar-expanded', function () {
+            test.assertSelectorHasText(
+                '.page_title',
+                'Apphooked page',
+                'Apphooked page was created and published'
+            );
+            test.assertExists('.cms-toolbar .cms-form-login', 'The toolbar login form is available');
+
+            this.fill('.cms-form-login', { username: 'totally', password: 'wrong' }, true);
+        })
+        .waitForSelector('.cms-error')
+        .waitUntilVisible('.cms-messages', function () {
+            test.assertSelectorHasText(
+                '.cms-messages',
+                'Please check your credentials and try again.',
+                'Error is displayed'
+            );
+
+            this.fill('.cms-form-login', globals.credentials, true);
+        })
+        .waitForSelector('.cms-ready', function () {
+            test.assertExists('.cms-toolbar-item-navigation', 'Login via the toolbar done');
+            test.assertExists('.cms-render-model-add', 'Apphooked page is correct');
+        })
+        .run(function () {
+            test.done();
+        });
+});

--- a/cms/tests/test_frontend.py
+++ b/cms/tests/test_frontend.py
@@ -202,65 +202,6 @@ class CMSLiveTests(StaticLiveServerTestCase, CMSTestCase):
                 del sys.modules[module]
 
 
-class ToolbarBasicTests(CMSLiveTests):
-    def setUp(self):
-        self.user = self.get_superuser()
-        Site.objects.create(domain='example.org', name='example.org')
-        self.base_url = self.live_server_url
-        self.driver.implicitly_wait(2)
-        super(ToolbarBasicTests, self).setUp()
-
-    def test_toolbar_login_view(self):
-        User = get_user_model()
-        create_page('Home', 'simple.html', 'en', published=True)
-        ex1 = Example1.objects.create(
-            char_1='char_1', char_2='char_1', char_3='char_3', char_4='char_4',
-            date_field=datetime.datetime.now()
-        )
-        try:
-            apphook_pool.register(Example1App)
-        except AppAlreadyRegistered:
-            pass
-        self.reload_urls()
-        create_page('apphook', 'simple.html', 'en', published=True,
-                    apphook=Example1App)
-
-
-        url = '%s/%s/?%s' % (self.live_server_url, 'apphook/detail/%s' % ex1.pk, get_cms_setting('CMS_TOOLBAR_URL__EDIT_ON'))
-        self.driver.get(url)
-        username_input = self.driver.find_element_by_id("id_cms-username")
-        username_input.send_keys(getattr(self.user, User.USERNAME_FIELD))
-        password_input = self.driver.find_element_by_id("id_cms-password")
-        password_input.send_keys("what")
-        password_input.submit()
-        self.wait_page_loaded()
-        self.assertTrue(self.driver.find_element_by_class_name('cms-error'))
-
-    def test_toolbar_login_cbv(self):
-        User = get_user_model()
-        try:
-            apphook_pool.register(Example1App)
-        except AppAlreadyRegistered:
-            pass
-        self.reload_urls()
-        create_page('Home', 'simple.html', 'en', published=True)
-        ex1 = Example1.objects.create(
-            char_1='char_1', char_2='char_1', char_3='char_3', char_4='char_4',
-            date_field=datetime.datetime.now()
-        )
-        create_page('apphook', 'simple.html', 'en', published=True,
-                    apphook=Example1App)
-        url = '%s/%s/?%s' % (self.live_server_url, 'apphook/detail/class/%s' % ex1.pk, get_cms_setting('CMS_TOOLBAR_URL__EDIT_ON'))
-        self.driver.get(url)
-        username_input = self.driver.find_element_by_id("id_cms-username")
-        username_input.send_keys(getattr(self.user, User.USERNAME_FIELD))
-        password_input = self.driver.find_element_by_id("id_cms-password")
-        password_input.send_keys("what")
-        password_input.submit()
-        self.wait_page_loaded()
-        self.assertTrue(self.driver.find_element_by_class_name('cms-error'))
-
-
 @override_settings(
     LANGUAGE_CODE='en',
     LANGUAGES=(('en', 'English'),

--- a/cms/tests/test_frontend.py
+++ b/cms/tests/test_frontend.py
@@ -210,21 +210,6 @@ class ToolbarBasicTests(CMSLiveTests):
         self.driver.implicitly_wait(2)
         super(ToolbarBasicTests, self).setUp()
 
-    def test_toolbar_login(self):
-        User = get_user_model()
-        create_page('Home', 'simple.html', 'en', published=True)
-        url = '%s/?%s' % (self.live_server_url, get_cms_setting('CMS_TOOLBAR_URL__EDIT_ON'))
-        self.assertTrue(User.objects.all().count(), 1)
-        self.driver.get(url)
-        self.assertRaises(NoSuchElementException, self.driver.find_element_by_class_name, 'cms-toolbar-item-logout')
-        username_input = self.driver.find_element_by_id("id_cms-username")
-        username_input.send_keys(getattr(self.user, User.USERNAME_FIELD))
-        password_input = self.driver.find_element_by_id("id_cms-password")
-        password_input.send_keys(getattr(self.user, User.USERNAME_FIELD))
-        password_input.submit()
-        self.wait_page_loaded()
-        self.assertTrue(self.driver.find_element_by_class_name('cms-toolbar-item-navigation'))
-
     def test_toolbar_login_view(self):
         User = get_user_model()
         create_page('Home', 'simple.html', 'en', published=True)

--- a/cms/tests/test_frontend.py
+++ b/cms/tests/test_frontend.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import datetime
 import os
 import sys
 import time
@@ -30,11 +29,7 @@ from selenium.common.exceptions import NoSuchElementException, NoAlertPresentExc
 
 from cms.api import create_page, create_title, add_plugin
 from cms.appresolver import clear_app_resolvers
-from cms.apphook_pool import apphook_pool
-from cms.exceptions import AppAlreadyRegistered
 from cms.models import CMSPlugin, Page, Placeholder
-from cms.test_utils.project.placeholderapp.cms_apps import Example1App
-from cms.test_utils.project.placeholderapp.models import Example1
 from cms.test_utils.testcases import CMSTestCase
 from cms.test_utils.util.mock import AttributeObject
 from cms.utils.conf import get_cms_setting

--- a/docs/contributing/testing.rst
+++ b/docs/contributing/testing.rst
@@ -144,6 +144,9 @@ test runner and `Jasmine <http://jasmine.github.io/>`_ as a test framework.
 Integration tests run on `PhantomJS <http://phantomjs.org/>`_ and are
 built using `CasperJS <http://casperjs.org/>`_.
 
+In order to be able to run them you need to install necessary dependencies as
+outlined in :ref:`frontend tooling installation instructions <contributing_frontend>`.
+
 Linting runs against the test files as well with ``gulp tests:lint``. In order
 to run linting continuously, do::
 
@@ -226,6 +229,11 @@ and run the tests with additional ``--screenshots`` argument. It will create
 ``screenshots`` folder with screenshots of almost every step of each test.
 Subsequent runs will override the existing files. Note that this is experimental
 and may change in the future.
+
+It might sometimes be useful not to restart the server when creating the tests,
+for that you can run ``python testserver.py`` with necessary arguments in one
+shell and ``gulp tests:integration --no-server`` in another. However you would
+need to clean the state yourself if the test you've been writing fails.
 
 *************
 Writing tests

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -125,7 +125,8 @@ var INTEGRATION_TESTS = [
         'editContentTools',
         'publish',
         'loginToolbar',
-        'changeSettings'
+        'changeSettings',
+        'toolbar-login-apphooks'
     ],
     [
         'pagetree',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -229,6 +229,10 @@ var integrationTests = {
             if (argv && argv.clean) {
                 child_process.execSync('rm -rf testdb.sqlite');
             }
+            if (argv && argv.server === false) {
+                resolve(false);
+                return;
+            }
             var server = spawn('python', ['testserver.py', args]);
             gutil.log('Starting a server');
             server.stdout.on('data', function (data) {
@@ -423,14 +427,18 @@ gulp.task('tests:integration', function (done) {
                     })
                     .then(function (exitCode) {
                         return new Promise(function (resolve, reject) {
-                            terminate(serverPid, function () {
-                                items.push(exitCode);
+                            var finish = function () {
                                 if (exitCode === 0) {
                                     resolve(items);
                                 } else {
                                     reject('Failure');
                                 }
-                            });
+                            };
+                            if (serverPid) {
+                                terminate(serverPid, finish);
+                            } else {
+                                finish();
+                            }
                         });
                     });
             }, []);

--- a/testserver.py
+++ b/testserver.py
@@ -79,6 +79,10 @@ HELPER_SETTINGS = dict(
         'djangocms_grid',
         'filer',
         'aldryn_bootstrap3',
+        'cms.test_utils.project.placeholderapp',
+    ],
+    MIDDLEWARE_CLASSES=[
+        'cms.middleware.utils.ApphookReloadMiddleware',
     ],
     TEMPLATE_DIRS=(
         os.path.join(
@@ -88,6 +92,7 @@ HELPER_SETTINGS = dict(
     CMS_TEMPLATES=(
         ('fullwidth.html', 'Fullwidth'),
         ('page.html', 'Standard page'),
+        ('simple.html', 'Simple page'),
     ),
 )
 


### PR DESCRIPTION
covers apphook selection
removes already covered tests from test_frontend.py
adds `--no-server` option for local development
adds more info about installation