### PR TITLE
Implement four-level CMS_PLACEHOLDER_CONF

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -27,6 +27,7 @@
   a placeholder.
 * Fixed an issue where plugin permissions where not checked when deleting
   a page or page translation.
+* Added support for tiered ``CMS_PLACEHOLDER_CONF``.
 
 
 === 3.3.0 (2016-05-26) ===

--- a/cms/plugin_pool.py
+++ b/cms/plugin_pool.py
@@ -166,18 +166,17 @@ class PluginPool(object):
         self.set_plugin_meta()
         plugins = sorted(self.plugins.values(), key=attrgetter('name'))
         template = page and page.get_template() or None
+
         allowed_plugins = get_placeholder_conf(
             setting_key,
             placeholder,
             template,
         ) or ()
-
         excluded_plugins = get_placeholder_conf(
-            'excluded plugins',
+            'excluded_plugins',
             placeholder,
             template,
         ) or ()
-        allowed_plugins = list(set(allowed_plugins) - set(excluded_plugins))
 
         if not include_page_only:
             # Filters out any plugin marked as page only because
@@ -185,12 +184,12 @@ class PluginPool(object):
             plugins = (plugin for plugin in plugins if not plugin.page_only)
 
         if allowed_plugins:
-            # Check that plugins are in the list of the allowed ones and not in the list
-            # of excluded ones
-            plugins = (
-                plugin for plugin in plugins if plugin.__name__ in allowed_plugins and
-                                                not plugin.__name__ not in excluded_plugins
-            )
+            # Check that plugins are in the list of the allowed ones
+            plugins = (plugin for plugin in plugins if plugin.__name__ in allowed_plugins)
+
+        if excluded_plugins:
+            # Check that plugins are not in the list of the excluded ones
+            plugins = (plugin for plugin in plugins if plugin.__name__ not in excluded_plugins)
 
         if placeholder:
             # Filters out any plugin that requires a parent or has set parent classes

--- a/cms/plugin_pool.py
+++ b/cms/plugin_pool.py
@@ -172,13 +172,25 @@ class PluginPool(object):
             template,
         ) or ()
 
+        excluded_plugins = get_placeholder_conf(
+            'excluded plugins',
+            placeholder,
+            template,
+        ) or ()
+        allowed_plugins = list(set(allowed_plugins) - set(excluded_plugins))
+
         if not include_page_only:
             # Filters out any plugin marked as page only because
             # the include_page_only flag has been set to False
             plugins = (plugin for plugin in plugins if not plugin.page_only)
 
         if allowed_plugins:
-            plugins = (plugin for plugin in plugins if plugin.__name__ in allowed_plugins)
+            # Check that plugins are in the list of the allowed ones and not in the list
+            # of excluded ones
+            plugins = (
+                plugin for plugin in plugins if plugin.__name__ in allowed_plugins and
+                                                not plugin.__name__ not in excluded_plugins
+            )
 
         if placeholder:
             # Filters out any plugin that requires a parent or has set parent classes

--- a/cms/tests/test_placeholder.py
+++ b/cms/tests/test_placeholder.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import itertools
+import re
 
 from django.conf import settings
 from django.contrib import admin
@@ -49,6 +50,11 @@ from cms.utils.placeholder import (PlaceholderNoAction, MLNGPlaceholderActions,
                                    _scan_placeholders)
 from cms.utils.plugins import assign_plugins
 from cms.utils.urlutils import admin_reverse
+
+
+def match_placeholder_conf_regexp(conf_key, key):
+    compiled_regex = re.compile(conf_key)
+    return compiled_regex.match(key)
 
 
 class PlaceholderTestCase(CMSTestCase, UnittestCompatMixin):
@@ -274,14 +280,32 @@ class PlaceholderTestCase(CMSTestCase, UnittestCompatMixin):
                 'inherit':'layout/home.html main',
                 'limits': {},
             },
-            '*': {
+            None: {
                 'name': u'All',
                 'plugins': ['FilerImagePlugin', 'LinkPlugin',],
                 'limits': {},
             },
         }
 
