### PR TITLE
fixes regression in command options

### DIFF
--- a/cms/management/commands/cms.py
+++ b/cms/management/commands/cms.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 from collections import OrderedDict
 
+import cms
+
 from .subcommands.base import SubcommandsCommand
 from .subcommands.check import CheckInstallation
 from .subcommands.list import ListCommand
@@ -29,3 +31,10 @@ class Command(SubcommandsCommand):
     missing_args_message = 'one of the available sub commands must be provided'
 
     subcommand_dest = 'cmd'
+
+    def get_version(self):
+        return cms.__version__
+
+    def add_arguments(self, parser):
+        parser.add_argument('--version', action='version', version=self.get_version())
+        super(Command, self).add_arguments(parser)

--- a/cms/management/commands/subcommands/base.py
+++ b/cms/management/commands/subcommands/base.py
@@ -1,10 +1,40 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, print_function, unicode_literals
+import os
 
 from collections import OrderedDict
 
-from django.core.management.base import BaseCommand, OutputWrapper
+from django.core.management.base import BaseCommand, CommandParser, OutputWrapper
 from django.core.management.color import no_style
+
+
+def add_builtin_arguments(parser):
+    parser.add_argument(
+        '--noinput',
+        action='store_false',
+        dest='interactive',
+        default=True,
+        help='Tells Django CMS to NOT prompt the user for input of any kind.'
+    )
+
+    # These are taking "as-is" from Django's management base
+    # management command.
+    parser.add_argument('-v', '--verbosity', action='store', dest='verbosity', default='1',
+        type=int, choices=[0, 1, 2, 3],
+        help='Verbosity level; 0=minimal output, 1=normal output, 2=verbose output, 3=very verbose output')
+    parser.add_argument('--settings',
+        help=(
+            'The Python path to a settings module, e.g. '
+            '"myproject.settings.main". If this isn\'t provided, the '
+            'DJANGO_SETTINGS_MODULE environment variable will be used.'
+        ),
+    )
+    parser.add_argument('--pythonpath',
+        help='A directory to add to the Python path, e.g. "/home/djangoprojects/myproject".')
+    parser.add_argument('--traceback', action='store_true',
+        help='Raise on CommandError exceptions')
+    parser.add_argument('--no-color', action='store_true', dest='no_color', default=False,
+        help="Don't colorize the command output.")
 
 
 class SubcommandsCommand(BaseCommand):
@@ -17,8 +47,18 @@ class SubcommandsCommand(BaseCommand):
 
     subcommand_dest = 'subcmd'
 
+    def create_parser(self, prog_name, subcommand):
+        parser = CommandParser(
+            self,
+            prog="%s %s" % (os.path.basename(prog_name), subcommand),
+            description=self.help or None
+        )
+        self.add_arguments(parser)
+        return parser
+
     def add_arguments(self, parser):
         self.instances = {}
+
         if self.subcommands:
             subparsers = parser.add_subparsers(dest=self.subcommand_dest)
             for command, cls in self.subcommands.items():
@@ -28,9 +68,10 @@ class SubcommandsCommand(BaseCommand):
                     cmd=self, name=instance.command_name, help=instance.help_string,
                     description=instance.help_string
                 )
+
+                add_builtin_arguments(parser=parser_sub)
                 instance.add_arguments(parser_sub)
                 self.instances[command] = instance
-            super(SubcommandsCommand, self).add_arguments(parser)
 
     def handle(self, *args, **options):
         if options[self.subcommand_dest] in self.instances:


### PR DESCRIPTION
Fixes #5326 
* Fixes regression where built in Django options like ``--settings`` would not work unless applied to the first cms command. So ``./manage.py cms check --settings=settings`` would throw an error vs ``./manage.py cms --settings=settings check``.
* Leverage Django's ``get_version()`` to allow users to do ``./manage.py cms --version``
* Add the --noinput option again.