### PR TITLE
More fixes related to #5260

### DIFF
--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -253,7 +253,7 @@ class Page(six.with_metaclass(PageMetaClass, MP_Node)):
         self.save()
 
         if target_public_page:
-            moved_page = self.move(target, pos=position)
+            moved_page = self.move(target_public_page, pos=position)
         else:
             moved_page = self.move(target, pos=position)
 

--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -217,36 +217,38 @@ class Page(six.with_metaclass(PageMetaClass, MP_Node)):
 
         is_inherited_template = (
             self.template == constants.TEMPLATE_INHERITANCE_MAGIC)
+        target_public_page = None
 
-        # make sure move_page does not break when using INHERIT template
-        # and moving to a top level position.
-        # The following code resolves the inherited template
-        # and sets it on the moved page.
-        if (position in ('left', 'right') and not target.parent and
-                is_inherited_template):
-            self.template = self.get_template()
+        if position in ('left', 'right') and not target.parent:
+            # make sure move_page does not break the tree
+            # when moving to a top level position.
+
+            if position == 'right' and target.publisher_public_id:
+                # The correct path order for pages at the root level
+                # is that any left sibling page has a path
+                # lower than the path of the current page.
+                # This rule applies to both draft and live pages
+                # so this condition will make sure to add the
+                # current page to the right of the target live page.
+                target_public_page = Page.objects.get(pk=target.publisher_public_id)
+                draft_root = target.get_root()
+                public_root = target_public_page.get_root()
+
+                # With this assert we can detect tree corruptions.
+                # It's important to raise this!
+                assert draft_root.get_next_sibling() == public_root
+
+            if is_inherited_template:
+                # The following code resolves the inherited template
+                # and sets it on the moved page.
+                # This is because the page is being moved to a root
+                # position and so can't inherit from anything.
+                self.template = self.get_template()
 
         if position == 'first-child' or position == 'last-child':
             self.parent_id = target.pk
         else:
             self.parent_id = target.parent_id
-
-        if position == 'right' and target.publisher_public_id:
-            # The correct path order for pages
-            # is that any left sibling page has a path
-            # lower than the path of the current page.
-            # This rule applies to both draft and live pages
-            # so this condition will make sure to add the
-            # current page to the right of the target live page.
-            target_public_page = Page.objects.get(pk=target.publisher_public_id)
-            draft_root = target.get_root()
-            public_root = target_public_page.get_root()
-
-            # With this assert we can detect tree corruptions.
-            # It's important to raise this!
-            assert draft_root.get_next_sibling() == public_root
-        else:
-            target_public_page = None
 
         self.save()
 
@@ -1382,14 +1384,23 @@ class Page(six.with_metaclass(PageMetaClass, MP_Node)):
                             public_prev_sib != prev_public_sibling:
                 if public_prev_sib:
                     # We've got a sibling on the left side (previous)
-                    # so move the public page (obj) to be a sibling
-                    # of the draft page (self).
-                    # This keeps the tree paths consistent by making sure
-                    # the public page (obj) has a greater path than
-                    # the draft page.
                     obj.parent_id = public_prev_sib.parent_id
                     obj.save()
-                    obj = obj.move(self, pos="right")
+
+                    if obj.parent_id:
+                        # The draft page (self) has been moved under
+                        # another page.
+                        # So move the live page (obj) to be a sibling
+                        # of the public closest sibling (public_prev_sib).
+                        obj = obj.move(public_prev_sib, pos="right")
+                    else:
+                        # The draft page (self) has been moved to the root
+                        # so move the public page (obj) to be a sibling
+                        # of the draft page (self).
+                        # This keeps the tree paths consistent by making sure
+                        # the public page (obj) has a greater path than
+                        # the draft page.
+                        obj = obj.move(self, pos="right")
                 elif public_parent:
                     # move as a first child to parent
                     obj.parent_id = public_parent.pk