-        TEST_CONF_LIST = [
+        with self.settings(CMS_PLACEHOLDER_CONF=TEST_CONF):
+            # test no inheritance
+            returned = get_placeholder_conf('plugins', 'main')
+            self.assertEqual(returned, TEST_CONF['main']['plugins'])
+            # test no inherited value with inheritance enabled
+            returned = get_placeholder_conf('plugins', 'main', 'layout/home.html')
+            self.assertEqual(returned, TEST_CONF['layout/home.html main']['plugins'])
+            # test direct inherited value
+            returned = get_placeholder_conf('plugins', 'main', 'layout/other.html')
+            self.assertEqual(returned, TEST_CONF['layout/home.html main']['plugins'])
+            # test grandparent inherited value
+            returned = get_placeholder_conf('default_plugins', 'main', 'layout/other.html')
+            self.assertEqual(returned, TEST_CONF['main']['default_plugins'])
+            # test generic configuration
+            returned = get_placeholder_conf('plugins', 'something')
+            self.assertEqual(returned, TEST_CONF[None]['plugins'])
+
+    def test_get_placeholder_regexp(self):
+        TEST_CONF_REGEXP = [
             ('^main$', {
                 'name': 'main content',
                 'plugins': ['TextPlugin', 'LinkPlugin'],
@@ -321,45 +345,31 @@ class PlaceholderTestCase(CMSTestCase, UnittestCompatMixin):
                 'limits': {},
             }),
         ]
-        with self.settings(CMS_PLACEHOLDER_CONF=TEST_CONF):
-            #test no inheritance
-            returned = get_placeholder_conf('plugins', 'main')
-            self.assertEqual(returned, TEST_CONF['main']['plugins'])
-            #test no inherited value with inheritance enabled
-            returned = get_placeholder_conf('plugins', 'main', 'layout/home.html')
-            self.assertEqual(returned, TEST_CONF['layout/home.html main']['plugins'])
-            #test direct inherited value
-            returned = get_placeholder_conf('plugins', 'main', 'layout/other.html')
-            self.assertEqual(returned, TEST_CONF['layout/home.html main']['plugins'])
-            #test grandparent inherited value
-            returned = get_placeholder_conf('default_plugins', 'main', 'layout/other.html')
-            self.assertEqual(returned, TEST_CONF['main']['default_plugins'])
-            #test generic configuration
-            returned = get_placeholder_conf('plugins', 'something')
-            self.assertEqual(returned, TEST_CONF['*']['plugins'])
 
-        with self.settings(CMS_PLACEHOLDER_CONF=TEST_CONF_LIST):
-            #test no inheritance
+        with self.settings(
+            CMS_PLACEHOLDER_CONF=TEST_CONF_REGEXP,
+            CMS_PLACEHOLDER_CONF_KEYS_PARSER=match_placeholder_conf_regexp
+        ):
+            # test no inheritance
             returned = get_placeholder_conf('plugins', 'main')
-            self.assertEqual(returned, TEST_CONF_LIST[0][1]['plugins'])
-            #test no inherited value with inheritance enabled
+            self.assertEqual(returned, TEST_CONF_REGEXP[0][1]['plugins'])
+            # test no inherited value with inheritance enabled
             returned = get_placeholder_conf('plugins', 'main', 'layout/home.html')
-            self.assertEqual(returned, TEST_CONF_LIST[1][1]['plugins'])
-            #test direct inherited value
+            self.assertEqual(returned, TEST_CONF_REGEXP[1][1]['plugins'])
+            # test direct inherited value
             returned = get_placeholder_conf('plugins', 'main', 'layout/other.html')
-            self.assertEqual(returned, TEST_CONF_LIST[1][1]['plugins'])
-            #test grandparent inherited value
+            self.assertEqual(returned, TEST_CONF_REGEXP[1][1]['plugins'])
+            # test grandparent inherited value
             returned = get_placeholder_conf('default_plugins', 'main', 'layout/other.html')
-            self.assertEqual(returned, TEST_CONF_LIST[0][1]['default_plugins'])
-            #test generic configuration
+            self.assertEqual(returned, TEST_CONF_REGEXP[0][1]['default_plugins'])
+            # test generic configuration
             returned = get_placeholder_conf('plugins', 'something')
-            self.assertEqual(returned, TEST_CONF_LIST[5][1]['plugins'])
-            #test regex
+            self.assertEqual(returned, TEST_CONF_REGEXP[5][1]['plugins'])
+            # test regex
             returned = get_placeholder_conf('plugins', 'foo-one')
-            self.assertEqual(returned, TEST_CONF_LIST[3][1]['plugins'])
+            self.assertEqual(returned, TEST_CONF_REGEXP[3][1]['plugins'])
             returned = get_placeholder_conf('plugins', 'somethingfoo-one')
-            self.assertEqual(returned, TEST_CONF_LIST[4][1]['plugins'])
-
+            self.assertEqual(returned, TEST_CONF_REGEXP[4][1]['plugins'])
 
     def test_placeholder_context_leaking(self):
         TEST_CONF = {'test': {'extra_context': {'extra_width': 10}}}

--- a/cms/tests/test_plugins.py
+++ b/cms/tests/test_plugins.py
@@ -219,6 +219,42 @@ class PluginsTestCase(PluginsTestBaseCase):
                 FilteredSelectMultiple,
             )
 
