### PR TITLE
Fixed #5418 -- Check plugin permissions when clearing placeholder.

### DIFF
--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -644,7 +644,8 @@ class PageAdmin(PlaceholderAdminMixin, ModelAdmin):
                 return False
             if not page.has_change_permission(request):
                 return False
-        return True
+        language = request.GET.get('language', None)
+        return placeholder.has_clear_permission(request.user, language)
 
     @create_revision()
     def post_add_plugin(self, request, plugin):

--- a/cms/admin/placeholderadmin.py
+++ b/cms/admin/placeholderadmin.py
@@ -200,6 +200,7 @@ class PlaceholderAdminMixin(object):
         if not permissions.has_plugin_permission(request.user, plugin.plugin_type, "delete"):
             return False
         placeholder = plugin.placeholder
+
         if not placeholder.has_delete_permission(request):
             return False
         return True
@@ -207,7 +208,8 @@ class PlaceholderAdminMixin(object):
     def has_clear_placeholder_permission(self, request, placeholder):
         if not placeholder.has_delete_permission(request):
             return False
-        return True
+        language = request.GET.get('language', None)
+        return placeholder.has_clear_permission(request.user, language)
 
     def post_add_plugin(self, request, plugin):
         pass
@@ -659,6 +661,7 @@ class PlaceholderAdminMixin(object):
     @xframe_options_sameorigin
     def clear_placeholder(self, request, placeholder_id):
         placeholder = get_object_or_404(Placeholder, pk=placeholder_id)
+
         if not self.has_clear_placeholder_permission(request, placeholder):
             return HttpResponseForbidden(force_text(_("You do not have permission to clear this placeholder")))
         language = request.GET.get('language', None)

--- a/cms/models/placeholdermodel.py
+++ b/cms/models/placeholdermodel.py
@@ -26,6 +26,7 @@ from cms.constants import (
     PUBLISHER_STATE_DIRTY,
 )
 from cms.utils import get_language_from_request
+from cms.utils import permissions
 from cms.utils.conf import get_cms_setting
 
 
@@ -156,6 +157,21 @@ class Placeholder(models.Model):
 
     def has_delete_permission(self, request):
         return self._get_permission(request, 'delete')
