### PR TITLE
fixes/issue #5273

### DIFF
--- a/cms/plugin_base.py
+++ b/cms/plugin_base.py
@@ -260,12 +260,13 @@ class CMSPluginBase(six.with_metaclass(CMSPluginBaseMetaclass, admin.ModelAdmin)
 
         # This flag allows us to know when the plugin initial attributes
         # should be set. This currently only happens on plugin creation.
-        form_class._cms_initial_attributes = True
-        form_class._cms_plugin_language = plugin_data['plugin_language']
-        form_class._cms_plugin_placeholder = plugin_data['placeholder_id']
-        form_class._cms_plugin_parent = plugin_data.get('plugin_parent', None)
-        form_class._cms_plugin_plugin_type = plugin_data['plugin_type']
-        form_class._cms_plugin_position = plugin_data['position']
+        form_class._cms_initial_attributes = {
+            'language': plugin_data['plugin_language'],
+            'placeholder': plugin_data['placeholder_id'],
+            'parent': plugin_data.get('plugin_parent', None),
+            'plugin_type': plugin_data['plugin_type'],
+            'position': plugin_data['position'],
+        }
         return form_class
 
     def validate_add_request(self, request):
@@ -376,14 +377,12 @@ class CMSPluginBase(six.with_metaclass(CMSPluginBaseMetaclass, admin.ModelAdmin)
 
     def save_form(self, request, form, change):
         obj = super(CMSPluginBase, self).save_form(request, form, change)
+        initial_attributes = getattr(form, '_cms_initial_attributes', None)
 
-        if getattr(form, '_cms_initial_attributes', None):
+        if initial_attributes:
             # Form has the initial attribute hooks
-            obj.language = form._cms_plugin_language
-            obj.placeholder = form._cms_plugin_placeholder
-            obj.parent = form._cms_plugin_parent
-            obj.plugin_type = form._cms_plugin_plugin_type
-            obj.position = form._cms_plugin_position
+            for field, value in initial_attributes.items():
+                setattr(obj, field, value)
         return obj
 
     def response_add(self, request, obj, **kwargs):

--- a/cms/plugin_base.py
+++ b/cms/plugin_base.py
@@ -258,8 +258,9 @@ class CMSPluginBase(six.with_metaclass(CMSPluginBaseMetaclass, admin.ModelAdmin)
         # Subclassing is not advisable because Django does metaclass
         # magic and some attributes get lost. Ticket #5273
 
-        # This flag allows us to know when the plugin initial attributes
-        # should be set. This currently only happens on plugin creation.
+        # The _cms_initial_attributes acts as a hook to set
+        # certain values when the form is saved.
+        # Currently this only happens on plugin creation.
         form_class._cms_initial_attributes = {
             'language': plugin_data['plugin_language'],
             'placeholder': plugin_data['placeholder_id'],

--- a/cms/test_utils/project/pluginapp/plugins/manytomany_rel/cms_plugins.py
+++ b/cms/test_utils/project/pluginapp/plugins/manytomany_rel/cms_plugins.py
@@ -1,3 +1,4 @@
+from django.contrib import admin
 from django.utils.translation import ugettext as _
 
 from cms.plugin_base import CMSPluginBase
@@ -15,6 +16,7 @@ class ArticlePlugin(CMSPluginBase):
     name = _("Articles")
     render_template = "articles.html"
     admin_preview = False
+    filter_horizontal = ['sections']
 
     def render(self, context, instance, placeholder):
         article_qs = Article.objects.filter(section__in=instance.sections.all())
@@ -23,7 +25,9 @@ class ArticlePlugin(CMSPluginBase):
                         'placeholder': placeholder})
         return context
 
-plugin_pool.register_plugin(ArticlePlugin)
+
+class ArticlePluginAdmin(admin.ModelAdmin):
+    filter_horizontal = ['sections']
 
 
 class ArticleDynamicTemplatePlugin(CMSPluginBase):
@@ -44,9 +48,6 @@ class ArticleDynamicTemplatePlugin(CMSPluginBase):
                         'placeholder': placeholder})
         return context
 
-plugin_pool.register_plugin(ArticleDynamicTemplatePlugin)
-
-
 ###
 
 
@@ -54,11 +55,16 @@ class PluginWithFKFromModel(CMSPluginBase):
     model = PluginModelWithFKFromModel
     render_template = "articles.html"
 
-plugin_pool.register_plugin(PluginWithFKFromModel)
-
 
 class PluginWithM2MToModel(CMSPluginBase):
     model = PluginModelWithM2MToModel
     render_template = "articles.html"
 
+
+plugin_pool.register_plugin(ArticlePlugin)
+plugin_pool.register_plugin(ArticleDynamicTemplatePlugin)
 plugin_pool.register_plugin(PluginWithM2MToModel)
+plugin_pool.register_plugin(PluginWithFKFromModel)
+
+# Used to test integrity of plugin form
+admin.site.register(ArticlePluginModel, ArticlePluginAdmin)


### PR DESCRIPTION
The sane-add-plugin branch introduced a regression that would prevent features like formfield callbacks from working correctly. This manifested itself in the filter_horizonal admin attribute not working correctly.

Related ticket #5273 

The reason for this problem is that Django has some special handling for things like formfield callbacks at the meta class level, so when subclassing we would not inherit the callback.

To fix this we now use internal attributes on the form class that will be used to create the plugin when the form is saved.

@mkoistinen @ojii Please have a look.