+    def test_not_add_plugin(self):
+        """
+        Test that you can't add a text plugin
+        """
+
+        CMS_PLACEHOLDER_CONF = {
+            'body': {
+                'excluded plugins': ['TextPlugin']
+            }
+        }
+
+        # try to add a new text plugin
+        with self.settings(CMS_PLACEHOLDER_CONF=CMS_PLACEHOLDER_CONF):
+            page_data = self.get_new_page_data()
+            self.client.post(URL_CMS_PAGE_ADD, page_data)
+            page = Page.objects.all()[0]
+            installed_plugins = plugin_pool.get_all_plugins('body', page)
+            installed_plugins = [cls.__name__ for cls in installed_plugins]
+            self.assertNotIn('TextPlugin', installed_plugins)
+
+        CMS_PLACEHOLDER_CONF = {
+            'body': {
+                'plugins': ['TextPlugin'],
+                'excluded plugins': ['TextPlugin']
+            }
+        }
+
+        # try to add a new text plugin
+        with self.settings(CMS_PLACEHOLDER_CONF=CMS_PLACEHOLDER_CONF):
+            page_data = self.get_new_page_data()
+            self.client.post(URL_CMS_PAGE_ADD, page_data)
+            page = Page.objects.all()[0]
+            installed_plugins = plugin_pool.get_all_plugins('body', page)
+            installed_plugins = [cls.__name__ for cls in installed_plugins]
+            self.assertNotIn('TextPlugin', installed_plugins)
+
     def test_plugin_edit_marks_page_dirty(self):
         page_data = self.get_new_page_data()
         response = self.client.post(URL_CMS_PAGE_ADD, page_data)

--- a/cms/tests/test_plugins.py
+++ b/cms/tests/test_plugins.py
@@ -219,14 +219,14 @@ class PluginsTestCase(PluginsTestBaseCase):
                 FilteredSelectMultiple,
             )
 
-    def test_not_add_plugin(self):
+    def test_excluded_plugin(self):
         """
         Test that you can't add a text plugin
         """
 
         CMS_PLACEHOLDER_CONF = {
             'body': {
-                'excluded plugins': ['TextPlugin']
+                'excluded_plugins': ['TextPlugin']
             }
         }
 
@@ -242,7 +242,7 @@ class PluginsTestCase(PluginsTestBaseCase):
         CMS_PLACEHOLDER_CONF = {
             'body': {
                 'plugins': ['TextPlugin'],
-                'excluded plugins': ['TextPlugin']
+                'excluded_plugins': ['TextPlugin']
             }
         }
 

--- a/cms/utils/conf.py
+++ b/cms/utils/conf.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from collections import OrderedDict
 from functools import update_wrapper
 import os
 
@@ -254,6 +255,12 @@ def get_unihandecode_host():
         return host + '/'
 
 
