### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,7 +75,7 @@ http://docs.django-cms.org/en/latest/introduction/index.html
 Quick Start
 ***********
 
-You can use the `django CMS installer <http://djangocms-installer.readthedocs.org>`_::
+You can use the `django CMS installer <https://djangocms-installer.readthedocs.io>`_::
 
     $ pip install --upgrade virtualenv
     $ virtualenv env

--- a/cms/utils/check.py
+++ b/cms/utils/check.py
@@ -362,8 +362,8 @@ def check_copy_relations(output):
         else:
             section.finish_success('Some plugins or page/title extensions do not define a "copy_relations" method.\n'
                                    'This might lead to data loss when publishing or copying plugins/extensions.\n'
-                                   'See https://django-cms.readthedocs.org/en/latest/extending_cms/custom_plugins.html#handling-relations or '  # noqa
-                                   'https://django-cms.readthedocs.org/en/latest/extending_cms/extending_page_title.html#handling-relations.')  # noqa
+                                   'See https://django-cms.readthedocs.io/en/latest/extending_cms/custom_plugins.html#handling-relations or '  # noqa
+                                   'https://django-cms.readthedocs.io/en/latest/extending_cms/extending_page_title.html#handling-relations.')  # noqa
 
 
 def _load_all_templates(directory):

--- a/cms/utils/django_load.py
+++ b/cms/utils/django_load.py
@@ -7,7 +7,7 @@ ANY changes to this file, be it upstream fixes or changes for the cms *must* be
 documented clearly within this file with comments.
 
 For documentation on how to use the functions described in this file, please
-refer to http://django-load.readthedocs.org/en/latest/index.html.
+refer to https://django-load.readthedocs.io/en/latest/index.html.
 """
 import imp
 import traceback # changed

--- a/docs/contributing/code.rst
+++ b/docs/contributing/code.rst
@@ -199,7 +199,7 @@ the source modules.
 
 .. _fork: http://github.com/divio/django-cms
 .. _PEP8: http://www.python.org/dev/peps/pep-0008/
-.. _Aldryn Boilerplate: http://aldryn-boilerplate-bootstrap3.readthedocs.org/en/latest/guidelines/index.html
+.. _Aldryn Boilerplate: https://aldryn-boilerplate-bootstrap3.readthedocs.io/en/latest/guidelines/index.html
 .. _django-cms-developers: http://groups.google.com/group/django-cms-developers
 .. _GitHub: http://www.github.com
 .. _GitHub help: http://help.github.com

--- a/docs/how_to/custom_plugins.rst
+++ b/docs/how_to/custom_plugins.rst
@@ -633,7 +633,7 @@ In your ``yourapp.cms_plugin_processors.py``::
 
 .. _Django admin documentation: http://docs.djangoproject.com/en/dev/ref/contrib/admin/
 .. _django-sekizai: https://github.com/ojii/django-sekizai
-.. _django-sekizai documentation: http://django-sekizai.readthedocs.org
+.. _django-sekizai documentation: https://django-sekizai.readthedocs.io
 
 
 Nested Plugins

--- a/docs/how_to/install.rst
+++ b/docs/how_to/install.rst
@@ -91,7 +91,7 @@ Revision management
     will cause your database size to increase.
 
 .. _django-reversion: https://github.com/etianen/django-reversion
-.. _Compatible Django Versions: http://django-reversion.readthedocs.org/en/latest/django-versions.html
+.. _Compatible Django Versions: https://django-reversion.readthedocs.io/en/latest/django-versions.html
 
 
 .. _installing-in-a-virtualenv-using-pip:

--- a/docs/introduction/install.rst
+++ b/docs/introduction/install.rst
@@ -63,7 +63,7 @@ This means:
    Django Filer, a useful application for managing files and processing images. Although it's not
    required for django CMS itself, a vast number of django CMS addons use it, and nearly all django
    CMS projects have it installed. If you know you won't need it, omit the flag. See the `django
-   CMS installer documentation for more information <http://djangocms-installer.readthedocs.org>`_.
+   CMS installer documentation for more information <https://djangocms-installer.readthedocs.io>`_.
 
 
 .. warning::

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -657,7 +657,7 @@ Add the library files from `GitHub ojii/unihandecode.js tree/dist <https://githu
                 unihandecode-1.0.0.vn.min.js
                 unihandecode-1.0.0.zh.min.js
 
-More documentation is available on `unihandecode.js' Read the Docs <https://unihandecodejs.readthedocs.org/>`_.
+More documentation is available on `unihandecode.js' Read the Docs <https://unihandecodejs.readthedocs.io/>`_.
 
 
 **************

--- a/docs/upgrade/2.2.rst
+++ b/docs/upgrade/2.2.rst
@@ -68,7 +68,7 @@ All templates in :setting:`CMS_TEMPLATES` must at least contain the ``js`` and
 
 Please refer to the documentation on :ref:`custom-plugins-handling-media` in
 custom CMS plugins and the
-`django-sekizai documentation <http://django-sekizai.readthedocs.org/>`_ for
+`django-sekizai documentation <https://django-sekizai.readthedocs.io/>`_ for
 more information.
 
 

--- a/docs/upgrade/3.0.rst
+++ b/docs/upgrade/3.0.rst
@@ -431,7 +431,7 @@ Upgrading from 2.4
     Django Debug Toolbar is installed. Please remove/disable Django Debug
     Toolbar and other non-essential apps before attempting to upgrade, then
     once complete, re-enable them following the `"Explicit setup"
-    <http://django-debug-toolbar.readthedocs.org/en/1.0/installation.html#explicit-setup>`_
+    <https://django-debug-toolbar.readthedocs.io/en/1.0/installation.html#explicit-setup>`_
     instructions.
 
 If you want to upgrade from version 2.4 to 3.0, there's a few things you need to do.


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.