### PR TITLE
catch TypeError as well

### DIFF
--- a/cms/models/pluginmodel.py
+++ b/cms/models/pluginmodel.py
@@ -257,7 +257,7 @@ class CMSPlugin(six.with_metaclass(PluginModelBase, MP_Node)):
             new_pos = max(CMSPlugin.objects.filter(parent_id=self.parent_id,
                                                    placeholder_id=self.placeholder_id,
                                                    language=self.language).exclude(pk=self.pk).order_by('depth', 'path').values_list('position', flat=True)) + 1
-        except ValueError:
+        except (TypeError, ValueError):
             # This is the first plugin in the set
             new_pos = 0
         self.position = new_pos


### PR DESCRIPTION
While copying a plugin, I had a situation where arithmetic would have given ``None + 1``. Therefore we should also catch a ``TypeError``.

@yakky looking at the query above, why do we need to ``.order_by('depth', 'path')`` the query result, and why don't we use an aggregate for it? You where the last one touching that line of code.