### PR TITLE
feature/improve plugin related names

### DIFF
--- a/cms/models/aliaspluginmodel.py
+++ b/cms/models/aliaspluginmodel.py
@@ -7,6 +7,7 @@ from cms.models import CMSPlugin, Placeholder
 
 @python_2_unicode_compatible
 class AliasPluginModel(CMSPlugin):
+    cmsplugin_ptr = models.OneToOneField(CMSPlugin, related_name='cms_aliasplugin', parent_link=True)
     plugin = models.ForeignKey(CMSPlugin, editable=False, related_name="alias_reference", null=True)
     alias_placeholder = models.ForeignKey(Placeholder, editable=False, related_name="alias_placeholder", null=True)
 

--- a/cms/models/managers.py
+++ b/cms/models/managers.py
@@ -75,10 +75,7 @@ class PageManager(PublisherManager):
                 continue
             field = cmsplugin.cmsplugin_ptr.field
             related_query_name = field.related_query_name()
-            if (
-                related_query_name and
-                related_query_name != '+'
-            ):
+            if related_query_name and not related_query_name.startswith('+'):
                 for field in cmsplugin.search_fields:
                     qp |= Q(**{
                         'placeholders__cmsplugin__{0}__{1}__icontains'.format(

--- a/cms/models/placeholderpluginmodel.py
+++ b/cms/models/placeholderpluginmodel.py
@@ -8,9 +8,9 @@ from django.utils.encoding import python_2_unicode_compatible
 
 @python_2_unicode_compatible
 class PlaceholderReference(CMSPlugin):
+    cmsplugin_ptr = models.OneToOneField(CMSPlugin, related_name='cms_placeholderreference', parent_link=True)
     name = models.CharField(max_length=255)
     placeholder_ref = PlaceholderField(slotname='clipboard')
-
     class Meta:
         app_label = 'cms'
 

--- a/cms/models/pluginmodel.py
+++ b/cms/models/pluginmodel.py
@@ -70,7 +70,7 @@ class ForwardOneToOneDescriptor(ForwardManyToOneDescriptor):
         deferred = instance.get_deferred_fields()
         # Because it's a parent link, all the data is available in the
         # instance, so populate the parent model with this data.
-        rel_model = self.field.remote_field.model
+        rel_model = self.field.rel.model
         fields = [field.attname for field in rel_model._meta.concrete_fields]
 
         # If any of the related model's fields are deferred, fallback to
@@ -99,6 +99,7 @@ class ForwardOneToOneDescriptor(ForwardManyToOneDescriptor):
                 rel_obj = self.get_inherited_object(instance)
 
                 if not rel_obj is None:
+                    # Populate the internal relationship cache.
                     setattr(instance, self.cache_name, rel_obj)
         return super(ForwardOneToOneDescriptor, self).__get__(instance, instance_type)
 

--- a/cms/models/pluginmodel.py
+++ b/cms/models/pluginmodel.py
@@ -121,7 +121,7 @@ class PluginModelBase(ModelBase):
         if not new_class._meta.abstract and not new_class._meta.proxy:
             # True if cmsplugin_ptr was explicitly defined
             # when subclassing CMSPlugin
-            explicit_rel = 'cmsplugin_ptr' not in attrs
+            explicit_rel = 'cmsplugin_ptr' in attrs
 
             for field in new_class._meta.fields:
                 if field.name != 'cmsplugin_ptr':

--- a/cms/models/pluginmodel.py
+++ b/cms/models/pluginmodel.py
@@ -123,7 +123,6 @@ class PluginModelBase(ModelBase):
             # The current class subclasses from CMSPlugin
             # and has not defined a cmsplugin_ptr field.
             meta = attrs.get('Meta', None)
-            abstract = getattr(meta, 'abstract', False)
             proxy = getattr(meta, 'proxy', False)
 
             # True if any of the base classes defines a cmsplugin_ptr field.

--- a/cms/models/pluginmodel.py
+++ b/cms/models/pluginmodel.py
@@ -129,8 +129,14 @@ class PluginModelBase(ModelBase):
             # True if any of the base classes defines a cmsplugin_ptr field.
             field_is_inherited = any(hasattr(parent, 'cmsplugin_ptr') for parent in parents)
 
-            # Skip abstract and proxied classes which are not autonomous ORM objects
-            if not abstract and not proxy and not field_is_inherited:
+            # Skip proxied classes which are not autonomous ORM objects
+            # We don't skip abstract classes because when a plugin
+            # inherits from an abstract class, we need to make sure the
+            # abstract class gets the correct related name, otherwise the
+            # plugin inherits the default related name and then the
+            # field_is_inherited check above will prevent us from adding
+            # the fixed related name.
+            if not proxy and not field_is_inherited:
                 # It's important to set the field as if it was set
                 # manually in the model class.
                 # This is because Django will do a lot of operations

--- a/cms/test_utils/project/mti_pluginapp/migrations/0003_auto_20160409_0838.py
+++ b/cms/test_utils/project/mti_pluginapp/migrations/0003_auto_20160409_0838.py
@@ -67,11 +67,13 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='MixedPlugin',
             fields=[
+                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, auto_created=True, to='cms.CMSPlugin')),
+                ('abs', models.CharField(default=b'test plugin abs', max_length=32, verbose_name=b'abs')),
                 ('mixed', models.CharField(default=b'test plugin mixed', max_length=32, verbose_name=b'mixed')),
             ],
             options={
                 'abstract': False,
             },
-            bases=('mti_pluginapp.nonpluginmodel', 'mti_pluginapp.testplugingammamodel'),
+            bases=('cms.cmsplugin', 'mti_pluginapp.nonpluginmodel'),
         ),
     ]

