### PR TITLE
corrupted context in render_plugin_toolbar_config tag

### DIFF
--- a/cms/templatetags/cms_admin.py
+++ b/cms/templatetags/cms_admin.py
@@ -6,6 +6,7 @@ from cms.constants import PUBLISHER_STATE_PENDING
 from cms.utils import get_cms_setting
 from cms.utils.admin import get_admin_menu_item_context
 from cms.utils.permissions import get_any_page_view_permissions
+from copy import copy
 from django import template
 from django.conf import settings
 from django.utils.encoding import force_text
@@ -290,12 +291,13 @@ def render_plugin_toolbar_config(context, plugin, placeholder_slot=None):
     child_classes = cms_plugin.get_child_classes(placeholder_slot, page)
     parent_classes = cms_plugin.get_parent_classes(placeholder_slot, page)
 
-    context.update({
+    new_context = copy(context)
+    new_context.update({
         'allowed_child_classes': child_classes,
         'allowed_parent_classes': parent_classes,
         'instance': plugin
     })
-    return context
+    return new_context
 
 
 @register.inclusion_tag('admin/cms/page/plugin/submit_line.html', takes_context=True)


### PR DESCRIPTION
There is a problem in render_plugin_toolbar_config tag because we call update but we never call pop of context.
I use render_plugin_toolbar_config to enable editing of child plugins without rendering them, but after toolbar refactoring, that tag got a very strange behaviour. So I found that when we call render_plugin we fill up some variables in context like "allowed_child_classes", and then if we use render_plugin_toolbar_config in the template of current plugin to render it's children we fill up exactly the save variables. So when the context comes to the toolbar_plugin_processor it's corrupted with values of it's own children plugins.