### PR TITLE
Renames CMS_WIZARD* to CMS_PAGE_WIZARD*

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,8 @@
 === 3.2.6 (unreleased) ===
 
 - Adds CMS_WIZARD_CONTENT_PLACEHOLDER setting
+- Renames the CMS_WIZARD_* settings to CMS_PAGE_WIZARD_*
+- Deprecates the old-style wizard-related settings
 
 === 3.2.5 (2016-04-27) ===
 

--- a/cms/forms/wizards.py
+++ b/cms/forms/wizards.py
@@ -243,7 +243,7 @@ class CreateCMSPageForm(BaseCMSPageForm):
         page = create_page(
             title=self.cleaned_data['title'],
             slug=self.cleaned_data['slug'],
-            template=get_cms_setting('WIZARD_DEFAULT_TEMPLATE'),
+            template=get_cms_setting('PAGE_WIZARD_DEFAULT_TEMPLATE'),
             language=self.language_code,
             created_by=smart_text(self.user),
             parent=parent,
@@ -277,9 +277,9 @@ class CreateCMSPageForm(BaseCMSPageForm):
         else:
             # If the user provided content, then use that instead.
             content = self.cleaned_data.get('content')
-            plugin_type = get_cms_setting('WIZARD_CONTENT_PLUGIN')
-            plugin_body = get_cms_setting('WIZARD_CONTENT_PLUGIN_BODY')
-            slot = get_cms_setting('WIZARD_CONTENT_PLACEHOLDER')
+            plugin_type = get_cms_setting('PAGE_WIZARD_CONTENT_PLUGIN')
+            plugin_body = get_cms_setting('PAGE_WIZARD_CONTENT_PLUGIN_BODY')
+            slot = get_cms_setting('PAGE_WIZARD_CONTENT_PLACEHOLDER')
 
             if plugin_type in plugin_pool.plugins and plugin_body:
                 if content and permissions.has_plugin_permission(

--- a/cms/utils/conf.py
+++ b/cms/utils/conf.py
@@ -265,8 +265,8 @@ COMPLEX = {
     'CMS_TOOLBAR_URL__DISABLE': get_toolbar_url__disable,
 }
 
-# To be removed in v3.5.0
-DEPRECATED_WIZARD_SETTINGS = {
+DEPRECATED_CMS_SETTINGS = {
+    # Old CMS_WIZARD_* settings to be removed in v3.5.0
     'PAGE_WIZARD_DEFAULT_TEMPLATE': 'WIZARD_DEFAULT_TEMPLATE',
     'PAGE_WIZARD_CONTENT_PLUGIN': 'WIZARD_CONTENT_PLUGIN',
     'PAGE_WIZARD_CONTENT_PLUGIN_BODY': 'WIZARD_CONTENT_PLUGIN_BODY',
@@ -278,10 +278,9 @@ def get_cms_setting(name):
     if name in COMPLEX:
         return COMPLEX[name]()
     else:
-        # To be removed in v3.5.0
-        if name in DEPRECATED_WIZARD_SETTINGS:
+        if name in DEPRECATED_CMS_SETTINGS:
             new_setting = 'CMS_%s' % name
-            old_setting = 'CMS_%s' % DEPRECATED_WIZARD_SETTINGS[name]
+            old_setting = 'CMS_%s' % DEPRECATED_CMS_SETTINGS[name]
             return getattr(settings, new_setting, getattr(settings, old_setting, DEFAULTS[name]))
 
         return getattr(settings, 'CMS_%s' % name, DEFAULTS[name])

--- a/cms/utils/conf.py
+++ b/cms/utils/conf.py
@@ -64,10 +64,10 @@ DEFAULTS = {
     'APP_NAME': None,
     'TOOLBAR_HIDE': False,
     'UNESCAPED_RENDER_MODEL_TAGS': True,
-    'WIZARD_DEFAULT_TEMPLATE': constants.TEMPLATE_INHERITANCE_MAGIC,
-    'WIZARD_CONTENT_PLUGIN': 'TextPlugin',
-    'WIZARD_CONTENT_PLUGIN_BODY': 'body',
-    'WIZARD_CONTENT_PLACEHOLDER': None,  # Use first placeholder it finds.
+    'PAGE_WIZARD_DEFAULT_TEMPLATE': constants.TEMPLATE_INHERITANCE_MAGIC,
+    'PAGE_WIZARD_CONTENT_PLUGIN': 'TextPlugin',
+    'PAGE_WIZARD_CONTENT_PLUGIN_BODY': 'body',
+    'PAGE_WIZARD_CONTENT_PLACEHOLDER': None,  # Use first placeholder it finds.
 }
 
 
@@ -265,11 +265,25 @@ COMPLEX = {
     'CMS_TOOLBAR_URL__DISABLE': get_toolbar_url__disable,
 }
 
+# To be removed in v3.5.0
+DEPRECATED_WIZARD_SETTINGS = {
+    'PAGE_WIZARD_DEFAULT_TEMPLATE': 'WIZARD_DEFAULT_TEMPLATE',
+    'PAGE_WIZARD_CONTENT_PLUGIN': 'WIZARD_CONTENT_PLUGIN',
+    'PAGE_WIZARD_CONTENT_PLUGIN_BODY': 'WIZARD_CONTENT_PLUGIN_BODY',
+    'PAGE_WIZARD_CONTENT_PLACEHOLDER': 'WIZARD_CONTENT_PLACEHOLDER',
+}
+
 
 def get_cms_setting(name):
     if name in COMPLEX:
         return COMPLEX[name]()
     else:
+        # To be removed in v3.5.0
+        if name in DEPRECATED_WIZARD_SETTINGS:
+            new_setting = 'CMS_%s' % name
+            old_setting = 'CMS_%s' % DEPRECATED_WIZARD_SETTINGS[name]
+            return getattr(settings, new_setting, getattr(settings, old_setting, DEFAULTS[name]))
+
         return getattr(settings, 'CMS_%s' % name, DEFAULTS[name])
 
 

--- a/cms/utils/conf.py
+++ b/cms/utils/conf.py
@@ -277,13 +277,11 @@ DEPRECATED_CMS_SETTINGS = {
 def get_cms_setting(name):
     if name in COMPLEX:
         return COMPLEX[name]()
-    else:
-        if name in DEPRECATED_CMS_SETTINGS:
-            new_setting = 'CMS_%s' % name
-            old_setting = 'CMS_%s' % DEPRECATED_CMS_SETTINGS[name]
-            return getattr(settings, new_setting, getattr(settings, old_setting, DEFAULTS[name]))
-
-        return getattr(settings, 'CMS_%s' % name, DEFAULTS[name])
+    elif name in DEPRECATED_CMS_SETTINGS:
+        new_setting = 'CMS_%s' % name
+        old_setting = 'CMS_%s' % DEPRECATED_CMS_SETTINGS[name]
+        return getattr(settings, new_setting, getattr(settings, old_setting, DEFAULTS[name]))
+    return getattr(settings, 'CMS_%s' % name, DEFAULTS[name])
 
 
 def get_site_id(site):

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -1046,21 +1046,21 @@ Example::
 
     CMS_TOOLBAR_SIMPLE_STRUCTURE_MODE = False
 
-.. setting:: WIZARD_DEFAULT_TEMPLATE
+.. setting:: CMS_PAGE_WIZARD_DEFAULT_TEMPLATE
 
-WIZARD_DEFAULT_TEMPLATE
-=======================
+CMS_PAGE_WIZARD_DEFAULT_TEMPLATE
+================================
 
 default
     ``TEMPLATE_INHERITANCE_MAGIC``
 
-This is the path of the template used to create pages in the wizard. It must be one
-of the templates in :setting:`CMS_TEMPLATES`.
+This is the path of the template used to create pages in the wizard. It must be
+one of the templates in :setting:`CMS_TEMPLATES`.
 
-.. setting:: CMS_WIZARD_CONTENT_PLACEHOLDER
+.. setting:: CMS_PAGE_WIZARD_CONTENT_PLACEHOLDER
 
-CMS_WIZARD_CONTENT_PLACEHOLDER
-==============================
+CMS_PAGE_WIZARD_CONTENT_PLACEHOLDER
+===================================
 
 default
     None
@@ -1071,29 +1071,28 @@ adding any content supplied in the wizards' "Content" field. If this is left
 unset, then the content will target the first suitable placeholder found on
 the page's template.
 
-.. setting:: CMS_WIZARD_CONTENT_PLUGIN
+.. setting:: CMS_PAGE_WIZARD_CONTENT_PLUGIN
 
-CMS_WIZARD_CONTENT_PLUGIN
-=========================
+CMS_PAGE_WIZARD_CONTENT_PLUGIN
+==============================
 
 default
     ``TextPlugin``
 
-This is the name of the plugin created in the Page Wizard when the "Content" field is
-filled in.
-There should be no need to change it, unless you **don't** use
-``djangocms-text-ckeditor`` in your project.
+This is the name of the plugin created in the Page Wizard when the "Content"
+field is filled in. There should be no need to change it, unless you
+**don't** use ``djangocms-text-ckeditor`` in your project.
 
-.. setting:: CMS_WIZARD_CONTENT_PLUGIN_BODY
+.. setting:: CMS_PAGE_WIZARD_CONTENT_PLUGIN_BODY
 
-CMS_WIZARD_CONTENT_PLUGIN_BODY
-==============================
+CMS_PAGE_WIZARD_CONTENT_PLUGIN_BODY
+===================================
 
 default
     ``body``
 
-This is the name of the body field in the plugin created in the Page Wizard when the
-"Content" field is filled in.
-There should be no need to change it, unless you **don't** use
-``djangocms-text-ckeditor`` in your project **and** your custom plugin defined in
-:setting:`CMS_WIZARD_CONTENT_PLUGIN` have a body field **different** than ``body``.
+This is the name of the body field in the plugin created in the Page Wizard
+when the "Content" field is filled in. There should be no need to change it,
+unless you **don't** use ``djangocms-text-ckeditor`` in your project **and**
+your custom plugin defined in :setting:`CMS_PAGE_WIZARD_CONTENT_PLUGIN` have a
+body field **different** than ``body``.

--- a/docs/upgrade/3.2.6.rst
+++ b/docs/upgrade/3.2.6.rst
@@ -39,5 +39,5 @@ them as follows at their earliest convenience. ::
     CMS_WIZARD_CONTENT_PLACEHOLDER => CMS_PAGE_WIZARD_CONTENT_PLACEHOLDER
 
 The CMS will accept both-schemes until 3.5.0 when support for the old scheme
-will be dropped. During this transition period, the CMS will favor the new-style
+will be dropped. During this transition period, the CMS prefers the new-style
 naming if both schemes are used in a project's settings.

--- a/docs/upgrade/3.2.6.rst
+++ b/docs/upgrade/3.2.6.rst
@@ -20,7 +20,7 @@ Deprecation of Old-Style Page Wizard Settings
 =============================================
 
 In this release, we introduce a new naming scheme for the Page Wizard settings
-that better reflects that they effect the CMS' Page Wizards, rather than all
+that better reflects that they effect the CMS's Page Wizards, rather than all
 wizards. This will also allow future settings for different wizards with a
 smaller chance of confusion or naming-collision.
 
@@ -39,5 +39,5 @@ them as follows at their earliest convenience. ::
     CMS_WIZARD_CONTENT_PLACEHOLDER => CMS_PAGE_WIZARD_CONTENT_PLACEHOLDER
 
 The cms will accept both-schemes until 3.5.0 when support for the old scheme
-will be dropped. During this transition period, the cms will favor the new-style
+will be dropped. During this transition period, the CMS will favor the new-style
 naming if both schemes are used in a project's settings.

--- a/docs/upgrade/3.2.6.rst
+++ b/docs/upgrade/3.2.6.rst
@@ -38,6 +38,6 @@ them as follows at their earliest convenience. ::
     CMS_WIZARD_CONTENT_PLUGIN_BODY => CMS_PAGE_WIZARD_CONTENT_PLUGIN_BODY
     CMS_WIZARD_CONTENT_PLACEHOLDER => CMS_PAGE_WIZARD_CONTENT_PLACEHOLDER
 
-The cms will accept both-schemes until 3.5.0 when support for the old scheme
+The CMS will accept both-schemes until 3.5.0 when support for the old scheme
 will be dropped. During this transition period, the CMS will favor the new-style
 naming if both schemes are used in a project's settings.

--- a/docs/upgrade/3.2.6.rst
+++ b/docs/upgrade/3.2.6.rst
@@ -16,8 +16,8 @@ Bug Fixes
 * Deprecates the old-style wizard-related settings
 
 
-Dropped support for Old-Style Page Wizard Settings
-==================================================
+Deprecation of Old-Style Page Wizard Settings
+=============================================
 
 In this release, we introduce a new naming scheme for the Page Wizard settings
 that better reflects that they effect the CMS' Page Wizards, rather than all

--- a/docs/upgrade/3.2.6.rst
+++ b/docs/upgrade/3.2.6.rst
@@ -12,3 +12,32 @@ Bug Fixes
 =========
 
 * Adds CMS_WIZARD_CONTENT_PLACEHOLDER setting
+* Renames the CMS_WIZARD_* settings to CMS_PAGE_WIZARD_*
+* Deprecates the old-style wizard-related settings
+
+
+Dropped support for Old-Style Page Wizard Settings
+==================================================
+
+In this release, we introduce a new naming scheme for the Page Wizard settings
+that better reflects that they effect the CMS' Page Wizards, rather than all
+wizards. This will also allow future settings for different wizards with a
+smaller chance of confusion or naming-collision.
+
+This release simultaneously deprecates the old naming scheme for these settings.
+Support for the old naming scheme will be dropped in version 3.5.0.
+
+Action Required
+---------------
+
+Developers using any of the following settings in their projects should rename
+them as follows at their earliest convenience. ::
+
+    CMS_WIZARD_DEFAULT_TEMPLATE => CMS_PAGE_WIZARD_DEFAULT_TEMPLATE
+    CMS_WIZARD_CONTENT_PLUGIN => CMS_PAGE_WIZARD_CONTENT_PLUGIN
+    CMS_WIZARD_CONTENT_PLUGIN_BODY => CMS_PAGE_WIZARD_CONTENT_PLUGIN_BODY
+    CMS_WIZARD_CONTENT_PLACEHOLDER => CMS_PAGE_WIZARD_CONTENT_PLACEHOLDER
+
+The cms will accept both-schemes until 3.5.0 when support for the old scheme
+will be dropped. During this transition period, the cms will favor the new-style
+naming if both schemes are used in a project's settings.


### PR DESCRIPTION
Deprecation of Old-Style Page Wizard Settings
=============================================

In this release, we introduce a new naming scheme for the Page Wizard settings
that better reflects that they effect the CMS' Page Wizards, rather than all
wizards. This will also allow future settings for different wizards with a
smaller chance of confusion or naming-collision.

This release simultaneously deprecates the old naming scheme for these settings.
Support for the old naming scheme will be dropped in version 3.5.0.

Action Required
---------------

Developers using any of the following settings in their projects should rename
them as follows at their earliest convenience. ::

    CMS_WIZARD_DEFAULT_TEMPLATE => CMS_PAGE_WIZARD_DEFAULT_TEMPLATE
    CMS_WIZARD_CONTENT_PLUGIN => CMS_PAGE_WIZARD_CONTENT_PLUGIN
    CMS_WIZARD_CONTENT_PLUGIN_BODY => CMS_PAGE_WIZARD_CONTENT_PLUGIN_BODY
    CMS_WIZARD_CONTENT_PLACEHOLDER => CMS_PAGE_WIZARD_CONTENT_PLACEHOLDER

The cms will accept both-schemes until 3.5.0 when support for the old scheme
will be dropped. During this transition period, the cms will favor the new-style
naming if both schemes are used in a project's settings.