### PR TITLE
fixes #4599

### DIFF
--- a/cms/tests/test_apphooks.py
+++ b/cms/tests/test_apphooks.py
@@ -529,6 +529,28 @@ class ApphooksTestCase(CMSTestCase):
         self.assertIsNotNone(TestApp2)
 
     @override_settings(ROOT_URLCONF='cms.test_utils.project.second_urls_for_apphook_tests')
+    def test_apphook_csrf_exempt_endpoint(self):
+        self.create_base_structure(NS_APP_NAME, 'en', 'instance_ns')
+
+        client = self.client_class(enforce_csrf_checks=True)
+
+        with force_language("en"):
+            path = reverse('namespaced_app_ns:sample-exempt')
+
+        response = client.post(path)
+
+        # Assert our POST request went through
+        self.assertEqual(response.status_code, 200)
+
+        with force_language("en"):
+            path = reverse('namespaced_app_ns:sample-account')
+
+        response = client.post(path)
+
+        # Assert our POST request did not go through
+        self.assertEqual(response.status_code, 403)
+
+    @override_settings(ROOT_URLCONF='cms.test_utils.project.second_urls_for_apphook_tests')
     def test_toolbar_current_app_namespace(self):
         self.create_base_structure(NS_APP_NAME, 'en', 'instance_ns')
         with force_language("en"):

--- a/cms/utils/decorators.py
+++ b/cms/utils/decorators.py
@@ -21,4 +21,9 @@ def cms_perms(func):
         inner.__name__ = func.__name__
     elif hasattr(func, '__class__'):
         inner.__name__ = func.__class__.__name__
+
+    if getattr(func, 'csrf_exempt', False):
+        # view has set csrf_exempt flag
+        # so pass it down to the decorator.
+        inner.csrf_exempt = True
     return inner


### PR DESCRIPTION
Allow apphook endpoints to disable csrf checks
Fixes #4599