--- a/cms/test_utils/project/mti_pluginapp/migrations/0003_auto_20160409_0838.py
+++ b/cms/test_utils/project/mti_pluginapp/migrations/0003_auto_20160409_0838.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('cms', '0015_auto_20160409_0838'),
+        ('mti_pluginapp', '0002_auto_20150112_2250'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='NonPluginModel',
+            fields=[
+                ('other_id', models.AutoField(serialize=False, primary_key=True)),
+                ('non_plugin', models.CharField(default=b'test non plugin', max_length=32, verbose_name=b'non plugin')),
+            ],
+        ),
+        migrations.CreateModel(
+            name='TestPluginGammaModel',
+            fields=[
+                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, related_name=b'mti_pluginapp_testplugingammamodel', auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin')),
+                ('abs', models.CharField(default=b'test plugin abs', max_length=32, verbose_name=b'abs')),
+                ('gamma', models.CharField(default=b'test plugin gamma', max_length=32, verbose_name=b'gamma')),
+            ],
+            options={
+                'abstract': False,
+            },
+            bases=('cms.cmsplugin',),
+        ),
+        migrations.CreateModel(
+            name='ProxiedAlphaPluginModel',
+            fields=[
+            ],
+            options={
+                'proxy': True,
+            },
+            bases=('mti_pluginapp.testpluginalphamodel',),
+        ),
+        migrations.CreateModel(
+            name='ProxiedBetaPluginModel',
+            fields=[
+            ],
+            options={
+                'proxy': True,
+            },
+            bases=('mti_pluginapp.testpluginbetamodel',),
+        ),
+        migrations.AlterField(
+            model_name='testpluginalphamodel',
+            name='cmsplugin_ptr',
+            field=models.OneToOneField(parent_link=True, related_name='mti_pluginapp_testpluginalphamodel', auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin'),
+        ),
+        migrations.CreateModel(
+            name='LessMixedPlugin',
+            fields=[
+                ('less_mixed', models.CharField(default=b'test plugin mixed', max_length=32, verbose_name=b'mixed')),
+            ],
+            options={
+                'abstract': False,
+            },
+            bases=('mti_pluginapp.nonpluginmodel', 'cms.cmsplugin'),
+        ),
+        migrations.CreateModel(
+            name='MixedPlugin',
+            fields=[
+                ('mixed', models.CharField(default=b'test plugin mixed', max_length=32, verbose_name=b'mixed')),
+            ],
+            options={
+                'abstract': False,
+            },
+            bases=('mti_pluginapp.nonpluginmodel', 'mti_pluginapp.testplugingammamodel'),
+        ),
+    ]

