### PR TITLE
Fixes #5298 on 3.3

### DIFF
--- a/cms/admin/forms.py
+++ b/cms/admin/forms.py
@@ -232,9 +232,9 @@ class AdvancedSettingsForm(forms.ModelForm):
         if not self.fields['language'].initial:
             self.fields['language'].initial = get_language()
         if 'navigation_extenders' in self.fields:
+            navigation_extenders = self.get_navigation_extenders()
             self.fields['navigation_extenders'].widget = forms.Select(
-                {}, [('', "---------")] + menu_pool.get_menus_by_attribute(
-                    "cms_enabled", True))
+                {}, [('', "---------")] + navigation_extenders)
         if 'application_urls' in self.fields:
             # Prepare a dict mapping the apps by class name ('PollApp') to
             # their app_name attribute ('polls'), if any.
@@ -282,6 +282,9 @@ class AdvancedSettingsForm(forms.ModelForm):
 
         if 'redirect' in self.fields:
             self.fields['redirect'].widget.language = self.fields['language'].initial
+
+    def get_navigation_extenders(self):
+        return menu_pool.get_menus_by_attribute("cms_enabled", True)
 
     def _check_unique_namespace_instance(self, namespace):
         return Page.objects.filter(

--- a/cms/api.py
+++ b/cms/api.py
@@ -21,7 +21,6 @@ from django.utils.translation import activate
 
 from cms import constants
 from cms.app_base import CMSApp
-from cms.apphook_pool import apphook_pool
 from cms.constants import TEMPLATE_INHERITANCE_MAGIC
 from cms.models.pagemodel import Page
 from cms.models.permissionmodels import (PageUser, PagePermission, GlobalPagePermission,
@@ -80,6 +79,8 @@ def _verify_apphook(apphook, namespace):
     """
     Verifies the apphook given is valid and returns the normalized form (name)
     """
+    from cms.apphook_pool import apphook_pool
+
     apphook_pool.discover_apps()
     if isinstance(apphook, CMSApp):
         try:

--- a/cms/api.py
+++ b/cms/api.py
@@ -21,6 +21,7 @@ from django.utils.translation import activate
 
 from cms import constants
 from cms.app_base import CMSApp
+from cms.apphook_pool import apphook_pool
 from cms.constants import TEMPLATE_INHERITANCE_MAGIC
 from cms.models.pagemodel import Page
 from cms.models.permissionmodels import (PageUser, PagePermission, GlobalPagePermission,
@@ -79,8 +80,6 @@ def _verify_apphook(apphook, namespace):
     """
     Verifies the apphook given is valid and returns the normalized form (name)
     """
-    from cms.apphook_pool import apphook_pool
-
     apphook_pool.discover_apps()
     if isinstance(apphook, CMSApp):
         try:

--- a/cms/cms_menus.py
+++ b/cms/cms_menus.py
@@ -258,11 +258,10 @@ class NavExtender(Modifier):
                                 extnode.parent_namespace = node.namespace
                                 extnode.parent = node
                                 node.children.append(extnode)
-        menus = self.manager.menus
         removed = []
 
         # find all not assigned nodes
-        for menu in menus.items():
+        for menu in self.manager.menus.items():
             if (hasattr(menu[1], 'cms_enabled')
                     and menu[1].cms_enabled and not menu[0] in exts):
                 for node in nodes:

--- a/cms/cms_menus.py
+++ b/cms/cms_menus.py
@@ -79,17 +79,18 @@ def get_visible_pages(request, pages, site=None):
     return [page.pk for page in pages]
 
 
-def page_to_node(page, home, cut):
+def page_to_node(manager, page, home, cut):
     """
     Transform a CMS page into a navigation node.
 
+    :param manager: MenuManager instance bound to the request
     :param page: the page you wish to transform
     :param home: a reference to the "home" page (the page with path="0001")
     :param cut: Should we cut page from its parent pages? This means the node will not
          have a parent anymore.
     """
     # Theses are simple to port over, since they are not calculated.
-    # Other attributes will be added conditionnally later.
+    # Other attributes will be added conditionally later.
     attr = {
         'is_page': True,
         'soft_root': page.soft_root,
@@ -116,9 +117,9 @@ def page_to_node(page, home, cut):
     # Extenders can be either navigation extenders or from apphooks.
     extenders = []
     if page.navigation_extenders:
-        if page.navigation_extenders in menu_pool.menus:
+        if page.navigation_extenders in manager.menus:
             extenders.append(page.navigation_extenders)
-        elif "{0}:{1}".format(page.navigation_extenders, page.pk) in menu_pool.menus:
+        elif "{0}:{1}".format(page.navigation_extenders, page.pk) in manager.menus:
             extenders.append("{0}:{1}".format(page.navigation_extenders, page.pk))
     # Is this page an apphook? If so, we need to handle the apphooks's nodes
     lang = get_language()
@@ -160,6 +161,7 @@ def page_to_node(page, home, cut):
 
 
 class CMSMenu(Menu):
+
     def get_nodes(self, request):
         page_queryset = get_page_queryset(request)
         site = current_site(request)
@@ -216,9 +218,11 @@ class CMSMenu(Menu):
             page = ids[title.page_id]
             page.title_cache[title.language] = title
 
+        manager = self.manager
+
         for page in actual_pages:
             if page.title_cache:
-                nodes.append(page_to_node(page, home, home_cut))
+                nodes.append(page_to_node(manager, page, home, home_cut))
         return nodes
 
 
@@ -226,6 +230,7 @@ menu_pool.register_menu(CMSMenu)
 
 
 class NavExtender(Modifier):
+
     def modify(self, request, nodes, namespace, root_id, post_cut, breadcrumb):
         if post_cut:
             return nodes
@@ -253,9 +258,11 @@ class NavExtender(Modifier):
                                 extnode.parent_namespace = node.namespace
                                 extnode.parent = node
                                 node.children.append(extnode)
+        menus = self.manager.menus
         removed = []
+
         # find all not assigned nodes
-        for menu in menu_pool.menus.items():
+        for menu in menus.items():
             if (hasattr(menu[1], 'cms_enabled')
                     and menu[1].cms_enabled and not menu[0] in exts):
                 for node in nodes:

--- a/cms/context_processors.py
+++ b/cms/context_processors.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+from django.utils import lru_cache
+from django.utils.functional import lazy
+
 from cms.utils.conf import get_cms_setting
 from cms.utils import get_template_from_request
 
@@ -7,8 +10,22 @@ def cms_settings(request):
     """
     Adds cms-related variables to the context.
     """
+    from menus.menu_pool import MenuManager
+
+    @lru_cache.lru_cache(maxsize=None)
+    def _get_menu_manager():
+        # We use lru_cache to avoid getting the manager
+        # every time this function is called.
+        from menus.menu_pool import menu_pool
+        return menu_pool.get_manager(request)
+
+    # Now use lazy() to avoid getting the menu manager
+    # up until the point is needed.
+    # lazy() does not memoize results, is why lru_cache is needed.
+    _get_menu_manager = lazy(_get_menu_manager, MenuManager)
 
     return {
+        'cms_menu_manager': _get_menu_manager(),
         'CMS_MEDIA_URL': get_cms_setting('MEDIA_URL'),
         'CMS_TEMPLATE': lambda: get_template_from_request(request),
     }

--- a/cms/tests/test_api.py
+++ b/cms/tests/test_api.py
@@ -116,7 +116,7 @@ class PythonAPITests(TestCase):
         if not menu_pool.discovered:
             menu_pool.discover_menus()
         self.old_menu = menu_pool.menus
-        menu_pool.menus = {'TestMenu': TestMenu()}
+        menu_pool.menus = {'TestMenu': TestMenu}
         self.assertRaises(AssertionError, create_page, navigation_extenders=1,
                           **self._get_default_create_page_arguments())
         menu_pool.menus = self.old_menu
@@ -135,7 +135,7 @@ class PythonAPITests(TestCase):
         if not menu_pool.discovered:
             menu_pool.discover_menus()
         self.old_menu = menu_pool.menus
-        menu_pool.menus = {'TestMenu': TestMenu()}
+        menu_pool.menus = {'TestMenu': TestMenu}
         page = create_page(navigation_extenders='TestMenu',
                            **self._get_default_create_page_arguments())
         self.assertEqual(page.navigation_extenders, 'TestMenu')

--- a/cms/tests/test_cache.py
+++ b/cms/tests/test_cache.py
@@ -89,8 +89,9 @@ class CacheTestCase(CMSTestCase):
                 self.client.get('/en/')
             with self.assertNumQueries(FuzzyInt(5, 9)):
                 self.client.get('/en/')
+
         with self.settings(CMS_PAGE_CACHE=False, MIDDLEWARE_CLASSES=middleware, CMS_PLACEHOLDER_CACHE=False):
-            with self.assertNumQueries(FuzzyInt(7, 11)):
+            with self.assertNumQueries(FuzzyInt(7, 13)):
                 self.client.get('/en/')
 
     def test_no_cache_plugin(self):

--- a/cms/tests/test_check.py
+++ b/cms/tests/test_check.py
@@ -12,7 +12,7 @@ from cms.models.placeholdermodel import Placeholder
 from cms.test_utils.project.pluginapp.plugins.manytomany_rel.models import ArticlePluginModel
 from cms.test_utils.project.extensionapp.models import MyPageExtension
 from cms.utils.check import FileOutputWrapper, check, FileSectionWrapper
-from cms.utils.compat import DJANGO_1_8
+
 from djangocms_text_ckeditor.cms_plugins import TextPlugin
 
 
@@ -62,16 +62,11 @@ class CheckTests(CheckAssertMixin, TestCase):
             self.assertCheck(True, warnings=1, errors=0)
 
     def test_no_sekizai(self):
-        if DJANGO_1_8:
-            from django.apps import apps
-            apps.set_available_apps(['cms', 'menus'])
-            self.assertCheck(False, errors=2)
-            apps.unset_available_apps()
-        else:
-            from django.apps import apps
-            apps.set_available_apps(['cms', 'menus'])
-            self.assertCheck(False, errors=2)
-            apps.unset_available_apps()
+        apps = list(settings.INSTALLED_APPS)
+        apps.remove('sekizai')
+
+        with self.settings(INSTALLED_APPS=apps):
+            self.assertCheck(False, errors=1)
 
     def test_no_cms_settings_context_processor(self):
         override = {'TEMPLATES': deepcopy(settings.TEMPLATES)}

--- a/cms/tests/test_check.py
+++ b/cms/tests/test_check.py
@@ -73,9 +73,15 @@ class CheckTests(CheckAssertMixin, TestCase):
             self.assertCheck(False, errors=2)
             apps.unset_available_apps()
 
+    def test_no_cms_settings_context_processor(self):
+        override = {'TEMPLATES': deepcopy(settings.TEMPLATES)}
+        override['TEMPLATES'][0]['OPTIONS']['context_processors'] = ['sekizai.context_processors.sekizai']
+        with self.settings(**override):
+            self.assertCheck(False, errors=1)
+
     def test_no_sekizai_template_context_processor(self):
         override = {'TEMPLATES': deepcopy(settings.TEMPLATES)}
-        override['TEMPLATES'][0]['OPTIONS']['context_processors'] = []
+        override['TEMPLATES'][0]['OPTIONS']['context_processors'] = ['cms.context_processors.cms_settings']
         with self.settings(**override):
             self.assertCheck(False, errors=2)
 

--- a/cms/tests/test_menu.py
+++ b/cms/tests/test_menu.py
@@ -74,25 +74,6 @@ class MenuDiscoveryTest(ExtendedMenusFixture, CMSTestCase):
         menu_pool.menus = self.old_menu
         super(MenuDiscoveryTest, self).tearDown()
 
-    def test_menu_types_expansion_basic(self):
-        request = self.get_request('/')
-
-        menu_pool.discover_menus()
-
-        for key, menu in menu_pool.menus.items():
-            self.assertTrue(issubclass(menu, Menu))
-        defined_menus = len(menu_pool.menus)
-
-        manager = menu_pool.get_manager(request)
-        loaded_menus = len(manager.menus)
-
-        # Testing expansion after get_nodes
-        manager.get_nodes(request)
-
-        for menu in manager.menus.values():
-            self.assertTrue(issubclass(menu, Menu))
-        self.assertEqual(defined_menus, loaded_menus)
-
     def test_menu_expanded(self):
         menu_pool.discovered = False
         menu_pool.discover_menus()

--- a/cms/tests/test_menu.py
+++ b/cms/tests/test_menu.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import copy
-from cms.test_utils.project.sampleapp.cms_apps import SampleApp
-import sys
+from cms.test_utils.project.sampleapp.cms_apps import NamespacedApp, SampleApp, SampleApp2
 
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser, Permission, Group
@@ -26,10 +25,6 @@ from cms.test_utils.util.context_managers import apphooks, LanguageOverride
 from cms.test_utils.util.mock import AttributeObject
 from cms.utils import get_cms_setting
 from cms.utils.i18n import force_language
-
-
-APP_NAME = 'SampleApp'
-APP_MODULE = "cms.test_utils.project.sampleapp.cms_apps"
 
 
 class BaseMenuTest(CMSTestCase):
@@ -179,21 +174,19 @@ class MenuDiscoveryTest(ExtendedMenusFixture, CMSTestCase):
                 self.assertEqual(static_menus_2, 0)
 
     def test_multiple_menus(self):
-        if APP_MODULE in sys.modules:
-            del sys.modules[APP_MODULE]
-
         with self.settings(ROOT_URLCONF='cms.test_utils.project.urls_for_apphook_tests'):
-            apphook_pool.discovered = False
-            apphook_pool.discover_apps()
-            create_page("apphooked-page", "nav_playground.html", "en",
-                        published=True, apphook="SampleApp2")
-            create_page("apphooked-page", "nav_playground.html", "en",
-                        published=True,
-                        navigation_extenders='StaticMenu')
-            create_page("apphooked-page", "nav_playground.html", "en",
-                        published=True, apphook="NamespacedApp", apphook_namespace='whatever',
-                        navigation_extenders='StaticMenu')
-            self.assertEqual(len(menu_pool.get_menus_by_attribute("cms_enabled", True)), 2)
+            with apphooks(NamespacedApp, SampleApp2):
+                apphook_pool.discovered = False
+                apphook_pool.discover_apps()
+                create_page("apphooked-page", "nav_playground.html", "en",
+                            published=True, apphook="SampleApp2")
+                create_page("apphooked-page", "nav_playground.html", "en",
+                            published=True,
+                            navigation_extenders='StaticMenu')
+                create_page("apphooked-page", "nav_playground.html", "en",
+                            published=True, apphook="NamespacedApp", apphook_namespace='whatever',
+                            navigation_extenders='StaticMenu')
+                self.assertEqual(len(menu_pool.get_menus_by_attribute("cms_enabled", True)), 2)
 
 
 class ExtendedFixturesMenuTests(ExtendedMenusFixture, BaseMenuTest):

--- a/cms/tests/test_menu.py
+++ b/cms/tests/test_menu.py
@@ -38,7 +38,8 @@ class BaseMenuTest(CMSTestCase):
         nodes = [node1, node2, node3, node4, node5]
         tree = _build_nodes_inner_for_one_menu([n for n in nodes], "test")
         request = self.get_request(path)
-        menu_pool.apply_modifiers(tree, request)
+        manager = menu_pool.get_manager(request)
+        manager.apply_modifiers(tree, request)
         return tree, nodes
 
     def setUp(self):

--- a/cms/tests/test_menu.py
+++ b/cms/tests/test_menu.py
@@ -8,7 +8,7 @@ from django.template import Template, TemplateSyntaxError
 from django.test.utils import override_settings
 from django.utils.translation import activate
 from cms.apphook_pool import apphook_pool
-from menus.base import NavigationNode, Menu
+from menus.base import NavigationNode
 from menus.menu_pool import menu_pool, _build_nodes_inner_for_one_menu
 from menus.models import CacheKey
 from menus.utils import mark_descendants, find_selected, cut_levels

--- a/cms/tests/test_menu.py
+++ b/cms/tests/test_menu.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import copy
 from cms.test_utils.project.sampleapp.cms_apps import SampleApp
+import sys
 
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser, Permission, Group
@@ -25,6 +26,10 @@ from cms.test_utils.util.context_managers import apphooks, LanguageOverride
 from cms.test_utils.util.mock import AttributeObject
 from cms.utils import get_cms_setting
 from cms.utils.i18n import force_language
+
+
+APP_NAME = 'SampleApp'
+APP_MODULE = "cms.test_utils.project.sampleapp.cms_apps"
 
 
 class BaseMenuTest(CMSTestCase):
@@ -174,6 +179,9 @@ class MenuDiscoveryTest(ExtendedMenusFixture, CMSTestCase):
                 self.assertEqual(static_menus_2, 0)
 
     def test_multiple_menus(self):
+        if APP_MODULE in sys.modules:
+            del sys.modules[APP_MODULE]
+
         with self.settings(ROOT_URLCONF='cms.test_utils.project.urls_for_apphook_tests'):
             apphook_pool.discovered = False
             apphook_pool.discover_apps()

--- a/cms/tests/test_menu_page_viewperm.py
+++ b/cms/tests/test_menu_page_viewperm.py
@@ -190,7 +190,8 @@ class ViewPermissionTests(CMSTestCase):
 
     def assertInMenu(self, page, user):
         request = self.get_request(user, page)
-        nodes = menu_pool.get_nodes(request)
+        manager = menu_pool.get_manager(request)
+        nodes = manager.get_nodes()
         target_url = page.get_absolute_url()
         found_in_menu = False
         for node in nodes:
@@ -201,7 +202,8 @@ class ViewPermissionTests(CMSTestCase):
 
     def assertNotInMenu(self, page, user):
         request = self.get_request(user, page)
-        nodes = menu_pool.get_nodes(request)
+        manager = menu_pool.get_manager(request)
+        nodes = manager.get_nodes()
         target_url = page.get_absolute_url()
         found_in_menu = False
         for node in nodes:
@@ -286,7 +288,8 @@ class ViewPermissionComplexMenuAllNodesTests(ViewPermissionTests):
         request = self.get_request()
         visible_page_ids = get_visible_pages(request, all_pages, self.site)
         self.assertEqual(len(all_pages), len(visible_page_ids))
-        nodes = menu_pool.get_nodes(request)
+        manager = menu_pool.get_manager(request)
+        nodes = manager.get_nodes()
         self.assertEqual(len(nodes), len(all_pages))
 
     def test_public_menu_anonymous_user(self):
@@ -310,7 +313,8 @@ class ViewPermissionComplexMenuAllNodesTests(ViewPermissionTests):
         urls = self.get_url_dict(all_pages)
         user = AnonymousUser()
         request = self.get_request(user, urls['/en/'])
-        nodes = menu_pool.get_nodes(request)
+        manager = menu_pool.get_manager(request)
+        nodes = manager.get_nodes()
         self.assertEqual(len(nodes), 4)
         self.assertInMenu(urls["/en/"], user)
         self.assertInMenu(urls["/en/page_c/"], user)

--- a/cms/tests/test_navextender.py
+++ b/cms/tests/test_navextender.py
@@ -24,13 +24,10 @@ class NavExtenderTestCase(NavextendersFixture, CMSTestCase):
         if not menu_pool.discovered:
             menu_pool.discover_menus()
         self.old_menu = menu_pool.menus
-        # NOTE: if we're going to directly manipulate this menu pool, we should
-        # at least be marking it as not _expanded.
         menu_pool.menus = {
             'CMSMenu': self.old_menu['CMSMenu'],
             'TestMenu': TestMenu
         }
-        menu_pool._expanded = False
 
     def tearDown(self):
         menu_pool.menus = self.old_menu

--- a/cms/tests/test_views.py
+++ b/cms/tests/test_views.py
@@ -231,7 +231,7 @@ class ContextTests(CMSTestCase):
         context._standard_context_processors = None
         # Number of queries when context processors is not enabled
         with self.settings(**override):
-            with self.assertNumQueries(FuzzyInt(0, 12)) as context:
+            with self.assertNumQueries(FuzzyInt(0, 15)) as context:
                 response = self.client.get("/en/plain_view/")
                 num_queries = len(context.captured_queries)
                 self.assertFalse('CMS_TEMPLATE' in response.context)
@@ -258,7 +258,10 @@ class ContextTests(CMSTestCase):
         # Number of queries when context processors is not enabled
         with self.settings(**override):
             # Baseline number of queries
-            with self.assertNumQueries(FuzzyInt(13, 25)) as context:
+            # It's clear that without the context processors
+            # the number of queries go up.
+            # This is because of the menu manager handling.
+            with self.assertNumQueries(FuzzyInt(20, 47)) as context:
                 response = self.client.get("/en/page-2/")
                 num_queries_page = len(context.captured_queries)
         cache.clear()
@@ -268,10 +271,11 @@ class ContextTests(CMSTestCase):
         with self.settings(**original_context):
             # Exactly the same number of queries are executed with and without
             # the context_processor
-            with self.assertNumQueries(num_queries_page):
+            with self.assertNumQueries(FuzzyInt(13, 25)) as context:
                 response = self.client.get("/en/page-2/")
                 template = Variable('CMS_TEMPLATE').resolve(response.context)
                 self.assertEqual(template, page_template)
+                num_queries_page = len(context.captured_queries)
         cache.clear()
         menu_pool.clear()
         page_2.template = 'INHERIT'

--- a/cms/tests/test_views.py
+++ b/cms/tests/test_views.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 import re
 import sys
 

--- a/cms/tests/test_views.py
+++ b/cms/tests/test_views.py
@@ -231,7 +231,7 @@ class ContextTests(CMSTestCase):
         context._standard_context_processors = None
         # Number of queries when context processors is not enabled
         with self.settings(**override):
-            with self.assertNumQueries(FuzzyInt(0, 15)) as context:
+            with self.assertNumQueries(FuzzyInt(0, 17)) as context:
                 response = self.client.get("/en/plain_view/")
                 num_queries = len(context.captured_queries)
                 self.assertFalse('CMS_TEMPLATE' in response.context)

--- a/cms/tests/test_views.py
+++ b/cms/tests/test_views.py
@@ -229,8 +229,6 @@ class ContextTests(CMSTestCase):
 
         # Number of queries when context processor is enabled
         with self.settings(**original_context):
-            # no extra query is run when accessing urls managed by standard
-            # django applications
             with self.assertNumQueries(FuzzyInt(0, 17)):
                 response = self.client.get("/en/plain_view/")
             # One query when determining current page
@@ -247,8 +245,6 @@ class ContextTests(CMSTestCase):
 
         # Number of queries when context processors is enabled
         with self.settings(**original_context):
-            # Exactly the same number of queries are executed with and without
-            # the context_processor
             with self.assertNumQueries(FuzzyInt(13, 25)) as context:
                 response = self.client.get("/en/page-2/")
                 template = Variable('CMS_TEMPLATE').resolve(response.context)

--- a/cms/utils/check.py
+++ b/cms/utils/check.py
@@ -161,6 +161,10 @@ def define_check(func):
     return func
 
 
+def get_processors():
+    return list(chain(*[template['OPTIONS'].get('context_processors', []) for template in settings.TEMPLATES]))
+
+
 @define_check
 def check_sekizai(output):
     with output.section("Sekizai") as section:
@@ -168,7 +172,7 @@ def check_sekizai(output):
             section.success("Sekizai is installed")
         else:
             section.error("Sekizai is not installed, could not find 'sekizai' in INSTALLED_APPS")
-        processors = list(chain(*[template['OPTIONS'].get('context_processors', []) for template in settings.TEMPLATES]))
+        processors = get_processors()
         if 'sekizai.context_processors.sekizai' in processors:
             section.success("Sekizai template context processor is installed")
         else:
@@ -231,6 +235,16 @@ def check_middlewares(output):
             if middleware not in settings.MIDDLEWARE_CLASSES:
                 section.error("%s middleware must be in MIDDLEWARE_CLASSES" % middleware)
 
+@define_check
+def check_context_processors(output):
+    with output.section("Context processors") as section:
+        processors = get_processors()
+        required_processors = (
+            'cms.context_processors.cms_settings',
+        )
+        for processor in required_processors:
+            if processor not in processors:
+                section.error("%s context processor must be in TEMPLATES option context_processors" % processor)
 
 @define_check
 def check_deprecated_settings(output):

--- a/cms/utils/check.py
+++ b/cms/utils/check.py
@@ -164,7 +164,9 @@ def define_check(func):
 @define_check
 def check_sekizai(output):
     with output.section("Sekizai") as section:
-        if is_installed('sekizai'):
+        sekizai_installed = is_installed('sekizai')
+
+        if sekizai_installed:
             section.success("Sekizai is installed")
         else:
             section.error("Sekizai is not installed, could not find 'sekizai' in INSTALLED_APPS")
@@ -173,6 +175,12 @@ def check_sekizai(output):
             section.success("Sekizai template context processor is installed")
         else:
             section.error("Sekizai template context processor is not installed, could not find 'sekizai.context_processors.sekizai' in TEMPLATES option context_processors")
+
+        if not sekizai_installed:
+            # sekizai is not installed.
+            # we can't reliable check templates
+            # because template loading won't work
+            return
 
         for template, _ in get_cms_setting('TEMPLATES'):
             if template == constants.TEMPLATE_INHERITANCE_MAGIC:

--- a/cms/utils/check.py
+++ b/cms/utils/check.py
@@ -161,10 +161,6 @@ def define_check(func):
     return func
 
 
-def get_processors():
-    return list(chain(*[template['OPTIONS'].get('context_processors', []) for template in settings.TEMPLATES]))
-
-
 @define_check
 def check_sekizai(output):
     with output.section("Sekizai") as section:
@@ -172,7 +168,7 @@ def check_sekizai(output):
             section.success("Sekizai is installed")
         else:
             section.error("Sekizai is not installed, could not find 'sekizai' in INSTALLED_APPS")
-        processors = get_processors()
+        processors = list(chain(*[template['OPTIONS'].get('context_processors', []) for template in settings.TEMPLATES]))
         if 'sekizai.context_processors.sekizai' in processors:
             section.success("Sekizai template context processor is installed")
         else:
@@ -238,7 +234,7 @@ def check_middlewares(output):
 @define_check
 def check_context_processors(output):
     with output.section("Context processors") as section:
-        processors = get_processors()
+        processors = list(chain(*[template['OPTIONS'].get('context_processors', []) for template in settings.TEMPLATES]))
         required_processors = (
             'cms.context_processors.cms_settings',
         )

--- a/menus/base.py
+++ b/menus/base.py
@@ -5,7 +5,9 @@ from django.utils.encoding import smart_str
 class Menu(object):
     namespace = None
 
-    def __init__(self):
+    def __init__(self, manager):
+        self.manager = manager
+
         if not self.namespace:
             self.namespace = self.__class__.__name__
 
@@ -17,6 +19,9 @@ class Menu(object):
 
 
 class Modifier(object):
+
+    def __init__(self, manager):
+        self.manager = manager
 
     def modify(self, request, nodes, namespace, root_id, post_cut, breadcrumb):
         pass

--- a/menus/menu_pool.py
+++ b/menus/menu_pool.py
@@ -92,7 +92,7 @@ def _get_menu_class_for_instance(menu_class, instance):
 
 class MenuManager(object):
     # The main logic behind this class is to decouple
-    # the singleton menu pool from the menu logic.
+    # the singleton menu pool from the menu rendering logic.
     # By doing this we can be sure that each request has it's
     # private instance that will always have the same attributes.
 
@@ -244,7 +244,7 @@ class MenuPool(object):
         register()
         self.discovered = True
 
-    def get_registered_menus(self, for_rendering=True):
+    def get_registered_menus(self, for_rendering=False):
         """
         Returns all registered menu classes.
 
@@ -345,13 +345,12 @@ class MenuPool(object):
         # Note that we are limiting the output to only single instances of any
         # specific menu class. This is to address issue (#4041) which has
         # cropped-up in 3.0.13/3.0.0.
-        self.discover_menus()
         # By setting for_rendering to False
         # we're limiting the output to menus
         # that are registered and have instances
         # (in case of attached menus).
         menus = self.get_registered_menus(for_rendering=False)
-        return sorted(list(set([(menu.__class__.__name__, menu.name)
+        return sorted(list(set([(menu.__name__, menu.name)
                                 for menu_class_name, menu in menus.items()
                                 if getattr(menu, name, None) == value])))
 

--- a/menus/menu_pool.py
+++ b/menus/menu_pool.py
@@ -224,7 +224,7 @@ class MenuPool(object):
         self.modifiers = []
         self.discovered = False
 
-    def __call__(self, request):
+    def get_manager(self, request):
         self.discover_menus()
         # Returns a menu pool wrapper that is bound
         # to the given request and can perform

--- a/menus/menu_pool.py
+++ b/menus/menu_pool.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import warnings
 from functools import partial
 from logging import getLogger
 
@@ -200,8 +201,7 @@ class MenuManager(object):
                 self.request, nodes, namespace, root_id, post_cut, breadcrumb)
         return nodes
 
-    def get_nodes(self, namespace=None, root_id=None, site_id=None,
-            breadcrumb=False):
+    def get_nodes(self, namespace=None, root_id=None, site_id=None, breadcrumb=False):
         if not site_id:
             site_id = Site.objects.get_current().pk
         nodes = self._build_nodes(site_id)
@@ -356,5 +356,35 @@ class MenuPool(object):
 
     def get_nodes_by_attribute(self, nodes, name, value):
         return [node for node in nodes if node.attr.get(name, None) == value]
+
+    def apply_modifiers(self, nodes, request, namespace=None, root_id=None,
+            post_cut=False, breadcrumb=False):
+        warnings.warn('menu_pool.apply_modifiers is deprecated '
+                      'and it will be removed in version 3.4; '
+                      'please use the menu manager instead.', DeprecationWarning)
+        manager = self.get_manager(request)
+        nodes = manager.apply_modifiers(
+            nodes=nodes,
+            namespace=namespace,
+            root_id=root_id,
+            post_cut=post_cut,
+            breadcrumb=breadcrumb,
+        )
+        return nodes
+
+    def get_nodes(self, request, namespace=None, root_id=None, site_id=None,
+                  breadcrumb=False):
+        warnings.warn('menu_pool.get_nodes is deprecated '
+                      'and it will be removed in version 3.4; '
+                      'please use the menu manager instead.', DeprecationWarning)
+        manager = self.get_manager(request)
+        nodes = manager.get_nodes(
+            namespace=namespace,
+            root_id=root_id,
+            site_id=site_id,
+            breadcrumb=breadcrumb,
+        )
+        return nodes
+
 
 menu_pool = MenuPool()

--- a/menus/menu_pool.py
+++ b/menus/menu_pool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-
+from functools import partial
 from logging import getLogger
 
 from django.conf import settings
@@ -78,12 +78,158 @@ def _build_nodes_inner_for_one_menu(nodes, menu_class_name):
     return final_nodes
 
 
+def _get_menu_class_for_instance(menu_class, instance):
+    """
+    Returns a new menu class that subclasses
+    menu_class but is bound to instance.
+    This means it sets the "instance" attribute of the class.
+    """
+    attrs = {'instance': instance}
+    class_name = menu_class.__name__
+    meta_class = type(menu_class)
+    return meta_class(class_name, (menu_class,), attrs)
+
+
+class MenuManager(object):
+    # The main logic behind this class is to decouple
+    # the singleton menu pool from the menu logic.
+    # By doing this we can be sure that each request has it's
+    # private instance that will always have the same attributes.
+
+    def __init__(self, pool, request):
+        self.pool = pool
+        # It's important this happens on init
+        # because we need to make sure that a menu manager
+        # points to the same registered menus as long as the
+        # instance lives.
+        self.menus = pool.get_registered_menus(for_rendering=True)
+        self.request = request
+
+    def _build_nodes(self, site_id):
+        """
+        This is slow. Caching must be used.
+        One menu is built per language and per site.
+
+        Namespaces: they are ID prefixes to avoid node ID clashes when plugging
+        multiple trees together.
+
+        - We iterate on the list of nodes.
+        - We store encountered nodes in a dict (with namespaces):
+            done_nodes[<namespace>][<node's id>] = node
+        - When a node has a parent defined, we lookup that parent in done_nodes
+            if it's found:
+                set the node as the node's parent's child (re-read this)
+            else:
+                the node is put at the bottom of the list
+        """
+        # Before we do anything, make sure that the menus are expanded.
+        # Cache key management
+        lang = get_language()
+        prefix = getattr(settings, "CMS_CACHE_PREFIX", "menu_cache_")
+        key = "%smenu_nodes_%s_%s" % (prefix, lang, site_id)
+        if self.request.user.is_authenticated():
+            key += "_%s_user" % self.request.user.pk
+        cached_nodes = cache.get(key, None)
+        if cached_nodes:
+            return cached_nodes
+
+        final_nodes = []
+        toolbar = getattr(self.request, 'toolbar', None)
+        for menu_class_name in self.menus:
+            MenuClass = self.menus[menu_class_name]
+
+            try:
+                menu = MenuClass(manager=self)
+                nodes = menu.get_nodes(self.request)
+            except NoReverseMatch:
+                # Apps might raise NoReverseMatch if an apphook does not yet
+                # exist, skip them instead of crashing
+                nodes = []
+                if toolbar and toolbar.is_staff:
+                    messages.error(self.request,
+                        _('Menu %s cannot be loaded. Please, make sure all '
+                          'its urls exist and can be resolved.') %
+                        menu_class_name)
+                logger.error("Menu %s could not be loaded." %
+                    menu_class_name, exc_info=True)
+            # nodes is a list of navigation nodes (page tree in cms + others)
+            final_nodes += _build_nodes_inner_for_one_menu(
+                nodes, menu_class_name)
+
+        cache.set(key, final_nodes, get_cms_setting('CACHE_DURATIONS')['menus'])
+        # We need to have a list of the cache keys for languages and sites that
+        # span several processes - so we follow the Django way and share through
+        # the database. It's still cheaper than recomputing every time!
+        # This way we can selectively invalidate per-site and per-language,
+        # since the cache shared but the keys aren't
+        CacheKey.objects.get_or_create(key=key, language=lang, site=site_id)
+        return final_nodes
+
+    def _mark_selected(self, nodes):
+        # There /may/ be two nodes that get marked with selected. A published
+        # and a draft version of the node. We'll mark both, later, the unused
+        # one will be removed anyway.
+        sel = []
+        for node in nodes:
+            node.sibling = False
+            node.ancestor = False
+            node.descendant = False
+            node_abs_url = node.get_absolute_url()
+            if node_abs_url == self.request.path[:len(node_abs_url)]:
+                if sel:
+                    if len(node_abs_url) > len(sel[0].get_absolute_url()):
+                        sel = [node]
+                    elif len(node_abs_url) == len(sel[0].get_absolute_url()):
+                        sel.append(node)
+                else:
+                    sel = [node]
+        for node in nodes:
+            node.selected = (node in sel)
+        return nodes
+
+    def apply_modifiers(self, nodes, namespace=None, root_id=None,
+            post_cut=False, breadcrumb=False):
+        if not post_cut:
+            nodes = self._mark_selected(nodes)
+
+        # Only fetch modifiers when they're needed.
+        # We can do this because unlike menu classes,
+        # modifiers can't change on a request basis.
+        for cls in self.pool.get_registered_modifiers():
+            inst = cls(manager=self)
+            nodes = inst.modify(
+                self.request, nodes, namespace, root_id, post_cut, breadcrumb)
+        return nodes
+
+    def get_nodes(self, namespace=None, root_id=None, site_id=None,
+            breadcrumb=False):
+        if not site_id:
+            site_id = Site.objects.get_current().pk
+        nodes = self._build_nodes(site_id)
+        nodes = copy.deepcopy(nodes)
+        nodes = self.apply_modifiers(
+            nodes=nodes,
+            namespace=namespace,
+            root_id=root_id,
+            post_cut=False,
+            breadcrumb=breadcrumb,
+        )
+        return nodes
+
+
 class MenuPool(object):
+
     def __init__(self):
         self.menus = {}
         self.modifiers = []
         self.discovered = False
-        self._expanded = False
+
+    def __call__(self, request):
+        self.discover_menus()
+        # Returns a menu pool wrapper that is bound
+        # to the given request and can perform
+        # operations based on the given request.
+        return MenuManager(pool=self, request=request)
 
     def discover_menus(self):
         if self.discovered:
@@ -94,57 +240,56 @@ class MenuPool(object):
         from menus.modifiers import register
         register()
         self.discovered = True
-        self._expanded = False
 
-    def _expand_menus(self):
+    def get_registered_menus(self, for_rendering=True):
         """
-        Expands the menu_pool by converting any found CMSAttachMenu entries to
-        one entry for each instance they are attached to. and instantiates menus
-        from the existing menu classes.
+        Returns all registered menu classes.
+
+        :param for_rendering: Flag that when True forces us to include
+            all CMSAttachMenu subclasses, even if they're not attached.
         """
-
-        # Ideally, this would have been done in discover_menus(), but the pages
-        # aren't loaded when that executes. This private method is used to
-        # perform the expansion and instantiate the menus classes into menu-
-        # instances just before any menus are built.
-
-        if self._expanded:
-            return
         expanded_menus = {}
+
         for menu_class_name, menu_cls in self.menus.items():
-            # In order to be eligible for "expansion", the menu_cls must, in
-            # fact, be an instantiable class. We are lenient about this here,
-            # though, because the CMS has previously allowed attaching
-            # CMSAttachMenu's as objects rather than classes.
             if isinstance(menu_cls, Menu):
-                # A Menu **instance** was registered, this is non-standard, but
-                # acceptable. However, it cannot be "expanded", so, just add it
-                # as-is to the list of expanded_menus.
+                # A Menu **instance** was registered,
+                # this is non-standard, but acceptable.
                 menu_cls = menu_cls.__class__
             if hasattr(menu_cls, "get_instances"):
-                # It quacks like a CMSAttachMenu, expand away!
-                # If a menu exists but has no instances,
-                # it's included in the available menus as is
-                instances = menu_cls.get_instances()
-                if not instances:
-                    expanded_menus[menu_class_name] = menu_cls()
-                else:
-                    for instance in instances:
-                        namespace = "{0}:{1}".format(
-                            menu_class_name, instance.pk)
-                        menu_inst = menu_cls()
-                        menu_inst.instance = instance
-                        expanded_menus[namespace] = menu_inst
+                # It quacks like a CMSAttachMenu.
+                # Expand the one CMSAttachMenu into multiple classes.
+                # Each class is bound to the instance the menu is attached to.
+                _get_menu_class = partial(_get_menu_class_for_instance, menu_cls)
+
+                instances = menu_cls.get_instances() or []
+                for instance in instances:
+                    # For each instance, we create a unique class
+                    # that is bound to that instance.
+                    # Doing this allows us to delay the instantiation
+                    # of the menu class until it's needed.
+                    # Plus we keep the menus consistent by always
+                    # pointing to a class instead of an instance.
+                    namespace = "{0}:{1}".format(
+                        menu_class_name, instance.pk)
+                    expanded_menus[namespace] = _get_menu_class(instance)
+
+                if not instances and not for_rendering:
+                    # The menu is a CMSAttachMenu but has no instances,
+                    # normally we'd just ignore it but it's been
+                    # explicitly set that we are not rendering these menus
+                    # via the (for_rendering) flag.
+                    expanded_menus[menu_class_name] = menu_cls
             elif hasattr(menu_cls, "get_nodes"):
                 # This is another type of Menu, cannot be expanded, but must be
                 # instantiated, none-the-less.
-                expanded_menus[menu_class_name] = menu_cls()
+                expanded_menus[menu_class_name] = menu_cls
             else:
                 raise ValidationError(
                     "Something was registered as a menu, but isn't.")
+        return expanded_menus
 
-        self._expanded = True
-        self.menus = expanded_menus
+    def get_registered_modifiers(self):
+        return self.modifiers
 
     def clear(self, site_id=None, language=None, all=False):
         '''
@@ -168,10 +313,7 @@ class MenuPool(object):
                           'please rename it to cms_menus.py', DeprecationWarning)
         from menus.base import Menu
         assert issubclass(menu_cls, Menu)
-        # If we should register a menu after we've already expanded the existing
-        # ones, we need to mark it as such.
-        self._expanded = False
-        if menu_cls.__name__ in self.menus.keys():
+        if menu_cls.__name__ in self.menus:
             raise NamespaceAlreadyRegistered(
                 "[{0}] a menu with this name is already registered".format(
                     menu_cls.__name__))
@@ -193,110 +335,6 @@ class MenuPool(object):
         if modifier_class not in self.modifiers:
             self.modifiers.append(modifier_class)
 
-    def _build_nodes(self, request, site_id):
-        """
-        This is slow. Caching must be used.
-        One menu is built per language and per site.
-
-        Namespaces: they are ID prefixes to avoid node ID clashes when plugging
-        multiple trees together.
-
-        - We iterate on the list of nodes.
-        - We store encountered nodes in a dict (with namespaces):
-            done_nodes[<namespace>][<node's id>] = node
-        - When a node has a parent defined, we lookup that parent in done_nodes
-            if it's found:
-                set the node as the node's parent's child (re-read this)
-            else:
-                the node is put at the bottom of the list
-        """
-        # Before we do anything, make sure that the menus are expanded.
-        self._expand_menus()
-        # Cache key management
-        lang = get_language()
-        prefix = getattr(settings, "CMS_CACHE_PREFIX", "menu_cache_")
-        key = "%smenu_nodes_%s_%s" % (prefix, lang, site_id)
-        if request.user.is_authenticated():
-            key += "_%s_user" % request.user.pk
-        cached_nodes = cache.get(key, None)
-        if cached_nodes:
-            return cached_nodes
-
-        final_nodes = []
-        for menu_class_name in self.menus:
-            menu = self.menus[menu_class_name]
-            try:
-                if isinstance(menu, type):
-                    menu = menu()
-                nodes = menu.get_nodes(request)
-            except NoReverseMatch:
-                # Apps might raise NoReverseMatch if an apphook does not yet
-                # exist, skip them instead of crashing
-                nodes = []
-                toolbar = getattr(request, 'toolbar', None)
-                if toolbar and toolbar.is_staff:
-                    messages.error(request,
-                        _('Menu %s cannot be loaded. Please, make sure all '
-                          'its urls exist and can be resolved.') %
-                        menu_class_name)
-                logger.error("Menu %s could not be loaded." %
-                    menu_class_name, exc_info=True)
-            # nodes is a list of navigation nodes (page tree in cms + others)
-            final_nodes += _build_nodes_inner_for_one_menu(
-                nodes, menu_class_name)
-
-        cache.set(key, final_nodes, get_cms_setting('CACHE_DURATIONS')['menus'])
-        # We need to have a list of the cache keys for languages and sites that
-        # span several processes - so we follow the Django way and share through
-        # the database. It's still cheaper than recomputing every time!
-        # This way we can selectively invalidate per-site and per-language,
-        # since the cache shared but the keys aren't
-        CacheKey.objects.get_or_create(key=key, language=lang, site=site_id)
-        return final_nodes
-
-    def apply_modifiers(self, nodes, request, namespace=None, root_id=None,
-            post_cut=False, breadcrumb=False):
-        if not post_cut:
-            nodes = self._mark_selected(request, nodes)
-        for cls in self.modifiers:
-            inst = cls()
-            nodes = inst.modify(
-                request, nodes, namespace, root_id, post_cut, breadcrumb)
-        return nodes
-
-    def get_nodes(self, request, namespace=None, root_id=None, site_id=None,
-            breadcrumb=False):
-        self.discover_menus()
-        if not site_id:
-            site_id = Site.objects.get_current().pk
-        nodes = self._build_nodes(request, site_id)
-        nodes = copy.deepcopy(nodes)
-        nodes = self.apply_modifiers(nodes, request, namespace, root_id,
-                                     post_cut=False, breadcrumb=breadcrumb)
-        return nodes
-
-    def _mark_selected(self, request, nodes):
-        # There /may/ be two nodes that get marked with selected. A published
-        # and a draft version of the node. We'll mark both, later, the unused
-        # one will be removed anyway.
-        sel = []
-        for node in nodes:
-            node.sibling = False
-            node.ancestor = False
-            node.descendant = False
-            node_abs_url = node.get_absolute_url()
-            if node_abs_url == request.path[:len(node_abs_url)]:
-                if sel:
-                    if len(node_abs_url) > len(sel[0].get_absolute_url()):
-                        sel = [node]
-                    elif len(node_abs_url) == len(sel[0].get_absolute_url()):
-                        sel.append(node)
-                else:
-                    sel = [node]
-        for node in nodes:
-            node.selected = (node in sel)
-        return nodes
-
     def get_menus_by_attribute(self, name, value):
         """
         Returns the list of menus that match the name/value criteria provided.
@@ -305,9 +343,13 @@ class MenuPool(object):
         # specific menu class. This is to address issue (#4041) which has
         # cropped-up in 3.0.13/3.0.0.
         self.discover_menus()
-        self._expand_menus()
+        # By setting for_rendering to False
+        # we're limiting the output to menus
+        # that are registered and have instances
+        # (in case of attached menus).
+        menus = self.get_registered_menus(for_rendering=False)
         return sorted(list(set([(menu.__class__.__name__, menu.name)
-                                for menu_class_name, menu in self.menus.items()
+                                for menu_class_name, menu in menus.items()
                                 if getattr(menu, name, None) == value])))
 
     def get_nodes_by_attribute(self, nodes, name, value):

--- a/menus/templatetags/menu_tags.py
+++ b/menus/templatetags/menu_tags.py
@@ -128,7 +128,11 @@ class ShowMenu(InclusionTag):
             children = next_page.children
         else:
             # new menu... get all the data so we can save a lot of queries
-            manager = menu_pool.get_manager(request)
+            manager = context.get('cms_menu_manager')
+
+            if not manager:
+                manager = menu_pool.get_manager(request)
+
             nodes = manager.get_nodes(namespace, root_id)
             if root_id:  # find the root id and cut the nodes
                 id_nodes = menu_pool.get_nodes_by_attribute(nodes, "reverse_id", root_id)
@@ -206,7 +210,12 @@ class ShowSubMenu(InclusionTag):
             request = context['request']
         except KeyError:
             return {'template': 'menu/empty.html'}
-        manager = menu_pool.get_manager(request)
+
+        manager = context.get('cms_menu_manager')
+
+        if not manager:
+            manager = menu_pool.get_manager(request)
+
         nodes = manager.get_nodes()
         children = []
         # adjust root_level so we cut before the specified level, not after
@@ -280,7 +289,11 @@ class ShowBreadcrumb(InclusionTag):
             only_visible = bool(only_visible)
         ancestors = []
 
-        manager = menu_pool.get_manager(request)
+        manager = context.get('cms_menu_manager')
+
+        if not manager:
+            manager = menu_pool.get_manager(request)
+
         nodes = manager.get_nodes(breadcrumb=True)
 
         # Find home

--- a/menus/templatetags/menu_tags.py
+++ b/menus/templatetags/menu_tags.py
@@ -128,7 +128,8 @@ class ShowMenu(InclusionTag):
             children = next_page.children
         else:
             # new menu... get all the data so we can save a lot of queries
-            nodes = menu_pool.get_nodes(request, namespace, root_id)
+            manager = menu_pool(request)
+            nodes = manager.get_nodes(namespace, root_id)
             if root_id:  # find the root id and cut the nodes
                 id_nodes = menu_pool.get_nodes_by_attribute(nodes, "reverse_id", root_id)
                 if id_nodes:
@@ -142,7 +143,7 @@ class ShowMenu(InclusionTag):
                 else:
                     nodes = []
             children = cut_levels(nodes, from_level, to_level, extra_inactive, extra_active)
-            children = menu_pool.apply_modifiers(children, request, namespace, root_id, post_cut=True)
+            children = manager.apply_modifiers(children, namespace, root_id, post_cut=True)
 
         try:
             context['children'] = children
@@ -205,6 +206,7 @@ class ShowSubMenu(InclusionTag):
             request = context['request']
         except KeyError:
             return {'template': 'menu/empty.html'}
+        manager = menu_pool(request)
         nodes = menu_pool.get_nodes(request)
         children = []
         # adjust root_level so we cut before the specified level, not after
@@ -231,9 +233,9 @@ class ShowSubMenu(InclusionTag):
                         # if root_level was 0 we need to give the menu the entire tree
                     # not just the children
                 if include_root:
-                    children = menu_pool.apply_modifiers([node], request, post_cut=True)
+                    children = manager.apply_modifiers([node], post_cut=True)
                 else:
-                    children = menu_pool.apply_modifiers(children, request, post_cut=True)
+                    children = manager.apply_modifiers(children, post_cut=True)
         context['children'] = children
         context['template'] = template
         context['from_level'] = 0
@@ -277,7 +279,9 @@ class ShowBreadcrumb(InclusionTag):
         except:
             only_visible = bool(only_visible)
         ancestors = []
-        nodes = menu_pool.get_nodes(request, breadcrumb=True)
+
+        manager = menu_pool(request)
+        nodes = manager.get_nodes(breadcrumb=True)
 
         # Find home
         home = None

--- a/menus/templatetags/menu_tags.py
+++ b/menus/templatetags/menu_tags.py
@@ -128,7 +128,7 @@ class ShowMenu(InclusionTag):
             children = next_page.children
         else:
             # new menu... get all the data so we can save a lot of queries
-            manager = menu_pool(request)
+            manager = menu_pool.get_manager(request)
             nodes = manager.get_nodes(namespace, root_id)
             if root_id:  # find the root id and cut the nodes
                 id_nodes = menu_pool.get_nodes_by_attribute(nodes, "reverse_id", root_id)
@@ -206,7 +206,7 @@ class ShowSubMenu(InclusionTag):
             request = context['request']
         except KeyError:
             return {'template': 'menu/empty.html'}
-        manager = menu_pool(request)
+        manager = menu_pool.get_manager(request)
         nodes = menu_pool.get_nodes(request)
         children = []
         # adjust root_level so we cut before the specified level, not after
@@ -280,7 +280,7 @@ class ShowBreadcrumb(InclusionTag):
             only_visible = bool(only_visible)
         ancestors = []
 
-        manager = menu_pool(request)
+        manager = menu_pool.get_manager(request)
         nodes = manager.get_nodes(breadcrumb=True)
 
         # Find home

--- a/menus/templatetags/menu_tags.py
+++ b/menus/templatetags/menu_tags.py
@@ -207,7 +207,7 @@ class ShowSubMenu(InclusionTag):
         except KeyError:
             return {'template': 'menu/empty.html'}
         manager = menu_pool.get_manager(request)
-        nodes = menu_pool.get_nodes(request)
+        nodes = manager.get_nodes()
         children = []
         # adjust root_level so we cut before the specified level, not after
         include_root = False


### PR DESCRIPTION
Fixes #5298

Basically because the menu logic was coupled with the rendering logic, there was an issue where all attached menu classes would be loaded on every request and all their nodes fetched, regardless of whether the menu class was attached or not. This was a regression and never a feature.

This pull request does a couple of things:

* Decouple the menu rendering logic from the menu discovery pool.
* Bind menu rendering to the request, so during a request the menu entries, modifiers, etc. are all constant.
* Expose a helper method on the menu pool to get all registered menu classes and allow specifying if it's for rendering or not. An example of this is on the admin we want to display all menu classes regardless of whether they are attached menus and have no instances, this is to allow the user to select the menu class but when rendering we **don't** want to load the menu classes that are not attached to an instance and are attached menu subclasses.

I introduced a new class called the ``MenuManager``.
This class is bound to a request and the menu pool instance.
The class exposes the familiar ``get_nodes()`` and ``apply_modifiers()`` methods.

The menu tags have been modified to first get the menu manager and then get the nodes using the manager, the idea is to **not** use the menu pool directly.

Both Menu and Modifier classes now require a ``manager`` instance on initialization.

The menu pool still defines ``get_nodes()`` and ``apply_modifiers()`` for backwards compatibility and will be deprecated in 3.4.

The ``menu_pool.menus`` attribute should **not** be used anymore, instead a new method has been introduced called ``get_registered_menus()``.

``get_registered_menus``
This method makes a query for each attached menu that is registered with the menu system.

Before this change, menus would fetch the instances of attached menus only once in a process and so this causes an issue where attached menus are set to pages but the menu pool would not know about it because it was expanded already.

Sadly moving this calculation to happen at the request/response cycle meant that we would have to make the attached menu queries on every request and once per menu tag!

So I made the menu_manager a context processor variable that only fetches the registered menus when an attribute of the manager is accessed (lazy) and it uses a meomized approach to only do it once, so this way we only get the registered menus literally once per request and only if needed.
If the cms settings context processor is not set then it makes a query per menu tag!

I adjusted the performance tests that would check the loading without context processors, as mentioned above the cms context processor is required and if not added then menu performance does decrease.

TODO:

- [x] Add just a few more tests
- [x] Add settings context processor to cms check
- [x] Add old ``get_nodes`` and ``apply_modifiers()`` to menu pool and deprecate them.


/cc @divio/django-cms-core 