### PR TITLE
Fixes move_page issue

### DIFF
--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -837,18 +837,30 @@ class Page(six.with_metaclass(PageMetaClass, MP_Node)):
                 publisher_public = page.publisher_public
 
                 if not publisher_public.parent_id:
-                    # This page clearly has a parent because it shows up
-                    # when calling self.get_descendants()
-                    # So this condition can be True when a published page
-                    # is moved under a page that has never been published.
-                    # It's draft version (page) has a reference to the new parent
-                    # but it's live version does not because it was never set
-                    # since it didn't exist when the move happened.
+                    # So this condition can be True when:
+                    #
+                    # 1) a published page is moved under a page that has never
+                    #    been published. It's draft version (page) has a
+                    #    reference to the new parent but it's live version
+                    #    does not because it was never set since it didn't
+                    #    exist when the move happened.
+                    #
+                    # 2) a published child page is moved to root. In this
+                    #    case, the published page is parent-less, but but its
+                    #    draft-twin still has a parent. In this case, calling
+                    #    _publisher_save_public() won't help at all.
+
+                    # This helps with case 1 and is ineffectual for case 2
                     publisher_public = page._publisher_save_public(publisher_public)
 
-                # Check if the parent of this page's
-                # public version is published.
-                if publisher_public.parent.is_published(language):
+                # If publisher_public still has no parent, then it probably
+                # was case 2 above, ok to proceed.
+                #
+                # If it has a parent that is published, then it was probably
+                # case 1 above, or had a parent anyway, ok to proceed.
+                #
+                # If the page has an unpublished parent, then skip this...
+                if not publisher_public.parent_id or publisher_public.parent.is_published(language):
                     public_title = titles_by_page_id.get(page.publisher_public_id)
 
                     if public_title and not public_title.published:
@@ -863,6 +875,7 @@ class Page(six.with_metaclass(PageMetaClass, MP_Node)):
                         draft_title.publisher_state = PUBLISHER_STATE_DEFAULT
                         draft_title._publisher_keep_state = True
                         draft_title.save()
+
             elif page.get_publisher_state(language) == PUBLISHER_STATE_PENDING:
                 page.publish(language)
 


### PR DESCRIPTION
This is particularly nuanced, so, upon proving the situation, I've added copious comments along with the fix.

To reproduce the issue, start with the commit before this PR.

1. Create a test project.
2. Add 4 pages nested within each other so that Alpha is the parent of Beta which is the parent of Gamma which is the parent of Delta.
3. Publish each page.
4. Move Beta to _beneath_ Alpha but at the root. Boom.

Applying this patch, the issue is gone and pages are again freely moveable in the tree.
