### PR TITLE
Add copy-content option to copy lang command

### DIFF
--- a/cms/tests/test_management.py
+++ b/cms/tests/test_management.py
@@ -309,6 +309,49 @@ class PageFixtureManagementTestCase(NavextendersFixture, CMSTestCase):
         self.assertEqual(stack_text_en.plugin_type, stack_text_de.plugin_type)
         self.assertEqual(stack_text_en.body, stack_text_de.body)
 
+    def test_copy_langs_no_content(self):
+        """
+        Various checks here:
+
+         * page structure is copied
+         * no plugin is copied
+        """
+        site = 1
+        number_start_plugins = CMSPlugin.objects.all().count()
+
+        out = StringIO()
+        management.call_command(
+            'cms', 'copy', 'lang', '--from-lang=en', '--to-lang=de', '--skip-content',
+            interactive=False, stdout=out
+        )
+        pages = Page.objects.on_site(site).drafts()
+        for page in pages:
+            self.assertEqual(set((u'en', u'de')), set(page.get_languages()))
+        # These asserts that no orphaned plugin exists
+        self.assertEqual(CMSPlugin.objects.all().count(), number_start_plugins)
+        self.assertEqual(CMSPlugin.objects.filter(language='en').count(), number_start_plugins)
+        self.assertEqual(CMSPlugin.objects.filter(language='de').count(), 0)
+
+        root_page = Page.objects.on_site(site).get_home()
+        root_plugins = CMSPlugin.objects.filter(
+            placeholder=root_page.placeholders.get(slot="body"))
+
+        first_plugin_en, _ = root_plugins.get(language='en', parent=None).get_plugin_instance()
+        first_plugin_de = None
+        with self.assertRaises(CMSPlugin.DoesNotExist):
+            first_plugin_de, _ = root_plugins.get(language='de', parent=None).get_plugin_instance()
+
+        self.assertIsNone(first_plugin_de)
+
+        stack_plugins = CMSPlugin.objects.filter(
+            placeholder=StaticPlaceholder.objects.order_by('?')[0].draft)
+
+        stack_text_en, _ = stack_plugins.get(language='en',
+                                             plugin_type='TextPlugin').get_plugin_instance()
+        with self.assertRaises(CMSPlugin.DoesNotExist):
+            stack_text_de, _ = stack_plugins.get(language='de',
+                                                 plugin_type='TextPlugin').get_plugin_instance()
+
     def test_copy_sites(self):
         """
         Various checks here:

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -124,6 +124,8 @@ It accepts the following options
   if set, copied content will be appended to the original one;
 * ``--site``: specify a SITE_ID to operate on sites different from the current one;
 * ``--verbosity``: set for more verbose output.
+* ``--skip-content``: if set content is not copied, and the command  will only
+  create titles in the given language.
 
 Example::
 

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -124,7 +124,7 @@ It accepts the following options
   if set, copied content will be appended to the original one;
 * ``--site``: specify a SITE_ID to operate on sites different from the current one;
 * ``--verbosity``: set for more verbose output.
-* ``--skip-content``: if set content is not copied, and the command  will only
+* ``--skip-content``: if set, content is not copied, and the command will only
   create titles in the given language.
 
 Example::


### PR DESCRIPTION
This allows to skip copying content when duplicating a language
~~A test is needed for this~~
Test added