--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -211,6 +211,7 @@ class Page(six.with_metaclass(PageMetaClass, MP_Node)):
         as it remains the same regardless of the page position in the tree
         """
         assert self.publisher_is_draft
+        assert target.publisher_is_draft
         # do not mark the page as dirty after page moves
         self._publisher_keep_state = True
 
@@ -218,29 +219,41 @@ class Page(six.with_metaclass(PageMetaClass, MP_Node)):
             self.template == constants.TEMPLATE_INHERITANCE_MAGIC)
 
         # make sure move_page does not break when using INHERIT template
-        # and moving to a top level position
+        # and moving to a top level position.
+        # The following code resolves the inherited template
+        # and sets it on the moved page.
         if (position in ('left', 'right') and not target.parent and
                 is_inherited_template):
             self.template = self.get_template()
-            if target.publisher_public_id and position == 'right':
-                public = target.publisher_public
-                target_root = target.get_root()
-                if target_root.get_next_sibling():
-                    if target_root.get_next_sibling() == public.get_root():
-                        target = public
-                    else:
-                        logger.warning('tree may need rebuilding: '
-                                       'run `manage.py cms fix-tree`')
-                else:
-                    # target's root is last 'root' node, switch to 'left'
-                    position = 'left'
+
         if position == 'first-child' or position == 'last-child':
             self.parent_id = target.pk
         else:
             self.parent_id = target.parent_id
 
+        if position == 'right' and target.publisher_public_id:
+            # The correct path order for pages
+            # is that any left sibling page has a path
+            # lower than the path of the current page.
+            # This rule applies to both draft and live pages
+            # so this condition will make sure to add the
+            # current page to the right of the target live page.
+            target_public_page = Page.objects.get(pk=target.publisher_public_id)
+            draft_root = target.get_root()
+            public_root = target_public_page.get_root()
+
+            # With this assert we can detect tree corruptions.
+            # It's important to raise this!
+            assert draft_root.get_next_sibling() == public_root
+        else:
+            target_public_page = None
+
         self.save()
-        moved_page = self.move(target, pos=position)
+
+        if target_public_page:
+            moved_page = self.move(target, pos=position)
+        else:
+            moved_page = self.move(target, pos=position)
 
         # fire signal
         import cms.signals as cms_signals
@@ -251,6 +264,9 @@ class Page(six.with_metaclass(PageMetaClass, MP_Node)):
 
         # Make sure to update the slug and path of the target page.
         page_utils.check_title_slugs(target)
+
+        if target_public_page:
+             page_utils.check_title_slugs(target)
 
         if moved_page.publisher_public_id:
             # Ensure we have up to date mptt properties
@@ -1365,9 +1381,15 @@ class Page(six.with_metaclass(PageMetaClass, MP_Node)):
                             public_parent != obj.parent or \
                             public_prev_sib != prev_public_sibling:
                 if public_prev_sib:
+                    # We've got a sibling on the left side (previous)
+                    # so move the public page (obj) to be a sibling
+                    # of the draft page (self).
+                    # This keeps the tree paths consistent by making sure
+                    # the public page (obj) has a greater path than
+                    # the draft page.
                     obj.parent_id = public_prev_sib.parent_id
                     obj.save()
-                    obj = obj.move(public_prev_sib, pos="right")
+                    obj = obj.move(self, pos="right")
                 elif public_parent:
                     # move as a first child to parent
                     obj.parent_id = public_parent.pk

--- a/cms/tests/test_publisher.py
+++ b/cms/tests/test_publisher.py
@@ -817,6 +817,14 @@ class PublishingTests(TestCase):
         # Assert "first child" is no longer in pending state
         # and instead is in published state.
         self.assertEqual(child_1_1.get_publisher_state('en', force_reload=True), PUBLISHER_STATE_DEFAULT)
+
+        draft_tree_path = child_1_1.path[:4]
+        live_tree_path = child_1_1.publisher_public.path[:4]
+
+        # Make sure the draft and live child nodes are on separate trees
+        self.assertNotEqual(draft_tree_path, live_tree_path)
+
+        # However they should share the same branch path
         self.assertEqual(child_1_1.path[4:], child_1_1.publisher_public.path[4:])
         self.assertEqual(child_1_1.depth, child_1_1.publisher_public.depth)
 


### PR DESCRIPTION
A picture is worth a thousand words.. so they say.

So here's a picture of a broken tree:

![broken-tree-after-move](https://cloud.githubusercontent.com/assets/994951/15271090/b2d5a3da-1a06-11e6-89d1-3454962e5066.png)

And here's a picture of a healthy tree:
![healthy-tree-after-move](https://cloud.githubusercontent.com/assets/994951/15271093/bd7b0b36-1a06-11e6-8783-f784101d24f4.png)

The problem with the broken tree is that the second "root" node (parentless) which has id 3
happens to have a path less than the path of the first "root" node's public page which has id 2.

The reason why the tree breaks is because before this change, we would only set the moved page to be a sibling of the old closest root page live version if it had inhered the template, otherwise we would set it as sibling of the draft version which would then change the path of the live version.

@divio/django-cms-core Please review. This is more or less an urgent fix.