+def get_placeholder_config():
+    name = 'PLACEHOLDER_CONF'
+    placeholder_conf = getattr(settings, 'CMS_%s' % name, DEFAULTS[name])
+    return OrderedDict(placeholder_conf)
+
+
 COMPLEX = {
     'CACHE_DURATIONS': get_cache_durations,
     'MEDIA_ROOT': get_media_root,
@@ -266,6 +273,7 @@ COMPLEX = {
     'CMS_TOOLBAR_URL__EDIT_OFF': get_toolbar_url__edit_off,
     'CMS_TOOLBAR_URL__BUILD': get_toolbar_url__build,
     'CMS_TOOLBAR_URL__DISABLE': get_toolbar_url__disable,
+    'PLACEHOLDER_CONF': get_placeholder_config
 }
 
 DEPRECATED_CMS_SETTINGS = {

--- a/cms/utils/conf.py
+++ b/cms/utils/conf.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from collections import OrderedDict
 from functools import update_wrapper
 import os
 
@@ -72,7 +71,6 @@ DEFAULTS = {
     'PAGE_WIZARD_CONTENT_PLUGIN': 'TextPlugin',
     'PAGE_WIZARD_CONTENT_PLUGIN_BODY': 'body',
     'PAGE_WIZARD_CONTENT_PLACEHOLDER': None,  # Use first placeholder it finds.
-    'PLACEHOLDER_CONF_KEYS_PARSER': 'default'
 }
 
 
@@ -256,12 +254,6 @@ def get_unihandecode_host():
         return host + '/'
 
 
-def get_placeholder_config():
-    name = 'PLACEHOLDER_CONF'
-    placeholder_conf = getattr(settings, 'CMS_%s' % name, DEFAULTS[name])
-    return OrderedDict(placeholder_conf)
-
-
 COMPLEX = {
     'CACHE_DURATIONS': get_cache_durations,
     'MEDIA_ROOT': get_media_root,
@@ -274,7 +266,6 @@ COMPLEX = {
     'CMS_TOOLBAR_URL__EDIT_OFF': get_toolbar_url__edit_off,
     'CMS_TOOLBAR_URL__BUILD': get_toolbar_url__build,
     'CMS_TOOLBAR_URL__DISABLE': get_toolbar_url__disable,
-    'PLACEHOLDER_CONF': get_placeholder_config
 }
 
 DEPRECATED_CMS_SETTINGS = {

--- a/cms/utils/conf.py
+++ b/cms/utils/conf.py
@@ -72,6 +72,7 @@ DEFAULTS = {
     'PAGE_WIZARD_CONTENT_PLUGIN': 'TextPlugin',
     'PAGE_WIZARD_CONTENT_PLUGIN_BODY': 'body',
     'PAGE_WIZARD_CONTENT_PLACEHOLDER': None,  # Use first placeholder it finds.
+    'PLACEHOLDER_CONF_KEYS_PARSER': 'default'
 }
 
 

--- a/cms/utils/placeholder.py
+++ b/cms/utils/placeholder.py
@@ -52,12 +52,12 @@ def get_placeholder_conf(setting, placeholder, template=None, default=None):
         placeholder_conf = get_cms_setting('PLACEHOLDER_CONF')
         # 1st level
         if template:
-            keys.append(force_text('%s %s' % (template, placeholder)))
+            keys.append(u'%s %s' % (template, placeholder))
         # 2nd level
-        keys.append(force_text(placeholder))
+        keys.append(placeholder)
         # 3rd level
         if template:
-            keys.append(force_text(template))
+            keys.append(template)
         # 4th level
         keys.append(None)
         for key in keys:

--- a/cms/utils/placeholder.py
+++ b/cms/utils/placeholder.py
@@ -11,7 +11,6 @@ from django.template.loader import get_template
 from django.template.loader_tags import BlockNode, ExtendsNode, IncludeNode
 from django.utils import six
 from django.utils.encoding import force_text
-from django.utils.six import iteritems
 
 from sekizai.helpers import get_varname, is_variable_extend_node
 
@@ -47,25 +46,10 @@ def get_placeholder_conf(setting, placeholder, template=None, default=None):
     CMS_PLACEHOLDER_CONF['placeholder']
     CMS_PLACEHOLDER_CONF['template placeholder'] (if template is given)
     """
-    # Ideas:
-    # 1)using real regex as keys
-    # 2)turn the setting in an orderedict
-    # 3)handling dictionary and list both
-
-    # Use function set in PLACEHOLDER_CONF_KEYS_PARSER to match configuration
-    # keys with the generated list of keys
-
-    def _match_placeholder_conf(conf_key, key):
-        return force_text(conf_key) == force_text(key)
 
     if placeholder:
         keys = []
         placeholder_conf = get_cms_setting('PLACEHOLDER_CONF')
-        parser = get_cms_setting('PLACEHOLDER_CONF_KEYS_PARSER')
-        if parser == 'default':
-            parser_function = _match_placeholder_conf
-        else:
-            parser_function = parser
         # 1st level
         if template:
             keys.append(force_text('%s %s' % (template, placeholder)))
@@ -77,8 +61,8 @@ def get_placeholder_conf(setting, placeholder, template=None, default=None):
         # 4th level
         keys.append(None)
         for key in keys:
-            for conf_key, conf in iteritems(placeholder_conf):
-                if parser_function(conf_key, key):
+            for conf_key, conf in placeholder_conf.items():
+                if force_text(conf_key) == force_text(key):
                     if not conf:
                         continue
                     value = conf.get(setting)

--- a/cms/utils/placeholder.py
+++ b/cms/utils/placeholder.py
@@ -39,16 +39,21 @@ def get_placeholder_conf(setting, placeholder, template=None, default=None):
     Returns the placeholder configuration for a given setting. The key would for
     example be 'plugins' or 'name'.
 
-    If a template is given, it will try
-    CMS_PLACEHOLDER_CONF['template placeholder'] and
-    CMS_PLACEHOLDER_CONF['placeholder'], if no template is given only the latter
-    is checked.
+    Resulting value will be the last from:
+
+    CMS_PLACEHOLDER_CONF['*'] (global)
+    CMS_PLACEHOLDER_CONF['template'] (if template is given)
+    CMS_PLACEHOLDER_CONF['placeholder']
+    CMS_PLACEHOLDER_CONF['template placeholder'] (if template is given)
     """
     if placeholder:
         keys = []
         if template:
             keys.append("%s %s" % (template, placeholder))
         keys.append(placeholder)
+        if template:
+            keys.append(template)
+        keys.append('*')
         for key in keys:
             conf = get_cms_setting('PLACEHOLDER_CONF').get(key)
             if not conf:

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -189,6 +189,10 @@ all placeholders.
 Example::
 
     CMS_PLACEHOLDER_CONF = {
+        None: {
+            "plugins": ['TextPlugin'],
+            'exclude_plugins': ['InheritPlugin'],
+        }
         'content': {
             'plugins': ['TextPlugin', 'PicturePlugin'],
             'text_only_plugins': ['LinkPlugin'],
@@ -232,8 +236,29 @@ Example::
         },
     }
 
+.. _placeholder_conf_precedence:
+
 You can combine template names and placeholder names to define
 plugins in a granular fashion, as shown above with ``base.html content``.
+
+Configuration is retrieved in the following order:
+
+* CMS_PLACEHOLDER_CONF['template placeholder']
+* CMS_PLACEHOLDER_CONF['placeholder']
+* CMS_PLACEHOLDER_CONF['template']
+* CMS_PLACEHOLDER_CONF[None]
+
+The first ``CMS_PLACEHOLDER_CONF`` key that matches for the required configuration attribute
+is used.
+
+E.g: given the example above if the ``plugins`` configuration is retrieved for the ``content``
+placeholder in a page using the ``base.html`` template, the value
+``['TextPlugin', 'PicturePlugin', 'TeaserPlugin']`` will be returned as ``'base.html content'``
+matches; if the same configuration is retrieved for the ``content`` placeholder in a page using
+``fullwidth.html`` template, the returned value will be ``['TextPlugin', 'PicturePlugin']``. If
+``plugins`` configuration is retrieved for ``sidebar_left`` placeholder, ``['TextPlugin']`` from
+``CMS_PLACEHOLDER_CONF`` key ``None`` will be returned.
+
 
 ``plugins``
     A list of plugins that can be added to this placeholder. If not supplied,
@@ -242,6 +267,14 @@ plugins in a granular fashion, as shown above with ``base.html content``.
 ``text_only_plugins``
     A list of additional plugins available only in the TextPlugin, these
     plugins can't be added directly to this placeholder.
+
+``excluded_plugins``
+    A list of plugins that will not be added to the given placeholder; this takes precedence
+    over ``plugins`` configuration: if a plugin is present in both lists, it **will not** be
+    available in the placeholder. This is basically a way to **blacklist** a plugin: even if
+    registered, it will not be available in the placeholder. If set on the ``None`` (default)
+    key, the plugins will not be available in any placeholder (except the ``excluded_plugins``
+    configuration is overridden in more specific ``CMS_PLACEHOLDER_KEYS``.
 
 ``extra_context``
     Extra context that plugins in this placeholder receive.


### PR DESCRIPTION
This replaces #5006 

Currently ``CMS_PLACEHOLDER_CONF`` only allows values for placeholder and template+placeholder keys
Sometimes a global configuration would make things much nicer / simpler
@ojii suggested a for level structure like (in increasing order of precedence)

    CMS_PLACEHOLDER_CONF[None] (global)
    CMS_PLACEHOLDER_CONF['template'] (if template is given)
    CMS_PLACEHOLDER_CONF['placeholder']
    CMS_PLACEHOLDER_CONF['template placeholder'] (if template is given)

This is backward-compatible and allow a few neat tricks.

This also implement ``excluded_plugins`` key to exclude plugins from the list of available one

Changes needed
 * [x] 4-level configuration
 * [x] tests
 * [x] documentation

On top of this is easy to implement plugin blacklisting (see #5000, #4979), list of plugins to show in text editor and other plugin configuration options

A step further is to implement more flexible way to select configuration for each placeholder based on different attributes than name and template

Fix #5000 
Fix #4979 