+
+    def has_clear_permission(self, user, language):
+        plugin_types = (
+            self
+            .get_plugins(language)
+            .values_list('plugin_type', flat=True)
+            .distinct()
+        )
+
+        has_permission = permissions.has_plugin_permission
+
+        for plugin_type in plugin_types.iterator():
+            if not has_permission(user, plugin_type, "delete"):
+                return False
+        return True
 
     def render(self, context, width, lang=None, editable=True, use_cache=True):
         '''

--- a/cms/tests/test_admin.py
+++ b/cms/tests/test_admin.py
@@ -32,6 +32,7 @@ from cms.models.placeholdermodel import Placeholder
 from cms.models.pluginmodel import CMSPlugin
 from cms.models.titlemodels import Title
 from cms.test_utils import testcases as base
+from cms.test_utils.project.placeholderapp.models import Example1
 from cms.test_utils.testcases import (
     CMSTestCase, URL_CMS_PAGE_DELETE, URL_CMS_PAGE,URL_CMS_TRANSLATION_DELETE,
     URL_CMS_PAGE_CHANGE_LANGUAGE, URL_CMS_PAGE_CHANGE, URL_CMS_PAGE_PERMISSIONS,
@@ -50,8 +51,13 @@ class AdminTestsBase(CMSTestCase):
 
     def _get_guys(self, admin_only=False, use_global_permissions=True):
         admin_user = self.get_superuser()
+
         if admin_only:
             return admin_user
+        staff_user = self._get_staff_user(use_global_permissions)
+        return admin_user, staff_user
+
+    def _get_staff_user(self, use_global_permissions=True):
         USERNAME = 'test'
 
         if get_user_model().USERNAME_FIELD == 'email':
@@ -76,7 +82,7 @@ class AdminTestsBase(CMSTestCase):
                 can_move_page=True,
             )
             gpp.sites = Site.objects.all()
-        return admin_user, normal_guy
+        return normal_guy
 
 
 class AdminTestCase(AdminTestsBase):
@@ -636,6 +642,121 @@ class AdminTestCase(AdminTestsBase):
         # After cleaning the de placeholder, en placeholder must still have all the plugins
         self.assertEqual(ph.get_plugins('en').count(), 2)
         self.assertEqual(ph.get_plugins('de').count(), 0)
+
+    def test_clear_placeholder_permissions_page(self):
+        """
+        Ensures a user without delete plugin permissions
+        cannot clear a page placeholder that contains said plugin.
+        """
+        page_en = create_page("EmptyPlaceholderTestPage (EN)", "nav_playground.html", "en")
+        ph = page_en.placeholders.get(slot="body")
+
+        # add text plugin
+        add_plugin(ph, "TextPlugin", "en", body="Hello World EN 1")
+        add_plugin(ph, "TextPlugin", "en", body="Hello World EN 2")
+
+        # add a link plugin to make sure we test diversity
+        add_plugin(ph, "LinkPlugin", "en", name='link-1')
+        add_plugin(ph, "LinkPlugin", "en", name='link-2')
+
+        # Staff user has basic page permissions but no
+        # plugin permissions.
+        staff = self._get_staff_user()
+        endpoint = '%s?language=en' % admin_reverse('cms_page_clear_placeholder', args=[ph.pk])
+
+        with self.login_user_context(staff):
+            response = self.client.post(endpoint, {'test': 0})
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(ph.get_plugins('en').count(), 4)
+
+        # Give the staff user permission to delete text plugins
+        staff.user_permissions.add(Permission.objects.get(codename='delete_text'))
+
+        with self.login_user_context(staff):
+            response = self.client.post(endpoint, {'test': 0})
+
+        # Operation results in 403 because staff user does not have
+        # permission to delete links
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(ph.get_plugins('en').count(), 4)
+
+        # Give the staff user permission to delete link plugins
+        staff.user_permissions.add(Permission.objects.get(codename='delete_link'))
+
+        with self.login_user_context(staff):
+            response = self.client.post(endpoint, {'test': 0})
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(ph.get_plugins('en').count(), 0)
+
+    def test_clear_placeholder_permissions_generic(self):
+        """
+        Ensures a user without delete plugin permissions
+        cannot clear a generic placeholder that contains said plugin.
+        """
+        ex1 = Example1.objects.create(
+            char_1="char_1",
+            char_2="char_2",
+            char_3="char_3",
+            char_4="char_4",
+        )
+
+        ph = ex1.placeholder
+
+        # add text plugin
+        add_plugin(ph, "TextPlugin", "en", body="Hello World EN 1")
+        add_plugin(ph, "TextPlugin", "en", body="Hello World EN 2")
+
+        # add a link plugin to make sure we test diversity
+        add_plugin(ph, "LinkPlugin", "en", name='link-1')
+        add_plugin(ph, "LinkPlugin", "en", name='link-2')
+
+        # Staff user has basic page permissions but no
+        # plugin permissions.
+        staff = self._get_staff_user()
+        endpoint = '%s?language=en' % admin_reverse('placeholderapp_example1_clear_placeholder', args=[ph.pk])
+
+        with self.login_user_context(staff):
+            response = self.client.post(endpoint, {'test': 0})
+
+        # Operation results in 403 because staff user does not have
+        # permission to delete the object the placeholder is attached to
+        # which is Example1 and the user also does not have permission
+        # to delete text and links
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(ph.get_plugins('en').count(), 4)
+
+        # Give the user permission to delete Example1 objects
+        staff.user_permissions.add(Permission.objects.get(codename='delete_example1'))
+
+        with self.login_user_context(staff):
+            response = self.client.post(endpoint, {'test': 0})
+
+        # Operation results in 403 because staff user does not have
+        # permission to delete text and links
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(ph.get_plugins('en').count(), 4)
+
+        # Give the staff user permission to delete text plugins
+        staff.user_permissions.add(Permission.objects.get(codename='delete_text'))
+
+        # Operation results in 403 because staff user does not have
+        # permission to delete links
+        with self.login_user_context(staff):
+            response = self.client.post(endpoint, {'test': 0})
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(ph.get_plugins('en').count(), 4)
+
+        # Give the staff user permission to delete link plugins
+        staff.user_permissions.add(Permission.objects.get(codename='delete_link'))
+
+        with self.login_user_context(staff):
+            response = self.client.post(endpoint, {'test': 0})
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(ph.get_plugins('en').count(), 0)
 
 
 class AdminTests(AdminTestsBase):


### PR DESCRIPTION
Fixes #5418

Note that because this is a bugfix, I've opted to keep the impact as small as possible and thus
did not change much of the internals.

A refactor will come soon..