--- a/cms/test_utils/project/mti_pluginapp/models.py
+++ b/cms/test_utils/project/mti_pluginapp/models.py
@@ -80,9 +80,9 @@ class NonPluginModel(models.Model):
     non_plugin = models.CharField('non plugin', blank=False, default='test non plugin', max_length=32)
 
 
-class MixedPlugin(NonPluginModel, TestPluginGammaModel):
+class MixedPlugin(AbstractPluginParent, NonPluginModel):
     """
-    Plugin which inherits from two concrete models, one of which is a plugin
+    Plugin which inherits from one abstract and one concrete model
     """
     mixed = models.CharField('mixed', blank=False, default='test plugin mixed', max_length=32)
 

--- a/cms/test_utils/project/mti_pluginapp/models.py
+++ b/cms/test_utils/project/mti_pluginapp/models.py
@@ -5,7 +5,11 @@ from django.db import models
 from cms.models import CMSPlugin
 
 
-class TestPluginAlphaModel(CMSPlugin):
+class SomeParent(object):
+    pass
+
+
+class TestPluginAlphaModel(SomeParent, CMSPlugin):
     """
     Nothing interesting here, move along.
     """
@@ -27,9 +31,64 @@ class TestPluginAlphaModel(CMSPlugin):
         return '/admin/custom/copy/'
 
 
+class ProxiedAlphaPluginModel(TestPluginAlphaModel):
+    """
+    This is a proxied model
+    """
+    class Meta:
+        proxy = True
+
+
 class TestPluginBetaModel(TestPluginAlphaModel):
     """
     NOTE: This is the subject of our test. A plugin which inherits from
     another concrete plugin via MTI or Multi-Table Inheritence.
     """
     beta = models.CharField('name', blank=False, default='test plugin beta', max_length=32)
+
+
+class ProxiedBetaPluginModel(TestPluginBetaModel):
+    """
+    This is a proxied model
+    """
+    class Meta:
+        proxy = True
+
+
+class AbstractPluginParent(CMSPlugin):
+    """
+    Abstract class
+    """
+    abs = models.CharField('abs', blank=False, default='test plugin abs', max_length=32)
+
+    class Meta:
+        abstract = True
+
+
+class TestPluginGammaModel(AbstractPluginParent):
+    """
+    Concrete class of an abstract parent
+    """
+    gamma = models.CharField('gamma', blank=False, default='test plugin gamma', max_length=32)
+
+
+class NonPluginModel(models.Model):
+    """
+    Non plugin base class
+    """
+    other_id = models.AutoField(primary_key=True)
+    non_plugin = models.CharField('non plugin', blank=False, default='test non plugin', max_length=32)
+
+
+class MixedPlugin(NonPluginModel, TestPluginGammaModel):
+    """
+    Plugin which inherits from two concrete models, one of which is a plugin
+    """
+    mixed = models.CharField('mixed', blank=False, default='test plugin mixed', max_length=32)
+
+
+class LessMixedPlugin(NonPluginModel, CMSPlugin):
+    """
+    Plugin which inherits from two concrete models, one of which is CMSPlugin
+    """
+    less_mixed = models.CharField('mixed', blank=False, default='test plugin mixed', max_length=32)

--- a/cms/tests/test_plugins.py
+++ b/cms/tests/test_plugins.py
@@ -1797,15 +1797,17 @@ class MTIPluginsTestCase(PluginsTestBaseCase):
                          'mti_pluginapp_testpluginalphamodel')
         self.assertEqual(ProxiedBetaPluginModel.cmsplugin_ptr.field.rel.related_name,
                          'mti_pluginapp_testpluginalphamodel')
