### PR TITLE
docs:intro:apphooks: "next" section wasn't Third-Party Apps

### DIFF
--- a/docs/introduction/apphooks.rst
+++ b/docs/introduction/apphooks.rst
@@ -64,4 +64,4 @@ directly from the new django CMS page.
 You can now remove the mention of the Polls application (``url(r'^polls/', include('polls.urls',
 namespace='polls'))``) from your project's ``urls.py`` - it's no longer even required there.
 
-Next, we're going to install a django-CMS-compatible third-party application.
+Later, we'll install a django-CMS-compatible :ref:`third-party application <third_party>`.

--- a/docs/introduction/third_party.rst
+++ b/docs/introduction/third_party.rst
@@ -1,3 +1,5 @@
+.. _third_party:
+
 #####################################
 Integrating a third-party application
 #####################################


### PR DESCRIPTION
new PR of https://github.com/divio/django-cms/pull/5397