### PR TITLE
Feature/plugin move speedup

### DIFF
--- a/cms/admin/placeholderadmin.py
+++ b/cms/admin/placeholderadmin.py
@@ -643,7 +643,7 @@ class PlaceholderAdminMixin(object):
         target_placeholder_admin = self._get_attached_admin(placeholder)
 
         if move_a_copy:  # "paste"
-            plugins = [plugin] + list(plugin.get_descendants())
+            plugins = list(plugin.get_tree())
             self.post_copy_plugins(request, source_placeholder, placeholder, plugins)
 
             if (target_placeholder_admin and

--- a/cms/models/placeholdermodel.py
+++ b/cms/models/placeholdermodel.py
@@ -12,12 +12,17 @@ from django.template.defaultfilters import title
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _, force_text
 
+from cms.cache.placeholder import clear_placeholder_cache
 from cms.exceptions import LanguageError
 from cms.utils.compat import DJANGO_1_8
 from cms.utils.helpers import reversion_register
 from cms.utils.i18n import get_language_object
 from cms.utils.urlutils import admin_reverse
-from cms.constants import EXPIRE_NOW, MAX_EXPIRATION_TTL
+from cms.constants import (
+    EXPIRE_NOW,
+    MAX_EXPIRATION_TTL,
+    PUBLISHER_STATE_DIRTY,
+)
 from cms.utils import get_language_from_request
 from cms.utils.conf import get_cms_setting
 
@@ -398,6 +403,31 @@ class Placeholder(models.Model):
                 return EXPIRE_NOW
 
         return min_ttl
+
+    def mark_as_dirty(self, language, clear_cache=True):
+        """
+        Utility method to mark the attached object of this placeholder
+        (if any) as dirty.
+        This allows us to know when the content in this placeholder
+        has been changed.
+        """
+        from cms.models import Page, StaticPlaceholder, Title
+
+        if clear_cache:
+            clear_placeholder_cache(self, language)
+
+        # Find the attached model for this placeholder
+        # This can be a static placeholder, page or none.
+        attached_model = self._get_attached_model()
+
+        if attached_model is Page:
+            Title.objects.filter(
+                page=self.page,
+                language=language,
+            ).update(publisher_state=PUBLISHER_STATE_DIRTY)
+
+        elif attached_model is StaticPlaceholder:
+            StaticPlaceholder.objects.filter(draft=self).update(dirty=True)
 
 
 reversion_register(Placeholder)

--- a/cms/models/pluginmodel.py
+++ b/cms/models/pluginmodel.py
@@ -233,9 +233,11 @@ class CMSPlugin(six.with_metaclass(PluginModelBase, MP_Node)):
         instance, plugin = self.get_plugin_instance()
         return force_text(plugin.icon_alt(instance)) if instance else u''
 
-    def update(self, **fields):
+    def update(self, refresh=False, **fields):
         CMSPlugin.objects.filter(pk=self.pk).update(**fields)
-        return self.reload()
+        if refresh:
+            return self.reload()
+        return
 
     def save(self, no_signals=False, *args, **kwargs):
         if not self.depth:
@@ -256,6 +258,7 @@ class CMSPlugin(six.with_metaclass(PluginModelBase, MP_Node)):
     def move(self, target, pos=None):
         super(CMSPlugin, self).move(target, pos)
         self = self.reload()
+
         try:
             new_pos = max(CMSPlugin.objects.filter(parent_id=self.parent_id,
                                                    placeholder_id=self.placeholder_id,
@@ -263,9 +266,7 @@ class CMSPlugin(six.with_metaclass(PluginModelBase, MP_Node)):
         except ValueError:
             # This is the first plugin in the set
             new_pos = 0
-        self.position = new_pos
-        self.save()
-        return self.reload()
+        return self.update(refresh=True, position=new_pos)
 
     def set_base_attr(self, plugin):
         for attr in ['parent_id', 'placeholder', 'language', 'plugin_type', 'creation_date', 'depth', 'path',

--- a/cms/models/pluginmodel.py
+++ b/cms/models/pluginmodel.py
@@ -233,6 +233,10 @@ class CMSPlugin(six.with_metaclass(PluginModelBase, MP_Node)):
         instance, plugin = self.get_plugin_instance()
         return force_text(plugin.icon_alt(instance)) if instance else u''
 
+    def update(self, **fields):
+        CMSPlugin.objects.filter(pk=self.pk).update(**fields)
+        return self.reload()
+
     def save(self, no_signals=False, *args, **kwargs):
         if not self.depth:
             if self.parent_id or self.parent:

--- a/cms/signals/plugins.py
+++ b/cms/signals/plugins.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from cms.cache.placeholder import clear_placeholder_cache
-from cms.constants import PUBLISHER_STATE_DIRTY
-from cms.models import CMSPlugin, Title, Page, StaticPlaceholder, Placeholder
+from cms.models import CMSPlugin, Placeholder
 
 
 def get_placeholder(plugin):
@@ -20,33 +18,33 @@ def set_dirty(plugin, delete_cache=True):
     if placeholder:
         language = plugin.language
 
-        if delete_cache:
-            clear_placeholder_cache(placeholder, language)
-
-        attached_model = placeholder._get_attached_model()
-
-        if attached_model is Page:
-            Title.objects.filter(page=placeholder.page, language=language).update(publisher_state=PUBLISHER_STATE_DIRTY)
-
-        elif attached_model is StaticPlaceholder:
-            StaticPlaceholder.objects.filter(draft=placeholder).update(dirty=True)
+        placeholder.mark_as_dirty(language, clear_cache=delete_cache)
 
 
 def pre_save_plugins(**kwargs):
     plugin = kwargs['instance']
+
     if hasattr(plugin, '_no_reorder'):
         return
 
     set_dirty(plugin)
 
-    if plugin.pk:
-        try:
-            old_plugin = CMSPlugin.objects.get(pk=plugin.pk)
-        except CMSPlugin.DoesNotExist:
-            pass
-        else:
-            if old_plugin.placeholder_id != plugin.placeholder_id:
-                set_dirty(old_plugin, delete_cache=False)
+    if not plugin.pk:
+        return
+
+    try:
+        old_plugin = (
+            CMSPlugin
+            .objects
+            .select_related('placeholder')
+            .only('language', 'placeholder')
+            .exclude(placeholder=plugin.placeholder_id)
+            .get(pk=plugin.pk)
+        )
+    except CMSPlugin.DoesNotExist:
+        pass
+    else:
+        set_dirty(old_plugin, delete_cache=False)
 
 
 def pre_delete_plugins(**kwargs):

--- a/cms/tests/test_plugins.py
+++ b/cms/tests/test_plugins.py
@@ -248,6 +248,36 @@ class PluginsTestCase(PluginsTestBaseCase):
             rendered_live_placeholder = live_placeholder.render(self.get_context(live_page.get_absolute_url(), page=live_page), None)
             self.assertEqual(rendered_live_placeholder, "I'm the firstI'm the secondI'm the third")
 
+        columns = api.add_plugin(placeholder, "MultiColumnPlugin", "en")
+        column = api.add_plugin(
+            placeholder,
+            "ColumnPlugin",
+            "en",
+            target=columns,
+            width='10%',
+        )
+
+        data = {
+            'placeholder_id': placeholder.id,
+            'plugin_id': text_plugin_1.id,
+            'plugin_parent': '',
+            'plugin_language': 'en',
+            'plugin_order[]': [
+                text_plugin_1.id,
+                text_plugin_2.id,
+                text_plugin_3.id,
+                columns.id,
+                column.id,
+            ],
+        }
+        response = self.client.post(URL_CMS_PLUGIN_MOVE, data)
+        self.assertEqual(response.status_code, 400)
+        self.assertContains(
+            response,
+            'order parameter references plugins in different trees',
+            status_code=400,
+        )
+
     def test_plugin_breadcrumbs(self):
         """
         Test the plugin breadcrumbs order

--- a/cms/utils/plugins.py
+++ b/cms/utils/plugins.py
@@ -194,24 +194,16 @@ def reorder_plugins(placeholder, parent_id, language, order):
         language=language,
     ).order_by('position')
 
-    x = 0
-    for level_plugin in plugins:
-        if order:
-            x = 0
-            found = False
-            for pk in order:
-                if level_plugin.pk == int(pk):
-                    level_plugin.position = x
-                    level_plugin.save()
-                    found = True
-                    break
-                x += 1
-            if not found:
-                return False
-        else:
-            level_plugin.position = x
-            level_plugin.save()
-            x += 1
+    if order:
+        plugins = plugins.filter(pk__in=order)
+        print order
+
+        for plugin in plugins.iterator():
+            position = order.index(plugin.pk)
+            plugin.update(position=position)
+    else:
+        for position, plugin in enumerate(plugins.iterator()):
+            plugin.update(position=position)
     return plugins
 
 

--- a/cms/utils/plugins.py
+++ b/cms/utils/plugins.py
@@ -188,9 +188,12 @@ def reorder_plugins(placeholder, parent_id, language, order):
     :param language: language
     :param order: optional custom order (given as list of plugin primary keys)
     """
-    plugins = CMSPlugin.objects.filter(parent=parent_id,
-                                       placeholder=placeholder,
-                                       language=language).order_by('position')
+    plugins = CMSPlugin.objects.filter(
+        parent=parent_id,
+        placeholder=placeholder,
+        language=language,
+    ).order_by('position')
+
     x = 0
     for level_plugin in plugins:
         if order:

--- a/cms/utils/plugins.py
+++ b/cms/utils/plugins.py
@@ -196,7 +196,6 @@ def reorder_plugins(placeholder, parent_id, language, order):
 
     if order:
         plugins = plugins.filter(pk__in=order)
-        print order
 
         for plugin in plugins.iterator():
             position = order.index(plugin.pk)

--- a/cms/utils/plugins.py
+++ b/cms/utils/plugins.py
@@ -194,6 +194,9 @@ def reorder_plugins(placeholder, parent_id, language, order):
         language=language,
     ).order_by('position')
 
+    # Make sure we're dealing with a list
+    order = list(order)
+
     if order:
         plugins = plugins.filter(pk__in=order)
 


### PR DESCRIPTION
* Refactored plugin reordering to avoid unnecessary ``save()`` calls.
* Reduced queries in ``move_plugin``.
* Introduced new plugin method called ``update()`` to update a plugin's data without calling ``save()``.
* Moved placeholder dirty logic to placeholder method ``mark_as_dirty``.
  This is to explicitly mark the placeholder as dirty when needed vs a signal.

I used a placeholder that contained over 20 plugins as my test case.
The load time of moving a plugin in this placeholder was about **3 minutes**.
This has now been lowered to an average of **4 seconds** with this PR.


BEFORE

![speedtest-before](https://cloud.githubusercontent.com/assets/994951/14658507/2c70f612-0662-11e6-904f-730639cf9b92.png)


AFTER

![speedtest-2](https://cloud.githubusercontent.com/assets/994951/14658511/31adcac4-0662-11e6-8b33-a89e483b66ec.png)