-        # Abstract plugins are skipped bc
-        self.assertIsNone(AbstractPluginParent.cmsplugin_ptr.field.rel.related_name)
+        # Abstract plugins will have the dynamic format for related name
+        self.assertEqual(
+            AbstractPluginParent.cmsplugin_ptr.field.rel.related_name,
+            '%(app_label)s_%(class)s'
+        )
         # Concrete plugin of an abstract plugin gets its relatedname
         self.assertEqual(TestPluginGammaModel.cmsplugin_ptr.field.rel.related_name,
                          'mti_pluginapp_testplugingammamodel')
-        # Child plugin -even if mixed with other models- keeps the same related name
-        # as its parent plugin
+        # Child plugin gets it's own related name
         self.assertEqual(MixedPlugin.cmsplugin_ptr.field.rel.related_name,
-                         'mti_pluginapp_testplugingammamodel')
+                         'mti_pluginapp_mixedplugin')
         # If the child plugin inherit straight from CMSPlugin, even if composed with
         # other models, gets its own related_name
         self.assertEqual(LessMixedPlugin.cmsplugin_ptr.field.rel.related_name,

--- a/cms/tests/test_plugins.py
+++ b/cms/tests/test_plugins.py
@@ -1781,3 +1781,34 @@ class MTIPluginsTestCase(PluginsTestBaseCase):
         plugin_model = TestPluginBetaModel.objects.all()[0]
         self.assertEqual("ALPHA", plugin_model.alpha)
         self.assertEqual("BETA", plugin_model.beta)
+
+    def test_related_name(self):
+        from cms.test_utils.project.mti_pluginapp.models import (
+            TestPluginAlphaModel, TestPluginBetaModel, ProxiedAlphaPluginModel,
+            ProxiedBetaPluginModel, AbstractPluginParent, TestPluginGammaModel, MixedPlugin,
+            LessMixedPlugin, NonPluginModel
+        )
+        # the first concrete class of the following four plugins is TestPluginAlphaModel
+        self.assertEqual(TestPluginAlphaModel.cmsplugin_ptr.field.rel.related_name,
+                         'mti_pluginapp_testpluginalphamodel')
+        self.assertEqual(TestPluginBetaModel.cmsplugin_ptr.field.rel.related_name,
+                         'mti_pluginapp_testpluginalphamodel')
+        self.assertEqual(ProxiedAlphaPluginModel.cmsplugin_ptr.field.rel.related_name,
+                         'mti_pluginapp_testpluginalphamodel')
+        self.assertEqual(ProxiedBetaPluginModel.cmsplugin_ptr.field.rel.related_name,
+                         'mti_pluginapp_testpluginalphamodel')
+        # Abstract plugins are skipped bc
+        self.assertIsNone(AbstractPluginParent.cmsplugin_ptr.field.rel.related_name)
+        # Concrete plugin of an abstract plugin gets its relatedname
+        self.assertEqual(TestPluginGammaModel.cmsplugin_ptr.field.rel.related_name,
+                         'mti_pluginapp_testplugingammamodel')
+        # Child plugin -even if mixed with other models- keeps the same related name
+        # as its parent plugin
+        self.assertEqual(MixedPlugin.cmsplugin_ptr.field.rel.related_name,
+                         'mti_pluginapp_testplugingammamodel')
+        # If the child plugin inherit straight from CMSPlugin, even if composed with
+        # other models, gets its own related_name
+        self.assertEqual(LessMixedPlugin.cmsplugin_ptr.field.rel.related_name,
+                         'mti_pluginapp_lessmixedplugin')
+        # Non plugins are skipped
+        self.assertFalse(hasattr(NonPluginModel, 'cmsplugin_ptr'))


### PR DESCRIPTION
> This is the continuing saga of Django 1.9 vs. cmsplugin_ptr. The changes in this PR were initially contributed by @yakky's #5032. - @mkoistinen 

This PR introduces two fixes:

* Use Django's dynamic related_name to avoid field name clashes.
* Backport a performance fix from Django that would cause one query per plugin being deleted.