### PR TITLE
rename MenuManager to MenuRenderer

### DIFF
--- a/cms/cms_menus.py
+++ b/cms/cms_menus.py
@@ -79,11 +79,11 @@ def get_visible_pages(request, pages, site=None):
     return [page.pk for page in pages]
 
 
-def page_to_node(manager, page, home, cut):
+def page_to_node(renderer, page, home, cut):
     """
     Transform a CMS page into a navigation node.
 
-    :param manager: MenuManager instance bound to the request
+    :param renderer: MenuRenderer instance bound to the request
     :param page: the page you wish to transform
     :param home: a reference to the "home" page (the page with path="0001")
     :param cut: Should we cut page from its parent pages? This means the node will not
@@ -117,9 +117,9 @@ def page_to_node(manager, page, home, cut):
     # Extenders can be either navigation extenders or from apphooks.
     extenders = []
     if page.navigation_extenders:
-        if page.navigation_extenders in manager.menus:
+        if page.navigation_extenders in renderer.menus:
             extenders.append(page.navigation_extenders)
-        elif "{0}:{1}".format(page.navigation_extenders, page.pk) in manager.menus:
+        elif "{0}:{1}".format(page.navigation_extenders, page.pk) in renderer.menus:
             extenders.append("{0}:{1}".format(page.navigation_extenders, page.pk))
     # Is this page an apphook? If so, we need to handle the apphooks's nodes
     lang = get_language()
@@ -218,11 +218,11 @@ class CMSMenu(Menu):
             page = ids[title.page_id]
             page.title_cache[title.language] = title
 
-        manager = self.manager
+        renderer = self.renderer
 
         for page in actual_pages:
             if page.title_cache:
-                nodes.append(page_to_node(manager, page, home, home_cut))
+                nodes.append(page_to_node(renderer, page, home, home_cut))
         return nodes
 
 
@@ -261,7 +261,7 @@ class NavExtender(Modifier):
         removed = []
 
         # find all not assigned nodes
-        for menu in self.manager.menus.items():
+        for menu in self.renderer.menus.items():
             if (hasattr(menu[1], 'cms_enabled')
                     and menu[1].cms_enabled and not menu[0] in exts):
                 for node in nodes:

--- a/cms/context_processors.py
+++ b/cms/context_processors.py
@@ -10,22 +10,22 @@ def cms_settings(request):
     """
     Adds cms-related variables to the context.
     """
-    from menus.menu_pool import MenuManager
+    from menus.menu_pool import MenuRenderer
 
     @lru_cache.lru_cache(maxsize=None)
-    def _get_menu_manager():
+    def _get_menu_renderer():
         # We use lru_cache to avoid getting the manager
         # every time this function is called.
         from menus.menu_pool import menu_pool
-        return menu_pool.get_manager(request)
+        return menu_pool.get_renderer(request)
 
-    # Now use lazy() to avoid getting the menu manager
+    # Now use lazy() to avoid getting the menu renderer
     # up until the point is needed.
     # lazy() does not memoize results, is why lru_cache is needed.
-    _get_menu_manager = lazy(_get_menu_manager, MenuManager)
+    _get_menu_renderer = lazy(_get_menu_renderer, MenuRenderer)
 
     return {
-        'cms_menu_manager': _get_menu_manager(),
+        'cms_menu_renderer': _get_menu_renderer(),
         'CMS_MEDIA_URL': get_cms_setting('MEDIA_URL'),
         'CMS_TEMPLATE': lambda: get_template_from_request(request),
     }

--- a/cms/tests/test_menu.py
+++ b/cms/tests/test_menu.py
@@ -38,8 +38,8 @@ class BaseMenuTest(CMSTestCase):
         nodes = [node1, node2, node3, node4, node5]
         tree = _build_nodes_inner_for_one_menu([n for n in nodes], "test")
         request = self.get_request(path)
-        manager = menu_pool.get_manager(request)
-        manager.apply_modifiers(tree, request)
+        renderer = menu_pool.get_renderer(request)
+        renderer.apply_modifiers(tree, request)
         return tree, nodes
 
     def setUp(self):
@@ -114,20 +114,20 @@ class MenuDiscoveryTest(ExtendedMenusFixture, CMSTestCase):
         self.assertEqual(len(registered), 5)
         self.assertEqual(len(registered_for_rendering), 5)
 
-    def test_menu_registered_in_manager(self):
+    def test_menu_registered_in_renderer(self):
         menu_pool.discovered = False
         menu_pool.discover_menus()
 
-        # The following tests that a menu manager calculates the registered
+        # The following tests that a menu renderer calculates the registered
         # menus on a request basis.
 
         request_1 = self.get_request('/en/')
-        request_1_manager = menu_pool.get_manager(request_1)
+        request_1_renderer = menu_pool.get_renderer(request_1)
 
         registered = menu_pool.get_registered_menus(for_rendering=False)
 
         self.assertEqual(len(registered), 3)
-        self.assertEqual(len(request_1_manager.menus), 1)
+        self.assertEqual(len(request_1_renderer.menus), 1)
 
         create_page("apphooked-page", "nav_playground.html", "en",
                     published=True,
@@ -138,10 +138,10 @@ class MenuDiscoveryTest(ExtendedMenusFixture, CMSTestCase):
                     navigation_extenders='StaticMenu2')
 
         request_2 = self.get_request('/en/')
-        request_2_manager = menu_pool.get_manager(request_2)
+        request_2_renderer = menu_pool.get_renderer(request_2)
 
         # The count should be 3 but grows to 5 because of the two published instances.
-        self.assertEqual(len(request_2_manager.menus), 5)
+        self.assertEqual(len(request_2_renderer.menus), 5)
 
     def test_menu_expanded(self):
         menu_pool.discovered = False
@@ -287,10 +287,10 @@ class FixturesMenuTests(MenusFixture, BaseMenuTest):
         self.assertEqual(response.status_code, 200)
         request = self.get_request()
 
-        manager = menu_pool.get_manager(request)
+        renderer = menu_pool.get_renderer(request)
 
         # test the cms menu class
-        menu = manager.get_menu('CMSMenu')
+        menu = renderer.get_menu('CMSMenu')
         nodes = menu.get_nodes(request)
         self.assertEqual(len(nodes), len(self.get_all_pages()))
 

--- a/cms/tests/test_menu_page_viewperm.py
+++ b/cms/tests/test_menu_page_viewperm.py
@@ -190,8 +190,8 @@ class ViewPermissionTests(CMSTestCase):
 
     def assertInMenu(self, page, user):
         request = self.get_request(user, page)
-        manager = menu_pool.get_manager(request)
-        nodes = manager.get_nodes()
+        menu_renderer = menu_pool.get_renderer(request)
+        nodes = menu_renderer.get_nodes()
         target_url = page.get_absolute_url()
         found_in_menu = False
         for node in nodes:
@@ -202,8 +202,8 @@ class ViewPermissionTests(CMSTestCase):
 
     def assertNotInMenu(self, page, user):
         request = self.get_request(user, page)
-        manager = menu_pool.get_manager(request)
-        nodes = manager.get_nodes()
+        menu_renderer = menu_pool.get_renderer(request)
+        nodes = menu_renderer.get_nodes()
         target_url = page.get_absolute_url()
         found_in_menu = False
         for node in nodes:
@@ -288,8 +288,8 @@ class ViewPermissionComplexMenuAllNodesTests(ViewPermissionTests):
         request = self.get_request()
         visible_page_ids = get_visible_pages(request, all_pages, self.site)
         self.assertEqual(len(all_pages), len(visible_page_ids))
-        manager = menu_pool.get_manager(request)
-        nodes = manager.get_nodes()
+        menu_renderer = menu_pool.get_renderer(request)
+        nodes = menu_renderer.get_nodes()
         self.assertEqual(len(nodes), len(all_pages))
 
     def test_public_menu_anonymous_user(self):
@@ -313,8 +313,8 @@ class ViewPermissionComplexMenuAllNodesTests(ViewPermissionTests):
         urls = self.get_url_dict(all_pages)
         user = AnonymousUser()
         request = self.get_request(user, urls['/en/'])
-        manager = menu_pool.get_manager(request)
-        nodes = manager.get_nodes()
+        menu_renderer = menu_pool.get_renderer(request)
+        nodes = menu_renderer.get_nodes()
         self.assertEqual(len(nodes), 4)
         self.assertInMenu(urls["/en/"], user)
         self.assertInMenu(urls["/en/page_c/"], user)

--- a/cms/tests/test_multilingual.py
+++ b/cms/tests/test_multilingual.py
@@ -162,13 +162,13 @@ class MultilingualTestCase(CMSTestCase):
         request_1 = self.get_request('/%s/' % TESTLANG, TESTLANG)
         request_2 = self.get_request('/%s/' % TESTLANG2, TESTLANG2)
 
-        request_1_menu_manager = menu_pool.get_manager(request_1)
-        request_2_menu_manager = menu_pool.get_manager(request_2)
+        request_1_menu_renderer = menu_pool.get_renderer(request_1)
+        request_2_menu_renderer = menu_pool.get_renderer(request_2)
 
         lang_settings[1][1]['hide_untranslated'] = False
         with self.settings(CMS_LANGUAGES=lang_settings):
-            request_1_nodes = request_1_menu_manager.get_menu('CMSMenu').get_nodes(request_1)
-            request_2_nodes = request_2_menu_manager.get_menu('CMSMenu').get_nodes(request_2)
+            request_1_nodes = request_1_menu_renderer.get_menu('CMSMenu').get_nodes(request_1)
+            request_2_nodes = request_2_menu_renderer.get_menu('CMSMenu').get_nodes(request_2)
             list_1 = [node.id for node in request_1_nodes]
             list_2 = [node.id for node in request_2_nodes]
             self.assertEqual(list_1, list_2)
@@ -176,8 +176,8 @@ class MultilingualTestCase(CMSTestCase):
 
         lang_settings[1][1]['hide_untranslated'] = True
         with self.settings(CMS_LANGUAGES=lang_settings):
-            request_1_nodes = request_1_menu_manager.get_menu('CMSMenu').get_nodes(request_1)
-            request_2_nodes = request_2_menu_manager.get_menu('CMSMenu').get_nodes(request_2)
+            request_1_nodes = request_1_menu_renderer.get_menu('CMSMenu').get_nodes(request_1)
+            request_2_nodes = request_2_menu_renderer.get_menu('CMSMenu').get_nodes(request_2)
             list_1 = [node.id for node in request_1_nodes]
             list_2 = [node.id for node in request_2_nodes]
             self.assertNotEqual(list_1, list_2)

--- a/menus/base.py
+++ b/menus/base.py
@@ -5,8 +5,8 @@ from django.utils.encoding import smart_str
 class Menu(object):
     namespace = None
 
-    def __init__(self, manager):
-        self.manager = manager
+    def __init__(self, renderer):
+        self.renderer = renderer
 
         if not self.namespace:
             self.namespace = self.__class__.__name__
@@ -20,8 +20,8 @@ class Menu(object):
 
 class Modifier(object):
 
-    def __init__(self, manager):
-        self.manager = manager
+    def __init__(self, renderer):
+        self.renderer = renderer
 
     def modify(self, request, nodes, namespace, root_id, post_cut, breadcrumb):
         pass

--- a/menus/menu_pool.py
+++ b/menus/menu_pool.py
@@ -91,7 +91,7 @@ def _get_menu_class_for_instance(menu_class, instance):
     return meta_class(class_name, (menu_class,), attrs)
 
 
-class MenuManager(object):
+class MenuRenderer(object):
     # The main logic behind this class is to decouple
     # the singleton menu pool from the menu rendering logic.
     # By doing this we can be sure that each request has it's
@@ -100,7 +100,7 @@ class MenuManager(object):
     def __init__(self, pool, request):
         self.pool = pool
         # It's important this happens on init
-        # because we need to make sure that a menu manager
+        # because we need to make sure that a menu renderer
         # points to the same registered menus as long as the
         # instance lives.
         self.menus = pool.get_registered_menus(for_rendering=True)
@@ -196,7 +196,7 @@ class MenuManager(object):
         # We can do this because unlike menu classes,
         # modifiers can't change on a request basis.
         for cls in self.pool.get_registered_modifiers():
-            inst = cls(manager=self)
+            inst = cls(renderer=self)
             nodes = inst.modify(
                 self.request, nodes, namespace, root_id, post_cut, breadcrumb)
         return nodes
@@ -217,7 +217,7 @@ class MenuManager(object):
 
     def get_menu(self, menu_name):
         MenuClass = self.menus[menu_name]
-        return MenuClass(manager=self)
+        return MenuClass(renderer=self)
 
 
 class MenuPool(object):
@@ -227,12 +227,12 @@ class MenuPool(object):
         self.modifiers = []
         self.discovered = False
 
-    def get_manager(self, request):
+    def get_renderer(self, request):
         self.discover_menus()
         # Returns a menu pool wrapper that is bound
         # to the given request and can perform
         # operations based on the given request.
-        return MenuManager(pool=self, request=request)
+        return MenuRenderer(pool=self, request=request)
 
     def discover_menus(self):
         if self.discovered:
@@ -361,9 +361,9 @@ class MenuPool(object):
             post_cut=False, breadcrumb=False):
         warnings.warn('menu_pool.apply_modifiers is deprecated '
                       'and it will be removed in version 3.4; '
-                      'please use the menu manager instead.', DeprecationWarning)
-        manager = self.get_manager(request)
-        nodes = manager.apply_modifiers(
+                      'please use the menu renderer instead.', DeprecationWarning)
+        renderer = self.get_renderer(request)
+        nodes = renderer.apply_modifiers(
             nodes=nodes,
             namespace=namespace,
             root_id=root_id,
@@ -376,9 +376,9 @@ class MenuPool(object):
                   breadcrumb=False):
         warnings.warn('menu_pool.get_nodes is deprecated '
                       'and it will be removed in version 3.4; '
-                      'please use the menu manager instead.', DeprecationWarning)
-        manager = self.get_manager(request)
-        nodes = manager.get_nodes(
+                      'please use the menu renderer instead.', DeprecationWarning)
+        renderer = self.get_renderer(request)
+        nodes = renderer.get_nodes(
             namespace=namespace,
             root_id=root_id,
             site_id=site_id,

--- a/menus/templatetags/menu_tags.py
+++ b/menus/templatetags/menu_tags.py
@@ -128,12 +128,12 @@ class ShowMenu(InclusionTag):
             children = next_page.children
         else:
             # new menu... get all the data so we can save a lot of queries
-            manager = context.get('cms_menu_manager')
+            menu_renderer = context.get('cms_menu_renderer')
 
-            if not manager:
-                manager = menu_pool.get_manager(request)
+            if not menu_renderer:
+                menu_renderer = menu_pool.get_renderer(request)
 
-            nodes = manager.get_nodes(namespace, root_id)
+            nodes = menu_renderer.get_nodes(namespace, root_id)
             if root_id:  # find the root id and cut the nodes
                 id_nodes = menu_pool.get_nodes_by_attribute(nodes, "reverse_id", root_id)
                 if id_nodes:
@@ -147,7 +147,7 @@ class ShowMenu(InclusionTag):
                 else:
                     nodes = []
             children = cut_levels(nodes, from_level, to_level, extra_inactive, extra_active)
-            children = manager.apply_modifiers(children, namespace, root_id, post_cut=True)
+            children = menu_renderer.apply_modifiers(children, namespace, root_id, post_cut=True)
 
         try:
             context['children'] = children
@@ -211,12 +211,12 @@ class ShowSubMenu(InclusionTag):
         except KeyError:
             return {'template': 'menu/empty.html'}
 
-        manager = context.get('cms_menu_manager')
+        menu_renderer = context.get('cms_menu_renderer')
 
-        if not manager:
-            manager = menu_pool.get_manager(request)
+        if not menu_renderer:
+            menu_renderer = menu_pool.get_renderer(request)
 
-        nodes = manager.get_nodes()
+        nodes = menu_renderer.get_nodes()
         children = []
         # adjust root_level so we cut before the specified level, not after
         include_root = False
@@ -242,9 +242,9 @@ class ShowSubMenu(InclusionTag):
                         # if root_level was 0 we need to give the menu the entire tree
                     # not just the children
                 if include_root:
-                    children = manager.apply_modifiers([node], post_cut=True)
+                    children = menu_renderer.apply_modifiers([node], post_cut=True)
                 else:
-                    children = manager.apply_modifiers(children, post_cut=True)
+                    children = menu_renderer.apply_modifiers(children, post_cut=True)
         context['children'] = children
         context['template'] = template
         context['from_level'] = 0
@@ -289,12 +289,12 @@ class ShowBreadcrumb(InclusionTag):
             only_visible = bool(only_visible)
         ancestors = []
 
-        manager = context.get('cms_menu_manager')
+        menu_renderer = context.get('cms_menu_renderer')
 
-        if not manager:
-            manager = menu_pool.get_manager(request)
+        if not menu_renderer:
+            menu_renderer = menu_pool.get_renderer(request)
 
-        nodes = manager.get_nodes(breadcrumb=True)
+        nodes = menu_renderer.get_nodes(breadcrumb=True)
 
         # Find home
         home = None


### PR DESCRIPTION
A change will come in the future to integrate renderers into the cms.
This is a step towards having a similar "api".
The menu renderer is the first of these renderers.

Note, this is not a feature, just renaming.