### PR TITLE
Fixed broken references across the documentation

### DIFF
--- a/docs/how_to/apphooks.rst
+++ b/docs/how_to/apphooks.rst
@@ -253,7 +253,7 @@ As mentioned above, whenever you:
 * change the slug of a page with a descendant with an apphook
 
 The CMS the server will reload its URL caches. It does this by listening for
-the signal :obj:`cms.signals.urls_need_reloading`.
+the signal ``cms.signals.urls_need_reloading``.
 
 .. warning::
 
@@ -279,4 +279,3 @@ django CMS ``{% placeholder %}`` template tag may be invoked - **but will not wo
 
 ``{% static_placeholder %}`` tags on the other hand are *not* page-specific and *will* function
 normally.
-

--- a/docs/how_to/custom_plugins.rst
+++ b/docs/how_to/custom_plugins.rst
@@ -71,9 +71,9 @@ A note about :class:`cms.plugin_base.CMSPluginBase`
 ===================================================
 
 :class:`cms.plugin_base.CMSPluginBase` is actually a sub-class of
-:class:`django.contrib.admin.options.ModelAdmin`.
+:class:`django:django.contrib.admin.ModelAdmin`.
 
-Because :class:`CMSPluginBase` sub-classes ``ModelAdmin`` several important
+Because :class:`~cms.plugin_base.CMSPluginBase` sub-classes ``ModelAdmin`` several important
 ``ModelAdmin`` options are also available to CMS plugin developers. These
 options are often used:
 
@@ -193,14 +193,14 @@ is ``True`` (the default):
 * ``get_render_template``: A method that returns a template path to render the
   plugin with.
 
-In addition to those attributes, you can also override the :ref:`render` method
+In addition to those attributes, you can also override the :meth:`~cms.plugin_base.CMSPluginBase.render()` method
 which determines the template context variables that are used to render your
 plugin. By default, this method only adds ``instance`` and ``placeholder``
 objects to your context, but plugins can override this to include any context
 that is required.
 
 A number of other methods are available for overriding on your CMSPluginBase
-sub-classes. See: :mod:`cms.plugin_base` for further details.
+sub-classes. See: :class:`~cms.plugin_base.CMSPluginBase` for further details.
 
 
 ***************
@@ -247,7 +247,7 @@ In our ``models.py`` we add the following::
 If you followed the Django tutorial, this shouldn't look too new to you. The
 only difference to normal models is that you sub-class
 :class:`cms.models.pluginmodel.CMSPlugin` rather than
-:class:`django.db.models.base.Model`.
+:class:`django.db.models.Model`.
 
 Now we need to change our plugin definition to use this model, so our new
 ``cms_plugins.py`` looks like this::
@@ -431,7 +431,7 @@ Plugin form
 ===========
 
 Since :class:`cms.plugin_base.CMSPluginBase` extends
-:class:`django.contrib.admin.options.ModelAdmin`, you can customise the form
+:class:`django:django.contrib.admin.ModelAdmin`, you can customise the form
 for your plugins just as you would customise your admin interfaces.
 
 The template that the plugin editing mechanism uses is
@@ -727,9 +727,9 @@ of placeholders or plugins.
 
 For this purpose you can overwrite 3 methods on CMSPluginBase.
 
-* :ref:`get_extra_placeholder_menu_items`
-* :ref:`get_extra_global_plugin_menu_items`
-* :ref:`get_extra_local_plugin_menu_items`
+* :meth:`~cms.plugin_base.CMSPluginBase.get_extra_placeholder_menu_items`
+* :meth:`~cms.plugin_base.CMSPluginBase.get_extra_global_plugin_menu_items`
+* :meth:`~cms.plugin_base.CMSPluginBase.get_extra_local_plugin_menu_items`
 
 Example::
 

--- a/docs/how_to/extending_page_title.rst
+++ b/docs/how_to/extending_page_title.rst
@@ -334,11 +334,14 @@ The simplified Toolbar API works by deriving your toolbar class from ``Extension
 which provides the following API:
 
 
-* :py:meth:`cms.extensions.toolbar.ExtensionToolbar._setup_extension_toolbar`: this must be called first to setup
+* :meth:`cms.extensions.toolbar.ExtensionToolbar._setup_extension_toolbar`: this must be called first to setup
   the environment and do the permission checking;
-* :py:meth:`cms.extensions.toolbar.ExtensionToolbar.get_page_extension_admin`: for page extensions, retrieves the
+* :py:meth:`~cms.extensions.toolbar.ExtensionToolbar.get_page_extension_admin()`: for page extensions, retrieves the
   correct admin URL for the related toolbar item; returns the extension instance (or `None` if not exists)
   and the admin URL for the toolbar item;
-* :py:meth:`cms.extensions.toolbar.ExtensionToolbar.get_title_extension_admin`: for title extensions, retrieves the
+* :py:meth:`~cms.extensions.toolbar.ExtensionToolbar.get_title_extension_admin()`: for title extensions, retrieves the
   correct admin URL for the related toolbar item; returns a list of the extension instances
   (or `None` if not exists) and the admin urls for each title of the current page;
+
+* :meth:`cms.toolbar.toolbar.CMSToolbar.get_or_create_menu`
+* :meth:`cms.extensions.toolbar.ExtensionToolbar._setup_extension_toolbar`

--- a/docs/how_to/frontend_models.rst
+++ b/docs/how_to/frontend_models.rst
@@ -20,10 +20,10 @@ hint on hover. Double-clicking opens a pop-up window containing the change form 
 
 .. warning::
 
-    By default and for consistency with previous releases, templatetags used
+    By default and for consistency with previous releases, template tags used
     by this feature mark as safe the content of the rendered
     model attribute. This may be a security risk if used on fields which may
-    hold non-trusted content. Be aware, and use the templatetags accordingly.
+    hold non-trusted content. Be aware, and use the template tags accordingly.
     To change this behaviour, set the setting: :setting:`CMS_UNESCAPED_RENDER_MODEL_TAGS` to False.
 
 
@@ -154,7 +154,7 @@ template tag::
     <h1>{% render_model instance "some_attribute" %}</h1>
     {% endblock content %}
 
-See :ttag:`templatetag reference <render_model>` for arguments documentation.
+See :ttag:`template tag reference <render_model>` for arguments documentation.
 
 
 Selected fields edit
@@ -215,7 +215,7 @@ evaluated with ``request`` as parameter.
 The custom view does not need to obey any specific interface; it will get
 ``edit_fields`` value as a ``GET`` parameter.
 
-See :ttag:`templatetag reference <render_model>` for arguments documentation.
+See :ttag:`template tag reference <render_model>` for arguments documentation.
 
 Example ``view_url``::
 

--- a/docs/how_to/menus.rst
+++ b/docs/how_to/menus.rst
@@ -46,7 +46,7 @@ Create a ``cms_menus.py`` in your application, with the following::
 If you refresh a page you should now see the menu entries above.
 The ``get_nodes`` function should return a list of
 :class:`NavigationNode <menus.base.NavigationNode>` instances. A
-:class:`NavigationNode` takes the following arguments:
+:class:`menus.base.NavigationNode` takes the following arguments:
 
 ``title``
   Text for the menu node
@@ -72,7 +72,7 @@ The ``get_nodes`` function should return a list of
 ``visible=True``
   Whether or not this menu item should be visible
 
-Additionally, each :class:`NavigationNode` provides a number of methods which are
+Additionally, each :class:`menus.base.NavigationNode` provides a number of methods which are
 detailed in the :class:`NavigationNode <menus.base.NavigationNode>` API references.
 
 

--- a/docs/how_to/placeholders.rst
+++ b/docs/how_to/placeholders.rst
@@ -9,12 +9,12 @@ user-editable content (plugins) in templates. That is, it's the place where a
 user can add text, video or any other plugin to a webpage, using the same
 frontend editing as the CMS pages.
 
-Placeholders can be viewed as containers for :class:`CMSPlugin` instances, and
+Placeholders can be viewed as containers for :class:`~cms.models.pluginmodel.CMSPlugin` instances, and
 can be used outside the CMS in custom applications using the
 :class:`~cms.models.fields.PlaceholderField`.
 
 By defining one (or several) :class:`~cms.models.fields.PlaceholderField` on a
-custom model you can take advantage of the full power of :class:`CMSPlugin`.
+custom model you can take advantage of the full power of :class:`~cms.models.pluginmodel.CMSPlugin`.
 
 ***********
 Get started
@@ -109,7 +109,7 @@ translated fields::
         def __unicode__(self):
             return self.title
 
-Be sure to combine both hvad's :class:`TranslatableAdmin` and :class:`~cms.admin.placeholderadmin.PlaceholderAdminMixin` when
+Be sure to combine both hvad's ``TranslatableAdmin`` and :class:`~cms.admin.placeholderadmin.PlaceholderAdminMixin` when
 registering your model with the admin site::
 
     from cms.admin.placeholderadmin import PlaceholderAdminMixin
@@ -142,8 +142,8 @@ The :ttag:`render_placeholder` tag takes the following parameters:
   specified language (optional)
 
 The view in which you render your placeholder field must return the
-:attr:`request <django.http.HttpRequest>` object in the context. This is
-typically achieved in Django applications by using :class:`RequestContext`::
+:class:`request <django.http.HttpRequest>` object in the context. This is
+typically achieved in Django applications by using :class:`~django.template.RequestContext`::
 
     from django.shortcuts import get_object_or_404, render
 

--- a/docs/how_to/sitemap.rst
+++ b/docs/how_to/sitemap.rst
@@ -10,7 +10,7 @@ Sitemap
 Sitemaps are XML files used by Google to index your website by using their
 **Webmaster Tools** and telling them the location of your sitemap.
 
-The :class:`CMSSitemap` will create a sitemap with all the published pages of
+The :class:`cms.sitemaps.CMSSitemap` will create a sitemap with all the published pages of
 your CMS.
 
 

--- a/docs/how_to/testing.rst
+++ b/docs/how_to/testing.rst
@@ -11,7 +11,7 @@ Resolving View Names
 
 Your apps need testing, but in your live site they aren't in ``urls.py`` as
 they are attached to a CMS page.  So if you want to be able to use
-:func:`~django.core.urlresolvers.reverse` in your tests, or test templates that
+:func:`~django.urls.reverse()` in your tests, or test templates that
 use the :ttag:`url` template tag, you need to hook up your app to a special
 test version of ``urls.py`` and tell your tests to use that.
 
@@ -27,7 +27,7 @@ So you could create ``myapp/tests/urls.py`` with the following code::
     ]
 
 And then in your tests you can plug this in with the
-:func:`~django.test.utils.override_settings` decorator::
+:func:`~django.test.override_settings` decorator::
 
     from django.test.utils import override_settings
     from cms.test_utils.testcases import CMSTestCase

--- a/docs/how_to/toolbar.rst
+++ b/docs/how_to/toolbar.rst
@@ -33,7 +33,7 @@ automatically loaded as long :setting:`CMS_TOOLBARS` is not set (or is set to
 ``None``).
 
 If you use the automated way, your ``cms_toolbars.py`` file should contain
-classes that extend ``cms.toolbar_base.CMSToolbar`` and are registered using :meth:`cms.toolbar_pool.toolbar_pool.register`.
+classes that extend ``cms.toolbar_base.CMSToolbar`` and are registered using :meth:`~cms.toolbar_pool.ToolbarPool.register()`.
 The register function can be used as a decorator.
 
 These classes have four attributes:
@@ -154,7 +154,7 @@ menus::
 
 
 If you wish to simply detect the presence of a menu without actually creating
-it, you can use :meth:`cms.toolbar.toolbar.CMSToolbar.get_menu`, which will
+it, you can use :meth:`~cms.toolbar.toolbar.CMSToolbar.get_menu()`, which will
 return the menu if it is present, or, if not, will return ``None``.
 
 

--- a/docs/introduction/plugins.rst
+++ b/docs/introduction/plugins.rst
@@ -173,7 +173,7 @@ In your poll application’s ``models.py`` add the following:
 
 .. note::
 
-    django CMS plugins inherit from :class:`cms.models.CMSPlugin` (or a
+    django CMS plugins inherit from :class:`cms.models.pluginmodel.CMSPlugin` (or a
     sub-class thereof) and not :class:`models.Model <django.db.models.Model>`.
 
     ``PollPluginModel`` might seem an odd choice for a model name (that is, with ``model`` in the
@@ -213,7 +213,7 @@ For our poll plugin, we're going to write the following plugin class:
 .. note::
 
     All plugin classes must inherit from :class:`cms.plugin_base.CMSPluginBase`
-    and must register themselves with the :data:`cms.plugin_pool.plugin_pool`.
+    and must register themselves with the :class:`plugin_pool <cms.plugin_pool.PluginPool>`.
 
 A reasonable convention for plugin naming is:
 

--- a/docs/reference/api_references.rst
+++ b/docs/reference/api_references.rst
@@ -62,8 +62,8 @@ Functions and constants
 
 .. function:: create_page(title, template, language, menu_title=None, slug=None, apphook=None, apphook_namespace=None, redirect=None, meta_description=None, created_by='python-api', parent=None, publication_date=None, publication_end_date=None, in_navigation=False, soft_root=False, reverse_id=None, navigation_extenders=None, published=False, site=None, login_required=False, limit_visibility_in_menu=VISIBILITY_ALL, position="last-child", overwrite_url=None, xframe_options=Page.X_FRAME_OPTIONS_INHERIT, with_revision=False)
 
-    Creates a :class:`cms.models.pagemodel.Page` instance and returns it. Also
-    creates a :class:`cms.models.titlemodels.Title` instance for the specified
+    Creates a :class:`cms.models.Page` instance and returns it. Also
+    creates a :class:`cms.models.Title` instance for the specified
     language.
 
     :param string title: Title of the page
@@ -79,7 +79,7 @@ Functions and constants
     :param created_by: User that is creating this page
     :type created_by: string of :class:`django.contrib.auth.models.User` instance
     :param parent: Parent page of this page
-    :type parent: :class:`cms.models.pagemodel.Page` instance
+    :type parent: :class:`cms.models.Page` instance
     :param datetime publication_date: Date to publish this page
     :param datetime publication_end_date: Date to unpublish this page
     :param bool in_navigation: Whether this page should be in the navigation or not
@@ -94,24 +94,24 @@ Functions and constants
     :type limit_menu_visibility: :data:`VISIBILITY_ALL` or :data:`VISIBILITY_USERS` or :data:`VISIBILITY_ANONYMOUS`
     :param string position: Where to insert this node if *parent* is given, must be ``'first-child'`` or ``'last-child'``
     :param string overwrite_url: Overwritten path for this page
-    :param integer xframe_options: X Frame Option value for Clickjacking protection
+    :param int xframe_options: X Frame Option value for Clickjacking protection
     :param bool with_revision: Whether to create a revision for the new page.
 
 
 .. function:: create_title(language, title, page, menu_title=None, slug=None, redirect=None, meta_description=None, parent=None, overwrite_url=None, with_revision=False)
 
-    Creates a :class:`cms.models.titlemodels.Title` instance and returns it.
+    Creates a :class:`cms.models.Title` instance and returns it.
 
     :param string language: Language code for this page. Must be in :setting:`django:LANGUAGES`
     :param string title: Title of the page
     :param page: The page for which to create this title
-    :type page: :class:`cms.models.pagemodel.Page` instance
+    :type page: :class:`cms.models.Page` instance
     :param string menu_title: Menu title for this page
     :param string slug: Slug for the page, by default uses a slugified version of *title*
     :param string redirect: URL redirect
     :param string meta_description: Description of this page for SEO
     :param parent: Used for automated slug generation
-    :type parent: :class:`cms.models.pagemodel.Page` instance
+    :type parent: :class:`cms.models.Page` instance
     :param string overwrite_url: Overwritten path for this page
     :param bool with_revision: Whether to create a revision for the new page.
 
@@ -127,7 +127,7 @@ Functions and constants
     :param string language: Language code for this plugin, must be in :setting:`django:LANGUAGES`
     :param string position: Position to add this plugin to the placeholder, must be a valid django-mptt position
     :param target: Parent plugin. Must be plugin instance
-    :param kwargs data: Data for the plugin type instance
+    :param data: Data for the plugin type instance
 
 
 .. function:: create_page_user(created_by, user, can_add_page=True, can_change_page=True, can_delete_page=True, can_recover_page=True, can_add_pageuser=True, can_change_pageuser=True, can_delete_pageuser=True, can_add_pagepermission=True, can_change_pagepermission=True, can_delete_pagepermission=True, grant_all=False)
@@ -145,15 +145,15 @@ Functions and constants
 .. function:: assign_user_to_page(page, user, grant_on=ACCESS_PAGE_AND_DESCENDANTS, can_add=False, can_change=False, can_delete=False, can_change_advanced_settings=False, can_publish=False, can_change_permissions=False, can_move_page=False, grant_all=False)
 
     Assigns a user to a page and gives them some permissions. Returns the
-    :class:`cms.models.permissionmodels.PagePermission` object that gets
+    :class:`cms.models.PagePermission` object that gets
     created.
 
     :param page: The page to assign the user to
-    :type page: :class:`cms.models.pagemodel.Page` instance
+    :type page: :class:`cms.models.Page` instance
     :param user: The user to assign to the page
     :type user: :class:`django.contrib.auth.models.User` instance
     :param grant_on: Controls which pages are affected
-    :type grant_on: :data:`cms.models.permissionmodels.ACCESS_PAGE`, :data:`cms.models.permissionmodels.ACCESS_CHILDREN`, :data:`cms.models.permissionmodels.ACCESS_DESCENDANTS` or :data:`cms.models.permissionmodels.ACCESS_PAGE_AND_DESCENDANTS`
+    :type grant_on: :data:`cms.models.ACCESS_PAGE`, :data:`cms.models.ACCESS_CHILDREN`, :data:`cms.models.ACCESS_DESCENDANTS` or :data:`cms.models.ACCESS_PAGE_AND_DESCENDANTS`
     :param can_*: Permissions to grant
     :param bool grant_all: Grant all permissions to the user
 
@@ -163,7 +163,7 @@ Functions and constants
     Publishes a page.
 
     :param page: The page to publish
-    :type page: :class:`cms.models.pagemodel.Page` instance
+    :type page: :class:`cms.models.Page` instance
     :param user: The user that performs this action
     :type user: :class:`django.contrib.auth.models.User` instance
     :param string language: The target language to publish to
@@ -183,7 +183,7 @@ Functions and constants
     page is a published version or a draft version.
 
     :param page: The page to get the draft version
-    :type page: :class:`cms.models.pagemodel.Page` instance
+    :type page: :class:`cms.models.Page` instance
     :return page: draft version of the page
 
 .. function:: copy_plugins_to_language(page, source_language, target_language, only_empty=True):
@@ -196,7 +196,7 @@ Functions and constants
     .. warning:: This function skips permissions checks
 
     :param page: the page to copy
-    :type page: :class:`cms.models.pagemodel.Page` instance
+    :type page: :class:`cms.models.Page` instance
     :param string source_language: The source language code, must be in :setting:`django:LANGUAGES`
     :param string target_language: The source language code, must be in :setting:`django:LANGUAGES`
     :param bool only_empty: if False, plugin are copied even if plugins exists in the
@@ -251,15 +251,15 @@ cms.constants
 cms.app_base
 ************
 
-.. module:: cms.app_base
+..  module:: cms.app_base
 
-.. autoclass:: CMSApp
+..  class:: CMSApp
 
     .. attribute:: _urls
 
         list of urlconfs: example: ``_urls = ["myapp.urls"]``
 
-    .. attribute:: _menus = []
+    .. attribute:: _menus
 
         list of menu classes: example: ``_menus = [MyAppMenu]``
 
@@ -307,7 +307,7 @@ cms.app_base
             Returns the menus for the apphook instance, selected according
             to the given arguments.
 
-            By default it returns the menus assigned to :py:attr:`CMSApp._menus`.
+            By default it returns the menus assigned to :attr:`_menus`
 
             If no page and language are provided, this method **must** return all the
             menus used by this apphook. Example::
@@ -330,7 +330,7 @@ cms.app_base
             Returns the URL configurations for the apphook instance, selected
             according to the given arguments.
 
-            By default it returns the URLs assigned to :attr:`CMSApp._urls`
+            By default it returns the urls assigned to :attr:`_urls`
 
             This method **must** return a non empty list of URL configurations,
             even if no arguments are passed.
@@ -338,539 +338,3 @@ cms.app_base
             :param page: page the apphook is attached to
             :param language: current site language
             :return: list of strings representing URL configurations
-
-***************
-cms.plugin_base
-***************
-
-.. module:: cms.plugin_base
-
-.. class:: CMSPluginBase
-
-    Inherits ``django.contrib.admin.options.ModelAdmin``.
-
-    .. attribute:: admin_preview
-
-        Defaults to ``False``, if ``True``, displays a preview in the admin.
-
-    .. attribute:: cache
-
-        If present and set to ``False``, the plugin will prevent the caching of
-        the resulting page.
-
-        .. important:: Setting this to ``False`` will effectively disable the
-                       CMS page cache and all upstream caches for pages where
-                       the plugin appears. This may be useful in certain cases
-                       but for general cache management, consider using the much
-                       more capable :meth:`get_cache_expiration`.
-
-    .. attribute:: change_form_template
-
-        Custom template to use to render the form to edit this plugin.
-
-    .. attribute:: form
-
-        Custom form class to be used to edit this plugin.
-
-    .. method:: get_plugin_urls(instance)
-
-        Returns URL patterns for which the plugin wants to register views for.
-        They are included under django CMS PageAdmin in the plugin path
-        (e.g.: ``/admin/cms/page/plugin/<plugin-name>/`` in the default case).
-        Useful if your plugin needs to asynchronously talk to the admin.
-
-    .. attribute:: model
-
-        Is the :class:`CMSPlugin` model we created earlier. If you don't need
-        model because you just want to display some template logic, use
-        :class:`CMSPlugin` from :mod:`cms.models` as the model instead.
-
-    .. attribute:: module
-
-        Will group the plugin in the plugin editor. If module is ``None``,
-        plugin is grouped "Generic" group.
-
-    .. attribute:: name
-
-        Will be displayed in the plugin editor.
-
-    .. attribute:: render_plugin
-
-        If set to ``False``, this plugin will not be rendered at all.
-
-    .. attribute:: render_template
-
-        Will be rendered with the context returned by the render function.
-
-    .. attribute:: text_enabled
-
-        Whether this plugin can be used in text plugins or not.
-
-    .. method:: icon_alt(instance)
-
-        Returns the alt text for the icon used in text plugins, see
-        :meth:`icon_src`.
-
-    .. method:: icon_src(instance)
-
-        Returns the URL to the icon to be used for the given instance when that
-        instance is used inside a text plugin.
-
-    .. method:: get_cache_expiration(request, instance, placeholder)
-
-        Provides expiration value to the placeholder, and in turn to the page
-        for determining the appropriate Cache-Control headers to add to the
-        HTTPResponse object.
-
-        Must return one of:
-
-            :``None``:
-                This means the placeholder and the page will not even consider
-                this plugin when calculating the page expiration.
-
-            :``datetime``:
-                A specific date and time (timezone-aware) in the future when
-                this plugin's content expires.
-
-                .. important:: The returned ``datetime`` must be timezone-aware
-                               or the plugin will be ignored (with a warning)
-                               during expiration calculations.
-
-            :``int``:
-                An number of seconds that this plugin's content can be cached.
-
-        There are constants are defined in ``cms.constants`` that may be
-        useful: :data:`EXPIRE_NOW` and :data:`MAX_EXPIRATION_TTL`.
-
-        An integer value of ``0`` (zero) or :data:`EXPIRE_NOW` effectively means
-        "do not cache". Negative values will be treated as :data:`EXPIRE_NOW`.
-        Values exceeding the value :data:`MAX_EXPIRATION_TTL` will be set to
-        that value.
-
-        Negative ``timedelta`` values or those greater than :data:`MAX_EXPIRATION_TTL`
-        will also be ranged in the same manner.
-
-        Similarly, ``datetime`` values earlier than now will be treated as
-        :data:`EXPIRE_NOW`. Values greater than :data:`MAX_EXPIRATION_TTL` seconds in the
-        future will be treated as :data:`MAX_EXPIRATION_TTL` seconds in the future.
-
-        :param request: Relevant ``HTTPRequest`` instance.
-        :param instance: The ``CMSPlugin`` instance that is being rendered.
-        :rtype: ``None`` or ``datetime`` or ``int``
-
-
-    .. method:: get_vary_cache_on(request, instance, placeholder)
-
-        Provides ``VARY`` header strings to be considered by the placeholder
-        and in turn by the page.
-
-        Must return one of:
-
-            :``None``:
-                This means that this plugin declares no headers for the cache
-                to be varied upon. (default)
-
-            :string:
-                The name of a header to vary caching upon.
-
-            :list of strings:
-                A list of strings, each corresponding to a header to vary the
-                cache upon.
-
-
-    .. method:: render(context, instance, placeholder)
-
-        This method returns the context to be used to render the template
-        specified in :attr:`render_template`.
-
-        It's recommended to always populate the context with default values
-        by calling the render method of the super class::
-
-            def render(self, context, instance, placeholder):
-                context = super(MyPlugin, self).render(context, instance, placeholder)
-                ...
-                return context
-
-
-        :param context: Current template context.
-        :param instance: Plugin instance that is being rendered.
-        :param placeholder: Name of the placeholder the plugin is in.
-        :rtype: ``dict``
-
-
-.. class:: PluginMenuItem
-
-    .. method:: __init___(name, url, data, question=None, action='ajax', attributes=None)
-
-        Creates an item in the plugin / placeholder menu
-
-        :param name: Item name (label)
-        :param url: URL the item points to. This URL will be called using POST
-        :param data: Data to be POSTed to the above URL
-        :param question: Confirmation text to be shown to the user prior to call the given URL (optional)
-        :param action: Custom action to be called on click; currently supported: 'ajax', 'ajax_add'
-        :param attributes: Dictionary whose content will be addes as data-attributes to the menu item
-
-.. _toolbar-api-reference:
-
-***********
-cms.toolbar
-***********
-
-
-All methods taking a ``side`` argument expect either
-:data:`cms.constants.LEFT` or :data:`cms.constants.RIGHT` for that
-argument.
-
-Methods accepting the ``position`` argument can insert items at a specific
-position. This can be either ``None`` to insert at the end, an integer
-index at which to insert the item, a :class:`cms.toolbar.items.ItemSearchResult` to insert
-it *before* that search result or a :class:`cms.toolbar.items.BaseItem` instance to insert
-it *before* that item.
-
-
-cms.toolbar.toolbar
-===================
-
-.. module:: cms.toolbar.toolbar
-
-
-.. class:: CMSToolbar
-
-    The toolbar class providing a Python API to manipulate the toolbar. Note
-    that some internal attributes are not documented here.
-
-    All methods taking a ``position`` argument expect either
-    :data:`cms.constants.LEFT` or :data:`cms.constants.RIGHT` for that
-    argument.
-
-    This class inherits :class:`cms.toolbar.items.ToolbarMixin`, so please
-    check that reference as well.
-
-    .. attribute:: is_staff
-
-        Whether the current user is a staff user or not.
-
-    .. attribute:: edit_mode
-
-        Whether the toolbar is in edit mode.
-
-    .. attribute:: build_mode
-
-        Whether the toolbar is in build mode.
-
-    .. attribute:: show_toolbar
-
-        Whether the toolbar should be shown or not.
-
-    .. attribute:: csrf_token
-
-        The CSRF token of this request
-
-    .. attribute:: toolbar_language
-
-        Language used by the toolbar.
-
-    .. attribute:: watch_models
-
-        A list of models this toolbar works on; used for redirection after editing
-        (:ref:`url_changes`).
-
-    .. method:: add_item(item, position=None)
-
-        Low level API to add items.
-
-        Adds an item, which must be an instance of
-        :class:`cms.toolbar.items.BaseItem`, to the toolbar.
-
-        This method should only be used for custom item classes, as all built-in
-        item classes have higher level APIs.
-
-        Read above for information on ``position``.
-
-    .. method:: remove_item(item)
-
-        Removes an item from the toolbar or raises a :exc:`KeyError` if it's
-        not found.
-
-    .. method:: get_or_create_menu(key. verbose_name, side=LEFT, position=NOne)
-
-        If a menu with ``key`` already exists, this method will return that
-        menu. Otherwise it will create a menu for that ``key`` with the given
-        ``verbose_name`` on ``side`` at ``position`` and return it.
-
-    .. method:: add_button(name, url, active=False, disabled=False, extra_classes=None, extra_wrapper_classes=None, side=LEFT, position=None)
-
-        Adds a button to the toolbar. ``extra_wrapper_classes`` will be applied
-        to the wrapping ``div`` while ``extra_classes`` are applied to the
-        ``<a>``.
-
-    .. method:: add_button_list(extra_classes=None, side=LEFT, position=None)
-
-        Adds an (empty) button list to the toolbar and returns it. See
-        :class:`cms.toolbar.items.ButtonList` for further information.
-
-
-cms.toolbar.items
-=================
-
-.. important:: **Overlay** and **sideframe**
-
-    Then django CMS *sideframe* has been replaced with an *overlay* mechanism. The API still refers
-    to the ``sideframe``, because it is invoked in the same way, and what has changed is merely the
-    behaviour in the user's browser.
-
-    In other words, *sideframe* and the *overlay* refer to different versions of the same thing.
-
-.. module:: cms.toolbar.items
-
-
-.. class:: ItemSearchResult
-
-    Used for the find APIs in :class:`ToolbarMixin`. Supports addition and
-    subtraction of numbers. Can be cast to an integer.
-
-    .. attribute:: item
-
-        The item found.
-
-    .. attribute:: index
-
-        The index of the item.
-
-.. class:: ToolbarMixin
-
-    Provides APIs shared between :class:`cms.toolbar.toolbar.CMSToolbar` and
-    :class:`Menu`.
-
-    The ``active`` and ``disabled`` flags taken by all methods of this class
-    specify the state of the item added.
-
-    ``extra_classes`` should be either ``None`` or a list of class names as
-    strings.
-
-    .. attribute:: REFRESH_PAGE
-
-        Constant to be used with ``on_close`` to refresh the current page when
-        the frame is closed.
-
-    .. attribute:: LEFT
-
-        Constant to be used with ``side``.
-
-    .. attribute:: RIGHT
-
-        Constant to be used with ``side``.
-
-    .. method:: get_item_count
-
-        Returns the number of items in the toolbar or menu.
-
-    .. method:: add_item(item, position=None)
-
-        Low level API to add items, adds the ``item`` to the toolbar or menu
-        and makes it searchable. ``item`` must be an instance of
-        :class:`BaseItem`. Read above for information about the ``position``
-        argument.
-
-    .. method:: remove_item(item)
-
-        Removes ``item`` from the toolbar or menu. If the item can't be found,
-        a :exc:`KeyError` is raised.
-
-    .. method:: find_items(item_type, **attributes)
-
-        Returns a list of :class:`ItemSearchResult` objects matching all items
-        of ``item_type``, which must be a sub-class of :class:`BaseItem`, where
-        all attributes in ``attributes`` match.
-
-    .. method:: find_first(item_type, **attributes)
-
-        Returns the first :class:`ItemSearchResult` that matches the search or
-        ``None``. The search strategy is the same as in :meth:`find_items`.
-        Since positional insertion allows ``None``, it's safe to use the return
-        value of this method as the position argument to insertion APIs.
-
-    .. method:: add_sideframe_item(name, url, active=False, disabled=False, extra_classes=None, on_close=None, side=LEFT, position=None)
-
-        Adds an item which opens ``url`` in the sideframe and returns it.
-
-        ``on_close`` can be set to ``None`` to do nothing when the sideframe
-        closes, :attr:`REFRESH_PAGE` to refresh the page when it
-        closes or a URL to open once it closes.
-
-    .. method:: add_modal_item(name, url, active=False, disabled=False, extra_classes=None, on_close=REFRESH_PAGE, side=LEFT, position=None)
-
-        The same as :meth:`add_sideframe_item`, but opens the ``url`` in a
-        modal dialog instead of the sideframe.
-
-        ``on_close`` can be set to ``None`` to do nothing when the side modal
-        closes, :attr:`REFRESH_PAGE` to refresh the page when it
-        closes or a URL to open once it closes.
-
-        Note: The default value for ``on_close`` is different in :meth:`add_sideframe_item` then in :meth:`add_modal_item`
-
-    .. method:: add_link_item(name, url, active=False, disabled=False, extra_classes=None, side=LEFT, position=None)
-
-        Adds an item that simply opens ``url`` and returns it.
-
-    .. method:: add_ajax_item(name, action, active=False, disabled=False, extra_classes=None, data=None, question=None, side=LEFT, position=None)
-
-        Adds an item which sends a POST request to ``action`` with ``data``.
-        ``data`` should be ``None`` or a dictionary, the CSRF token will
-        automatically be added to it.
-
-        If ``question`` is set to a string, it will be asked before the
-        request is sent to confirm the user wants to complete this action.
-
-
-.. class:: BaseItem(position)
-
-    Base item class.
-
-    .. attribute:: template
-
-        Must be set by sub-classes and point to a Django template
-
-    .. attribute:: side
-
-        Must be either :data:`cms.constants.LEFT` or
-        :data:`cms.constants.RIGHT`.
-
-    .. method:: render()
-
-        Renders the item and returns it as a string. By default calls
-        :meth:`get_context` and renders :attr:`template` with the context
-        returned.
-
-    .. method:: get_context()
-
-        Returns the context (as dictionary) for this item.
-
-
-.. class:: Menu(name, csrf_token, side=LEFT, position=None)
-
-    The menu item class. Inherits :class:`ToolbarMixin` and provides the APIs
-    documented on it.
-
-    The ``csrf_token`` must be set as this class provides high level APIs to
-    add items to it.
-
-    .. method:: get_or_create_menu(key, verbose_name, side=LEFT, position=None)
-
-        The same as :meth:`cms.toolbar.toolbar.CMSToolbar.get_or_create_menu` but adds
-        the menu as a sub menu and returns a :class:`SubMenu`.
-
-    .. method:: add_break(identifier=None, position=None)
-
-        Adds a visual break in the menu, useful for grouping items, and
-        returns it. ``identifier`` may be used to make this item searchable.
-
-
-.. class:: SubMenu(name, csrf_token, side=LEFT, position=None)
-
-    Same as :class:`Menu` but without the :meth:`Menu.get_or_create_menu` method.
-
-
-.. class:: LinkItem(name, url, active=False, disabled=False, extra_classes=None, side=LEFT)
-
-    Simple link item.
-
-
-.. class:: SideframeItem(name, url, active=False, disabled=False, extra_classes=None, on_close=None, side=LEFT)
-
-    Item that opens ``url`` in sideframe.
-
-
-.. class:: AjaxItem(name, action, csrf_token, data=None, active=False, disabled=False, extra_classes=None, question=None, side=LEFT)
-
-    An item which posts ``data`` to ``action``.
-
-
-.. class:: ModalItem(name, url, active=False, disabled=False, extra_classes=None, on_close=None, side=LEFT)
-
-    Item that opens ``url`` in the modal.
-
-
-.. class:: Break(identifier=None)
-
-    A visual break for menus. ``identifier`` may be provided to make this item
-    searchable. Since breaks can only be within menus, they have no ``side``
-    attribute.
-
-
-.. class:: ButtonList(identifier=None, extra_classes=None, side=LEFT)
-
-    A list of one or more buttons.
-
-    The ``identifier`` may be provided to make this item searchable.
-
-    .. method:: add_item(item)
-
-        Adds ``item`` to the list of buttons. ``item`` must be an instance of
-        :class:`Button`.
-
-    .. method:: add_button(name, url, active=False, disabled=False, extra_classes=None)
-
-        Adds a :class:`Button` to the list of buttons and returns it.
-
-
-.. class:: Button(name, url, active=False, disabled=False, extra_classes=None)
-
-    A button to be used with :class:`ButtonList`. Opens ``url`` when selected.
-
-
-**********
-menus.base
-**********
-
-.. module:: menus.base
-
-.. class:: NavigationNode(title, url, id[, parent_id=None][, parent_namespace=None][, attr=None][, visible=True])
-
-    A navigation node in a menu tree.
-
-    :param string title: The title to display this menu item with.
-    :param string url: The URL associated with this menu item.
-    :param id: Unique (for the current tree) ID of this item.
-    :param parent_id: Optional, ID of the parent item.
-    :param parent_namespace: Optional, namespace of the parent.
-    :param dict attr: Optional, dictionary of additional information to store on
-                      this node.
-    :param bool visible: Optional, defaults to ``True``, whether this item is
-                         visible or not.
-
-
-    .. attribute:: attr
-
-        A dictionary of various additional information describing the node.
-        Nodes that represent CMS pages have the following keys in attr:
-
-        * **auth_required** (*bool*) – is authentication required to access this page
-        * **is_page** (*bool*) – Always True
-        * **navigation_extenders** (*list*) – navigation extenders connected to this node (including Apphooks)
-        * **redirect_url** (*str*) – redirect URL of page (if any)
-        * **reverse_id** (*str*) – unique identifier for the page
-        * **soft_root** (*bool*) – whether page is a soft root
-        * **visible_for_authenticated** (*bool*) – visible for authenticated users
-        * **visible_for_anonymous** (*bool*) – visible for anonymous users
-
-    .. method:: get_descendants
-
-        Returns a list of all children beneath the current menu item.
-
-    .. method:: get_ancestors
-
-        Returns a list of all parent items, excluding the current menu item.
-
-    .. method:: get_absolute_url
-
-        Utility method to return the URL associated with this menu item,
-        primarily to follow naming convention asserted by Django.
-
-    .. method:: get_menu_title
-
-        Utility method to return the associated title, using the same naming
-        convention used by :class:`cms.models.pagemodel.Page`.
-
-

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -7,6 +7,7 @@ Configuration
 django CMS has a number of settings to configure its behaviour. These should
 be available in your ``settings.py`` file.
 
+
 .. _installed_apps:
 
 ******************************
@@ -43,7 +44,7 @@ the classes as possible.
 Custom User Requirements
 ************************
 
-.. setting:: AUTH_USER_MODEL
+..  setting:: AUTH_USER_MODEL
 
 When using a custom user model (i.e. the ``AUTH_USER_MODEL`` Django setting), there are a few
 requirements that must be met.
@@ -68,13 +69,11 @@ Additionally, the application in which the model is defined **must** be loaded b
     only at the beginning of a project, before the database is created.
 
 
-
-
 *****************
 Required Settings
 *****************
 
-.. setting:: CMS_TEMPLATES
+..  setting:: CMS_TEMPLATES
 
 CMS_TEMPLATES
 =============
@@ -115,7 +114,7 @@ Example::
 Basic Customisation
 *******************
 
-.. setting:: CMS_TEMPLATE_INHERITANCE
+..  setting:: CMS_TEMPLATE_INHERITANCE
 
 CMS_TEMPLATE_INHERITANCE
 ========================
@@ -129,7 +128,7 @@ When enabled, pages' ``Template`` options will include a new default: *Inherit
 from the parent page* (unless the page is a root page).
 
 
-.. setting:: CMS_TEMPLATES_DIR
+..  setting:: CMS_TEMPLATES_DIR
 
 CMS_TEMPLATES_DIR
 =================
@@ -167,7 +166,7 @@ as keys and template names as values::::
 Being a normal python file, templates labels can be passed through gettext
 for translation.
 
-.. note::
+..  note::
 
     As templates are still loaded by the Django template loader, the given
     directory **must** be reachable by the template loading system.
@@ -175,7 +174,7 @@ for translation.
     supported.
 
 
-.. setting:: CMS_PLACEHOLDER_CONF
+..  setting:: CMS_PLACEHOLDER_CONF
 
 CMS_PLACEHOLDER_CONF
 ====================
@@ -385,8 +384,8 @@ matches; if the same configuration is retrieved for the ``content`` placeholder 
     and just overwrites the ``plugins`` setting to allow ``TeaserPlugin``, thus you
     have not to duplicate the configuration of ``content``.
 
-.. setting:: CMS_PLUGIN_CONTEXT_PROCESSORS
 
+..  setting:: CMS_PLUGIN_CONTEXT_PROCESSORS
 
 CMS_PLUGIN_CONTEXT_PROCESSORS
 =============================
@@ -398,8 +397,8 @@ A list of plugin context processors. Plugin context processors are callables
 that modify all plugins' context *before* rendering. See
 :doc:`/how_to/custom_plugins` for more information.
 
-.. setting:: CMS_PLUGIN_PROCESSORS
 
+..  setting:: CMS_PLUGIN_PROCESSORS
 
 CMS_PLUGIN_PROCESSORS
 =====================
@@ -411,7 +410,7 @@ A list of plugin processors. Plugin processors are callables that modify all
 plugins' output *after* rendering. See :doc:`/how_to/custom_plugins`
 for more information.
 
-.. setting:: CMS_APPHOOKS
+..  setting:: CMS_APPHOOKS
 
 
 CMS_APPHOOKS
@@ -440,10 +439,11 @@ Example::
 I18N and L10N
 *************
 
-.. setting:: CMS_LANGUAGES
-
 CMS_LANGUAGES
 =============
+
+..  setting:: CMS_LANGUAGES
+
 
 default
     Value of :setting:`django:LANGUAGES` converted to this format
@@ -522,8 +522,8 @@ language.
 
 What are the properties a language node can have?
 
-.. setting::code
 
+..  setting:: code
 
 code
 ----
@@ -542,7 +542,7 @@ String. The verbose name of the language.
 .. note:: Is required for every language.
 
 
-.. setting::public
+..  setting:: public
 
 public
 ------
@@ -553,8 +553,8 @@ type
 default
     ``True``
 
-.. setting::fallbacks
 
+..  setting:: fallbacks
 
 fallbacks
 ---------
@@ -566,8 +566,8 @@ example
 default
     ``[]``
 
-.. setting::hide_untranslated
 
+..  setting:: hide_untranslated
 
 hide_untranslated
 -----------------
@@ -578,8 +578,8 @@ type
 default
     ``True``
 
-.. setting::redirect_on_fallback
 
+.. setting:: redirect_on_fallback
 
 redirect_on_fallback
 --------------------
@@ -608,7 +608,7 @@ unihandecode.js, at least :setting:`CMS_UNIHANDECODE_HOST` and
 :setting:`CMS_UNIHANDECODE_VERSION` must be set.
 
 
-.. setting:: CMS_UNIHANDECODE_HOST
+..  setting:: CMS_UNIHANDECODE_HOST
 
 CMS_UNIHANDECODE_HOST
 ---------------------
@@ -630,7 +630,7 @@ If set to ``None``, the default, unihandecode.js is not used.
     can be cached by the browser for a very long period.
 
 
-.. setting:: CMS_UNIHANDECODE_VERSION
+..  setting:: CMS_UNIHANDECODE_VERSION
 
 CMS_UNIHANDECODE_VERSION
 ------------------------
@@ -644,7 +644,7 @@ URLs for the javascript files. URLs are built like this:
 ``<CMS_UNIHANDECODE_HOST>-<CMS_UNIHANDECODE_VERSION>.<DECODER>.min.js``.
 
 
-.. setting:: CMS_UNIHANDECODE_DECODERS
+..  setting:: CMS_UNIHANDECODE_DECODERS
 
 CMS_UNIHANDECODE_DECODERS
 -------------------------
@@ -655,7 +655,7 @@ default
 If you add additional decoders to your :setting:`CMS_UNIHANDECODE_HOST`, you can add them to this setting.
 
 
-.. setting:: CMS_UNIHANDECODE_DEFAULT_DECODER
+..  setting:: CMS_UNIHANDECODE_DEFAULT_DECODER
 
 CMS_UNIHANDECODE_DEFAULT_DECODER
 --------------------------------
@@ -697,7 +697,8 @@ More documentation is available on `unihandecode.js' Read the Docs <https://unih
 Media Settings
 **************
 
-.. setting:: CMS_MEDIA_PATH
+
+..  setting:: CMS_MEDIA_PATH
 
 CMS_MEDIA_PATH
 ==============
@@ -708,7 +709,7 @@ default
 The path from :setting:`django:MEDIA_ROOT` to the media files located in ``cms/media/``
 
 
-.. setting:: CMS_MEDIA_ROOT
+..  setting:: CMS_MEDIA_ROOT
 
 CMS_MEDIA_ROOT
 ==============
@@ -719,7 +720,7 @@ default
 The path to the media root of the cms media files.
 
 
-.. setting:: CMS_MEDIA_URL
+..  setting:: CMS_MEDIA_URL
 
 CMS_MEDIA_URL
 =============
@@ -730,7 +731,7 @@ default
 The location of the media files that are located in ``cms/media/cms/``
 
 
-.. setting:: CMS_PAGE_MEDIA_PATH
+..  setting:: CMS_PAGE_MEDIA_PATH
 
 CMS_PAGE_MEDIA_PATH
 ===================
@@ -750,7 +751,7 @@ user under which Django will be running.
 Advanced Settings
 *****************
 
-.. setting:: CMS_INTERNAL_IPS
+..  setting:: CMS_INTERNAL_IPS
 
 CMS_INTERNAL_IPS
 ================
@@ -772,7 +773,7 @@ The client IP address is obtained via the :setting:`CMS_REQUEST_IP_RESOLVER`
 in the ``cms.middleware.toolbar.ToolbarMiddleware`` middleware.
 
 
-.. setting:: CMS_REQUEST_IP_RESOLVER
+..  setting:: CMS_REQUEST_IP_RESOLVER
 
 CMS_REQUEST_IP_RESOLVER
 =======================
@@ -790,7 +791,7 @@ The supplied method should accept a single argument `request` and return an
 IP address String.
 
 
-.. setting:: CMS_PERMISSION
+..  setting:: CMS_PERMISSION
 
 CMS_PERMISSION
 ==============
@@ -816,7 +817,7 @@ Naturally he can limit the rights of the users he creates even further,
 allowing them to see only a subset of the pages to which he is allowed access.
 
 
-.. setting:: CMS_RAW_ID_USERS
+..  setting:: CMS_RAW_ID_USERS
 
 CMS_RAW_ID_USERS
 ================
@@ -845,10 +846,10 @@ performance.
           benefit from this setting.
 
 .. versionchanged:: 3.2.1: CMS_RAW_ID_USERS also applies to
-                           :class:`cms.model.GlobalPagePermission`` admin.
+                           ``GlobalPagePermission`` admin.
 
 
-.. setting:: CMS_PUBLIC_FOR
+..  setting:: CMS_PUBLIC_FOR
 
 CMS_PUBLIC_FOR
 ==============
@@ -860,7 +861,7 @@ Determines whether pages without any view restrictions are public by default or
 staff only. Possible values are ``all`` and ``staff``.
 
 
-.. setting:: CMS_CACHE_DURATIONS
+..  setting:: CMS_CACHE_DURATIONS
 
 CMS_CACHE_DURATIONS
 ===================
@@ -879,7 +880,7 @@ template tags.
 
 .. note::
 
-    This settings was previously called :setting:`CMS_CONTENT_CACHE_DURATION`
+    This settings was previously called ``CMS_CONTENT_CACHE_DURATION``
 
 
 ``'menus'``
@@ -892,7 +893,7 @@ Cache expiration (in seconds) for the menu tree.
 
 .. note::
 
-    This settings was previously called :setting:`MENU_CACHE_DURATION`
+    This settings was previously called ``MENU_CACHE_DURATION``
 
 
 ``'permissions'``
@@ -904,7 +905,7 @@ default
 Cache expiration (in seconds) for view and other permissions.
 
 
-.. setting:: CMS_CACHE_PREFIX
+..  setting:: CMS_CACHE_PREFIX
 
 CMS_CACHE_PREFIX
 ================
@@ -921,13 +922,13 @@ Example::
 
     CMS_CACHE_PREFIX = 'mysite-live'
 
-.. note::
+..  note::
 
     Django 1.3 introduced a site-wide cache key prefix. See Django's own docs
     on :ref:`cache key prefixing <django:cache_key_prefixing>`
 
 
-.. setting:: CMS_PAGE_CACHE
+..  setting:: CMS_PAGE_CACHE
 
 CMS_PAGE_CACHE
 ==============
@@ -940,7 +941,7 @@ Takes the language, and time zone into account. Pages for logged in users are no
 If the toolbar is visible the page is not cached as well.
 
 
-.. setting:: CMS_PLACEHOLDER_CACHE
+..  setting:: CMS_PLACEHOLDER_CACHE
 
 CMS_PLACEHOLDER_CACHE
 =====================
@@ -953,7 +954,7 @@ Takes the current language and time zone into account. If the toolbar is in edit
 present the placeholders will not be cached.
 
 
-.. setting:: CMS_PLUGIN_CACHE
+..  setting:: CMS_PLUGIN_CACHE
 
 CMS_PLUGIN_CACHE
 ================
@@ -967,7 +968,7 @@ Default value of the ``cache`` attribute of plugins. Should plugins be cached by
     If you disable the plugin cache be sure to restart the server and clear the cache afterwards.
 
 
-.. setting:: CMS_MAX_PAGE_PUBLISH_REVERSIONS
+..  setting:: CMS_MAX_PAGE_PUBLISH_REVERSIONS
 
 CMS_MAX_PAGE_HISTORY_REVERSIONS
 ===============================
@@ -1005,7 +1006,7 @@ If set to *0* all published revisions are kept, but you will need to ensure
 that the revision table does not grow excessively large.
 
 
-.. setting:: CMS_TOOLBARS
+..  setting:: CMS_TOOLBARS
 
 CMS_TOOLBARS
 ============
@@ -1069,6 +1070,7 @@ This should be an integer preferably taken from the ``cms.constants`` e.g.
 - X_FRAME_OPTIONS_SAMEORIGIN
 - X_FRAME_OPTIONS_DENY
 
+
 .. _CMS_TOOLBAR_SIMPLE_STRUCTURE_MODE:
 
 CMS_TOOLBAR_SIMPLE_STRUCTURE_MODE
@@ -1087,7 +1089,7 @@ Example::
     CMS_TOOLBAR_SIMPLE_STRUCTURE_MODE = False
 
 
-.. setting:: CMS_PAGE_WIZARD_DEFAULT_TEMPLATE
+..  setting:: CMS_PAGE_WIZARD_DEFAULT_TEMPLATE
 
 CMS_PAGE_WIZARD_DEFAULT_TEMPLATE
 ================================
@@ -1098,7 +1100,7 @@ default
 This is the path of the template used to create pages in the wizard. It must be
 one of the templates in :setting:`CMS_TEMPLATES`.
 
-.. setting:: CMS_PAGE_WIZARD_CONTENT_PLACEHOLDER
+..  setting:: CMS_PAGE_WIZARD_CONTENT_PLACEHOLDER
 
 CMS_PAGE_WIZARD_CONTENT_PLACEHOLDER
 ===================================
@@ -1112,7 +1114,8 @@ adding any content supplied in the wizards' "Content" field. If this is left
 unset, then the content will target the first suitable placeholder found on
 the page's template.
 
-.. setting:: CMS_PAGE_WIZARD_CONTENT_PLUGIN
+
+..  setting:: CMS_PAGE_WIZARD_CONTENT_PLUGIN
 
 CMS_PAGE_WIZARD_CONTENT_PLUGIN
 ==============================
@@ -1124,7 +1127,7 @@ This is the name of the plugin created in the Page Wizard when the "Content"
 field is filled in. There should be no need to change it, unless you
 **don't** use ``djangocms-text-ckeditor`` in your project.
 
-.. setting:: CMS_PAGE_WIZARD_CONTENT_PLUGIN_BODY
+..  setting:: CMS_PAGE_WIZARD_CONTENT_PLUGIN_BODY
 
 CMS_PAGE_WIZARD_CONTENT_PLUGIN_BODY
 ===================================
@@ -1137,3 +1140,31 @@ when the "Content" field is filled in. There should be no need to change it,
 unless you **don't** use ``djangocms-text-ckeditor`` in your project **and**
 your custom plugin defined in :setting:`CMS_PAGE_WIZARD_CONTENT_PLUGIN` have a
 body field **different** than ``body``.
+
+
+..  setting:: CMS_UNESCAPED_RENDER_MODEL_TAGS
+
+CMS_UNESCAPED_RENDER_MODEL_TAGS
+===================================
+
+..  versionadded:: 3.2.4
+
+default
+    True
+
+To immediately improve the security of your project and to prepare for
+future releases of django CMS and related addons, the project
+administrator should carefully review each use of the ``render_model``
+template tags provided by django CMS. He or she is encouraged to ensure
+that all content which is rendered to a page using this template tag is
+cleansed of any potentially harmful HTML markup, CSS styles or JavaScript.
+Once the administrator or developer is satisfied that the content is
+clean, he or she can add the "safe" filter parameter to the render_model
+template tag if the content should be rendered without escaping. If there
+is no need to render the content unescaped, no further action
+is required.
+
+Once all template tags have been reviewed and adjusted where necessary,
+the administrator should set ``CMS_UNESCAPED_RENDER_MODEL_TAGS = False``
+in the project settings. At that point, the project is more secure and
+will be ready for any future upgrades.

--- a/docs/reference/fields.rst
+++ b/docs/reference/fields.rst
@@ -10,11 +10,16 @@ Model fields
 
 .. py:class:: cms.models.fields.PageField
 
-    This is a foreign key field to the :class:`cms.models.pagemodel.Page` model
+    This is a foreign key field to the :class:`cms.models.Page` model
     that defaults to the :class:`cms.forms.fields.PageSelectFormField` form
     field when rendered in forms. It has the same API as the
-    :class:`django.db.models.fields.related.ForeignKey` but does not require
+    :class:`django:django.db.models.ForeignKey` but does not require
     the ``othermodel`` argument.
+
+
+.. py:class:: cms.models.fields.PlaceholderField
+
+    A foreign key field to the :class:`cms.models.placeholdermodel.Placeholder` model.
 
 
 ***********
@@ -24,20 +29,21 @@ Form fields
 
 .. py:class:: cms.forms.fields.PageSelectFormField
 
-    Behaves like a :class:`django.forms.models.ModelChoiceField` field for the
-    :class:`cms.models.pagemodel.Page` model, but displays itself as a split
+    Behaves like a :class:`django.forms.ModelChoiceField` field for the
+    :class:`cms.models.Page` model, but displays itself as a split
     field with a select drop-down for the site and one for the page. It also
     indents the page names based on what level they're on, so that the page
     select drop-down is easier to use. This takes the same arguments as
-    :class:`django.forms.models.ModelChoiceField`.
+    :class:`django.forms.ModelChoiceField`.
 
 .. py:class:: cms.forms.fields.PageSmartLinkField
 
-    A field making use of :class:`cms.forms.widgets.PageSmartLinkWidget`.
+    A field making use of ``cms.forms.widgets.PageSmartLinkWidget``.
     This field will offer you a list of matching internal pages as you type.
     You can either pick one or enter an arbitrary URL to create a non existing entry.
     Takes a `placeholder_text` argument to define the text displayed inside the
     input before you type.
+
     The widget uses an ajax request to try to find pages match. It will try to find
     case insensitive matches amongst public and published pages on the `title`, `path`,
     `page_title`, `menu_title` fields.

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -9,11 +9,17 @@ Technical reference material.
 .. toctree::
     :maxdepth: 1
 
-    configuration
-    navigation
-    plugins
     api_references
-    fields
-    templatetags
     cli
+    configuration
+    fields
+    navigation
+    pages
+    permissions
+    placeholders
+    plugins
+    sitemaps
+    templatetags
+    titles
+    toolbar
     wizards

--- a/docs/reference/navigation.rst
+++ b/docs/reference/navigation.rst
@@ -15,13 +15,14 @@ menu:
 To use any of these template tags, you need to have ``{% load menu_tags %}`` in
 your template before the line on which you call the template tag.
 
-.. note::
+..  note::
 
-    Please note that menus live in the :mod:`menus` application, which though
-    tightly coupled to the :mod:`cms` application exists independently of it.
+    Please note that menus live in the ``menus`` application, which though
+    tightly coupled to the ``cms`` application exists independently of it.
     Menus are usable by any application, not just by django CMS.
 
-.. templatetag:: show_menu
+
+..  templatetag:: show_menu
 
 *********
 show_menu
@@ -84,6 +85,8 @@ Navigation with a custom template::
     {% show_menu 0 100 100 100 "myapp/menu.html" %}
 
 
+..  templatetag:: show_menu_below_id
+
 ******************
 show_menu_below_id
 ******************
@@ -106,7 +109,7 @@ Unlike :ttag:`show_menu`, however, soft roots will not affect the menu when
 using :ttag:`show_menu_below_id`.
 
 
-.. templatetag:: show_sub_menu
+..  templatetag:: show_sub_menu
 
 *************
 show_sub_menu
@@ -146,6 +149,7 @@ Or with a custom template::
         {% show_sub_menu 1 None 100 "myapp/submenu.html" %}
     </ul>
 
+..  templatetag:: show_breadcrumb
 
 ***************
 show_breadcrumb
@@ -250,9 +254,150 @@ If true this node is a :ref:`soft root <soft-root>`. A page can be marked as a *
 in its 'Advanced Settings'.
 
 
-
 ******************************
 Modifying & Extending the menu
 ******************************
 
 Please refer to the :doc:`/how_to/menus` documentation
+
+
+********************************
+Menu system classes and function
+********************************
+
+``menu`` application
+====================
+
+..  class:: menus.base.Menu
+
+    The base class for all menu-generating classes.
+
+    ..  method:: get_nodes(self, request)
+
+        Each sub-class of ``Menu`` should return a list of NavigationNode instances.
+
+
+..  class:: menus.base.Modifier
+
+    The base class for all menu-modifying classes. A modifier add, removes or changes NavigationNodes in the list.
+
+    ..  method:: modify(self, request, nodes, namespace, root_id, post_cut, breadcrumb)
+
+        Each sub-class of ``Modifier`` should implement a ``modify()`` method.
+
+
+..  class:: menus.menu_pool.MenuPool
+
+    ..  method:: get_nodes()
+
+    ..  method:: discover_menus()
+
+    ..  method:: apply_modifiers()
+
+    ..  method:: _build_nodes()
+
+    ..  method:: _mark_selected()
+
+
+..  function:: menus.menu_pool._build_nodes_inner_for_one_menu()
+
+
+..  function:: menus.templatetags.menu_tags.cut_levels()
+
+
+..  class:: menus.templatetags.menu_tags.ShowMenu
+
+    ..  method:: get_context()
+
+
+..  class:: menus.base.NavigationNode(title, url, id[, parent_id=None][, parent_namespace=None][, attr=None][, visible=True])
+
+    Each node in a menu tree is represented by a ``NavigationNode`` instance.
+
+    :param string title: The title to display this menu item with.
+    :param string url: The URL associated with this menu item.
+    :param id: Unique (for the current tree) ID of this item.
+    :param parent_id: Optional, ID of the parent item.
+    :param parent_namespace: Optional, namespace of the parent.
+    :param dict attr: Optional, dictionary of additional information to store on
+                      this node.
+    :param bool visible: Optional, defaults to ``True``, whether this item is
+                         visible or not.
+
+
+    .. attribute:: attr
+
+        A dictionary, provided in order that arbitrary attributes may be added to the node -
+        placing them directly on the node itself could cause a clash with an existing or future attribute.
+
+        An important key in this dictionary is ``is_page``: if ``True``, the node represents a django CMS ``Page``
+        object.
+
+        Nodes that represent CMS pages have the following keys in ``attr``:
+
+        * **auth_required** (*bool*) – is authentication required to access this page
+        * **is_page** (*bool*) – Always True
+        * **navigation_extenders** (*list*) – navigation extenders connected to this node (including Apphooks)
+        * **redirect_url** (*str*) – redirect URL of page (if any)
+        * **reverse_id** (*str*) – unique identifier for the page
+        * **soft_root** (*bool*) – whether page is a soft root
+        * **visible_for_authenticated** (*bool*) – visible for authenticated users
+        * **visible_for_anonymous** (*bool*) – visible for anonymous users
+
+    .. method:: get_descendants
+
+        Returns a list of all children beneath the current menu item.
+
+    .. method:: get_ancestors
+
+        Returns a list of all parent items, excluding the current menu item.
+
+    .. method:: get_absolute_url
+
+        Utility method to return the URL associated with this menu item,
+        primarily to follow naming convention asserted by Django.
+
+    .. method:: get_menu_title
+
+        Utility method to return the associated title, using the same naming
+        convention used by :class:`cms.models.Page`.
+
+
+    ..  attribute:: attr
+
+        A dictionary, provided in order that arbitrary attributes may be added to the node -
+        placing them directly on the node itself could cause a clash with an existing or future attribute.
+
+        An important key in this dictionary is ``is_page``: if ``True``, the node represents a django CMS ``Page``
+        object.
+
+
+..  class:: menus.modifiers.Marker
+
+..  class:: menus.modifiers.AuthVisibility
+
+..  class:: menus.modifiers.Level
+
+    ..  method:: mark_levels()
+
+
+``cms`` application
+===================
+
+..  class:: cms.menu.CMSMenu
+
+    Subclass of :class:`menus.base.Menu`. Its :meth:`~menus.base.Menu.get_nodes()` creates a list of NavigationNodes
+    based on ``Page`` objects.
+
+
+..  class:: cms.menu.NavExtender
+
+..  class:: cms.menu.SoftRootCutter
+
+..  class:: cms.menu_bases.CMSAttachMenu
+
+
+
+
+
+

--- a/docs/reference/pages.rst
+++ b/docs/reference/pages.rst
@@ -1,0 +1,10 @@
+######
+Models
+######
+
+..  class:: cms.models.Page
+
+    A ``Page`` is the basic unit of site structure in django CMS. The CMS uses a hierachical page model: each page
+    stands in relation to other pages as parent, child or sibling.
+
+

--- a/docs/reference/permissions.rst
+++ b/docs/reference/permissions.rst
@@ -1,0 +1,17 @@
+###########
+Permissions
+###########
+
+
+..  module:: cms.models
+
+..  class:: PagePermission
+
+
+..  data:: ACCESS_PAGE
+
+..  data:: ACCESS_CHILDREN
+
+..  data:: ACCESS_DESCENDANTS
+
+..  data:: ACCESS_PAGE_AND_DESCENDANTS

--- a/docs/reference/placeholders.rst
+++ b/docs/reference/placeholders.rst
@@ -1,0 +1,10 @@
+############
+Placeholders
+############
+
+..  class:: cms.models.placeholdermodel.Placeholder
+
+    ``Placeholders`` can be filled with plugins, which store or generate content.
+
+
+..  class:: cms.admin.placeholderadmin.PlaceholderAdminMixin

--- a/docs/reference/plugins.rst
+++ b/docs/reference/plugins.rst
@@ -6,553 +6,611 @@ Plugins
 CMSPluginBase Attributes and Methods Reference
 **********************************************
 
-These are a list of attributes and methods that can (or should) be overridden
-on your Plugin definition.
+..  class:: cms.plugin_base.CMSPluginBase
 
-Attributes
-==========
+    Inherits :class:`django:django.contrib.admin.ModelAdmin` and in most respects behaves like a
+    normal sub-class. Note however that some attributes of ``ModelAdmin`` simply won't make sense in the
+    context of a Plugin.
 
-admin_preview
--------------
 
-Default: ``False``
+    **Attributes**
 
-If ``True``, displays a preview in the admin.
+    ..  attribute:: admin_preview
 
+        Default: ``False``
 
-allow_children
---------------
+        If ``True``, displays a preview in the admin.
 
-Default: ``False``
 
-Can this plugin have child plugins? Or can other plugins be placed inside this
-plugin? If set to ``True`` you are responsible to render the children in your
-plugin template.
+    ..  attribute:: allow_children
 
-Please use something like this or something similar:
+        Default: ``False``
 
-.. code-block:: html+django
+        Allows this plugin to have child plugins - other plugins placed inside it?
 
-    {% load cms_tags %}
-    <div class="myplugin">
-        {{ instance.my_content }}
-        {% for plugin in instance.child_plugin_instances %}
-            {% render_plugin plugin %}
-        {% endfor %}
-    </div>
+        If ``True`` you need to ensure that your plugin can render its children in the plugin template. For example:
 
+        .. code-block:: html+django
 
-Be sure to access ``instance.child_plugin_instances`` to get all children.
-They are pre-filled and ready to use. To finally render your child plugins use
-the ``{% render_plugin %}`` template tag.
+            {% load cms_tags %}
+            <div class="myplugin">
+                {{ instance.my_content }}
+                {% for plugin in instance.child_plugin_instances %}
+                    {% render_plugin plugin %}
+                {% endfor %}
+            </div>
 
-See also: `child_classes`_, `parent_classes`_, `require_parent`_
+        ``instance.child_plugin_instances`` provides access to all the plugin's children.
+        They are pre-filled and ready to use. The child plugins should be rendered using
+        the ``{% render_plugin %}`` template tag.
 
+        See also: :attr:`child_classes`, :attr:`parent_classes`, :attr:`require_parent`.
 
-cache
------
 
-Default: :setting:`CMS_PLUGIN_CACHE`
+    ..  attribute:: cache
 
-Is this plugin cacheable? If your plugin displays content based on the user or
-request or other dynamic properties set this to False.
+        Default: :setting:`CMS_PLUGIN_CACHE`
 
-.. warning::
-    If you disable a plugin cache be sure to restart the server and clear the cache afterwards.
+        Is this plugin cacheable? If your plugin displays content based on the user or
+        request or other dynamic properties set this to ``False``.
 
+        If present and set to ``False``, the plugin will prevent the caching of
+        the resulting page.
 
-change_form_template
---------------------
+        .. important:: Setting this to ``False`` will effectively disable the
+                       CMS page cache and all upstream caches for pages where
+                       the plugin appears. This may be useful in certain cases
+                       but for general cache management, consider using the much
+                       more capable :meth:`get_cache_expiration`.
 
-Default: ``admin/cms/page/plugin_change_form.html``
+        .. warning::
 
-The template used to render the form when you edit the plugin.
+            If you disable a plugin cache be sure to restart the server and clear the cache afterwards.
 
-Example::
 
-    class MyPlugin(CMSPluginBase):
-        model = MyModel
-        name = _("My Plugin")
-        render_template = "cms/plugins/my_plugin.html"
-        change_form_template = "admin/cms/page/plugin_change_form.html"
+    ..  attribute:: change_form_template
 
-See also: `frontend_edit_template`_
+        Default: ``admin/cms/page/plugin_change_form.html``
 
+        The template used to render the form when you edit the plugin.
 
-child_classes
--------------
+        Example::
 
-Default: ``None``
+            class MyPlugin(CMSPluginBase):
+                model = MyModel
+                name = _("My Plugin")
+                render_template = "cms/plugins/my_plugin.html"
+                change_form_template = "admin/cms/page/plugin_change_form.html"
 
-A List of Plugin Class Names. If this is set, only plugins listed here can be
-added to this plugin.
+        See also: :attr:`frontend_edit_template`.
 
-See also: `parent_classes`_
 
+    ..  attribute:: child_classes
 
-disable_child_plugins
----------------------
+        Default: ``None``
 
-Default: ``False``
+        A list of Plugin Class Names. If this is set, only plugins listed here can be
+        added to this plugin.
 
-Disables dragging of child plugins in structure mode.
+        See also: :attr:`parent_classes`.
 
 
-frontend_edit_template
-----------------------
+    ..  attribute:: disable_child_plugins
 
-Default: ``cms/toolbar/plugin.html``
+        Default: ``False``
 
-The template used for wrapping the plugin in frontend editing.
+        Disables dragging of child plugins in structure mode.
 
-See also: `change_form_template`_
 
+    .. attribute:: form
 
-model
------
+        Custom form class to be used to edit this plugin.
 
-Default: ``CMSPlugin``
 
-If the plugin requires per-instance settings, then this setting must be set to
-a model that inherits from :class:`CMSPlugin`.
+    ..  attribute:: frontend_edit_template
 
-See also: :ref:`storing configuration`
+        Default: ``cms/toolbar/placeholder_wrapper.html``
 
+        The template used for wrapping the plugin in frontend editing.
 
-page_only
----------
+        See also: :attr:`change_form_template`.
 
-Default: ``False``
 
-Can this plugin only be attached to a placeholder that is attached to a page?
-Set this to ``True`` if you always need a page for this plugin.
+    ..  attribute:: model
 
-See also: `child_classes`_, `parent_classes`_, `require_parent`_,
+        Default: ``CMSPlugin``
 
+        If the plugin requires per-instance settings, then this setting must be set to
+        a model that inherits from :class:`~cms.models.pluginmodel.CMSPlugin`.
 
-parent_classes
---------------
+        See also: :ref:`storing configuration`.
 
-Default: ``None``
 
-A list of Plugin Class Names. If this is set, this plugin may only be added
-to plugins listed here.
+    .. attribute:: module
 
-See also: `child_classes`_, `require_parent`_
+        Will group the plugin in the plugin picker. If module is ``None``,
+        plugin is listed in the "Generic" group.
 
 
-render_plugin
--------------
+    .. attribute:: name
 
-Default: ``True``
+        Will be displayed in the plugin picker.
 
-Should the plugin be rendered at all, or doesn't it have any output?  If
-`render_plugin` is ``True``, then you must also define :meth:`render_template`
 
-See also: `render_template`_, `get_render_template`_
+    ..  attribute:: page_only
 
+        Default: ``False``
 
-render_template
----------------
+        Set to ``True`` if this plugin should only be used in a placeholder that is attached to a django CMS page,
+        and not other models with ``PlaceholderFields``.
 
-Default: ``None``
+        See also: :attr:`child_classes`, :attr:`parent_classes`, :attr:`require_parent`.
 
-The path to the template used to render the template. If ``render_plugin``
-is ``True`` either this or ``get_render_template`` **must** be defined;
 
-See also: `render_plugin`_ , `get_render_template`_
+    ..  attribute:: parent_classes
 
+        Default: ``None``
 
-require_parent
---------------
+        A list of the names of permissible parent classes for this plugin.
 
-Default: ``False``
+        See also: :attr:`child_classes`, :attr:`require_parent`.
 
-Is it required that this plugin is a child of another plugin? Or can it be
-added to any placeholder, even one attached to a page.
 
-See also: `child_classes`_, `parent_classes`_
+    ..  attribute:: render_plugin
 
+        If set to ``False``, this plugin will not be rendered at all.
+        Default: ``True``
 
-text_enabled
-------------
+        If ``True``, :meth:`render_template` must also be defined.
 
-Default: ``False``
+        See also: :attr:`render_template`, :meth:`get_render_template`.
 
-Can the plugin be inserted inside the text plugin?  If this is ``True`` then
-:meth:`icon_src` must be overridden.
 
-See also: `icon_src`_, `icon_alt`_
+    ..  attribute:: render_template
 
+        Default: ``None``
 
-Methods
-=======
+        The path to the template used to render the template. If ``render_plugin``
+        is ``True`` either this or ``get_render_template`` **must** be defined;
 
-.. _render:
+        See also: :attr:`render_plugin` , :meth:`get_render_template`.
 
-render
-------
 
-The :meth:`render` method takes three arguments:
+    ..  attribute:: require_parent
 
-* ``context``: The context with which the page is rendered.
-* ``instance``: The instance of your plugin that is rendered.
-* ``placeholder``: The name of the placeholder that is rendered.
+        Default: ``False``
 
-This method must return a dictionary or an instance of
-:class:`django.template.Context`, which will be used as context to render the
-plugin template.
+        Is it required that this plugin is a child of another plugin? Or can it be
+        added to any placeholder, even one attached to a page.
 
-.. versionadded:: 2.4
+        See also: :attr:`child_classes`, :attr:`parent_classes`.
 
-By default this method will add ``instance`` and ``placeholder`` to the
-context, which means for simple plugins, there is no need to overwrite this
-method.
 
-If you overwrite this method it's recommended to always populate the context
-with default values by calling the render method of the super class::
+    ..  attribute:: text_enabled
 
-    def render(self, context, instance, placeholder):
-        context = super(MyPlugin, self).render(context, instance, placeholder)
-        ...
-        return context
+        Default: ``False``
 
+        Not all plugins are usable in text plugins. If your plugin *is* usable in a text plugin:
 
-get_render_template
--------------------
+        * set this to ``True``
+        * make sure your plugin provides its own :meth:`icon_src`
 
-If you need to determine the plugin render model at render time
-you can implement :meth:`get_render_template` method on the plugin
-class; this method takes the same arguments as ``render``.
-The method **must** return a valid template file path.
+        See also: :attr:`icon_src`, :attr:`icon_alt`.
 
-Example::
 
-    def get_render_template(self, context, instance, placeholder):
-        if instance.attr = 'one':
-            return 'template1.html'
-        else:
-            return 'template2.html'
+    **Methods**
 
-See also: `render_plugin`_ , `render_template`_
+    .. method:: get_plugin_urls(instance)
 
-icon_src
---------
+        Returns the URL patterns the plugin wants to register views for.
+        They are included under django CMS's page admin URLS in the plugin path
+        (e.g.: ``/admin/cms/page/plugin/<plugin-name>/`` in the default case).
 
-By default, this returns an empty string, which, if left unoverridden would
-result in no icon rendered at all, which, in turn, would render the plugin
-uneditable by the operator inside a parent text plugin.
 
-Therefore, this should be overridden when the plugin has ``text_enabled`` set to
-``True`` to return the path to an icon to display in the text of the text
-plugin.
+        ``get_plugin_urls()`` is useful if your plugin needs to talk asynchronously to the admin.
 
-icon_src takes 1 argument:
 
-* ``instance``: The instance of the plugin model
+    ..  method:: get_render_template()
 
-Example::
+        If you need to determine the plugin render model at render time
+        you can implement the :meth:`get_render_template` method on the plugin
+        class; this method takes the same arguments as ``render``.
 
-    def icon_src(self, instance):
-        return settings.STATIC_URL + "cms/img/icons/plugins/link.png"
+        The method **must** return a valid template file path.
 
-See also: `text_enabled`_, `icon_alt`_
+        Example::
 
+            def get_render_template(self, context, instance, placeholder):
+                if instance.attr = 'one':
+                    return 'template1.html'
+                else:
+                    return 'template2.html'
 
-icon_alt
---------
+        See also: :meth:`render_plugin` , :meth:`render_template`
 
-Although it is optional, authors of "text enabled" plugins should consider
-overriding this function as well.
 
-This function accepts the ``instance`` as a parameter and returns a string to be
-used as the ``alt`` text for the plugin's icon which will appear as a tooltip in
-most browsers.  This is useful, because if the same plugin is used multiple
-times within the same text plugin, they will typically all render with the
-same icon rendering them visually identical to one another. This ``alt`` text and
-related tooltip will help the operator distinguish one from the others.
+    ..  method:: get_extra_placeholder_menu_items(self, request, placeholder)
 
-By default :meth:`icon_alt` will return a string of the form: "[plugin type] -
-[instance]", but can be modified to return anything you like.
+        Extends the context menu for all placeholders.
 
-:meth:`icon_alt` takes 1 argument:
+        To add one or more custom context menu items that are displayed in the context menu for all placeholders when
+        in structure mode, override this method in a related plugin to return a list of
+        :class:`cms.plugin_base.PluginMenuItem` instances.
 
-* ``instance``: The instance of the plugin model
 
-The default implementation is as follows::
+    ..  method:: get_extra_global_plugin_menu_items(self, request, plugin)
 
-    def icon_alt(self, instance):
-        return "%s - %s" % (force_text(self.name), force_text(instance))
+        Extends the context menu for all plugins.
 
-See also: `text_enabled`_, `icon_src`_
+        To add one or more custom context menu items that are displayed in the context menu for all plugins when in
+        structure mode, override this method in a related plugin to return a list of
+        :class:`cms.plugin_base.PluginMenuItem` instances.
 
-text_editor_button_icon
------------------------
 
-When `text_enabled`_ is ``True``, this plugin can be added in a text editor and
-there might be an icon button for that purpose. This method allows to override
-this icon.
+    ..  method:: get_extra_local_plugin_menu_items()
 
-By default, it returns ``None`` and each text editor plugin may have its own
-fallback icon.
+        Extends the context menu for a specific plugin. To add one or more custom
+        context menu items that are displayed in the context menu for a given plugin
+        when in structure mode, override this method in the plugin to return a list of
+        :class:`cms.plugin_base.PluginMenuItem` instances.
 
-:meth:`text_editor_button_icon` takes 2 arguments:
+    .. _get_cache_expiration:
 
-* ``editor_name``: The plugin name of the text editor
-* ``icon_context``: A dictionary containing information about the needed icon
-  like `width`, `height`, `theme`, etc
+    ..  method:: get_cache_expiration(self, request, instance, placeholder)
 
-Usually this method should return the icon URL. But, it may depends on the text
-editor because what is needed may differ. Please consult the documentation of
-your text editor plugin.
+        Provides expiration value to the placeholder, and in turn to the page
+        for determining the appropriate Cache-Control headers to add to the
+        HTTPResponse object.
 
-This requires support from the text plugin; support for this is currently planned
-for `djangocms-text-ckeditor <https://github.com/divio/djangocms-text-ckeditor/>`_ 2.5.0.
+        Must return one of:
 
-See also: `text_enabled`_
+            :``None``:
+                This means the placeholder and the page will not even consider
+                this plugin when calculating the page expiration.
 
-.. _get_extra_placeholder_menu_items:
+            :``datetime``:
+                A specific date and time (timezone-aware) in the future when
+                this plugin's content expires.
 
-get_extra_placeholder_menu_items
---------------------------------
+                .. important:: The returned ``datetime`` must be timezone-aware
+                               or the plugin will be ignored (with a warning)
+                               during expiration calculations.
 
-``get_extra_placeholder_menu_items(self, request, placeholder)``
+            :``int``:
+                An number of seconds that this plugin's content can be cached.
 
-Extends the context menu for all placeholders. To add one or more custom context
-menu items that are displayed in the context menu for all placeholders when in
-structure mode, override this method in a related plugin to return a list of
-:class:`cms.plugin_base.PluginMenuItem` instances.
+        There are constants are defined in ``cms.constants`` that may be
+        useful: :const:`~cms.constants.EXPIRE_NOW` and :data:`~cms.constants.MAX_EXPIRATION_TTL`.
 
-.. _get_extra_global_plugin_menu_items:
+        An integer value of ``0`` (zero) or :const:`~cms.constants.EXPIRE_NOW` effectively means
+        "do not cache". Negative values will be treated as :const:`~cms.constants.EXPIRE_NOW`.
+        Values exceeding the value :data:`~cms.constants.MAX_EXPIRATION_TTL` will be set to
+        that value.
 
-get_extra_global_plugin_menu_items
-----------------------------------
+        Negative ``timedelta`` values or those greater than :data:`~cms.constants.MAX_EXPIRATION_TTL`
+        will also be ranged in the same manner.
 
-``get_extra_global_plugin_menu_items(self, request, plugin)``
+        Similarly, ``datetime`` values earlier than now will be treated as :const:`~cms.constants.EXPIRE_NOW`. Values
+        greater than :const:`~cms.constants.MAX_EXPIRATION_TTL` seconds in the future will be treated as
+        :data:`~cms.constants.MAX_EXPIRATION_TTL` seconds in the future.
 
-Extends the context menu for all plugins. To add one or more custom context menu
-items that are displayed in the context menu for all plugins when in structure
-mode, override this method in a related plugin to return a list of
-:class:`cms.plugin_base.PluginMenuItem` instances.
+        :param request: Relevant ``HTTPRequest`` instance.
+        :param instance: The ``CMSPlugin`` instance that is being rendered.
+        :rtype: ``None`` or ``datetime`` or ``int``
 
-.. _get_extra_local_plugin_menu_items:
 
-get_extra_local_plugin_menu_items
----------------------------------
+    .. _get_vary_cache_on:
 
-``get_extra_local_plugin_menu_items(self, request, plugin)``
+    ..  method:: get_vary_cache_on(self, request, instance, placeholder)
 
-Extends the context menu for a specific plugin. To add one or more custom
-context menu items that are displayed in the context menu for a given plugin
-when in structure mode, override this method in the plugin to return a list of
-:class:`cms.plugin_base.PluginMenuItem` instances.
+        Returns an HTTP VARY header string or a list of them to be considered by the placeholder
+        and in turn by the page to caching behaviour.
 
-.. _get_cache_expiration:
+        Overriding this method is optional.
 
-get_cache_expiration
---------------------
+        Must return one of:
 
-``get_cache_expiration(self, request, instance, placeholder)``
+            :``None``:
+                This means that this plugin declares no headers for the cache
+                to be varied upon. (default)
 
-Return a positive integer of seconds or a future, TZ-aware `datetime` to
-explicitly declare when this plugin's content should expire from caching.
-This will affect the internal cms caching, Django's caching middleware
-caching, any downstream caches and client browser caching.
+            :string:
+                The name of a header to vary caching upon.
 
-This method is optional. The default implementation returns ``None`` which
-will not affect the cms's normal cache expiration functions.
+            :list of strings:
+                A list of strings, each corresponding to a header to vary the
+                cache upon.
 
-.. _get_vary_cache_on:
 
-get_vary_cache_on
------------------
+    ..  method:: icon_alt()
 
-``get_vary_cache_on(self, request, instance, placeholder)``
+        Although it is optional, authors of "text enabled" plugins should consider
+        overriding this function as well.
 
-Return an HTTP header name or a list of HTTP header names and they will
-affect the caching of the containing placeholder and ultimately the page.
+        This function accepts the ``instance`` as a parameter and returns a string to be
+        used as the ``alt`` text for the plugin's icon which will appear as a tooltip in
+        most browsers.  This is useful, because if the same plugin is used multiple
+        times within the same text plugin, they will typically all render with the
+        same icon rendering them visually identical to one another. This ``alt`` text and
+        related tooltip will help the operator distinguish one from the others.
 
-This method is optional. The default implementation returns ``None`` which
-will not affect HTTP ``VARY`` headers.
+        By default :meth:`icon_alt` will return a string of the form: "[plugin type] -
+        [instance]", but can be modified to return anything you like.
+
+        :meth:`icon_alt` takes 1 argument:
+
+        * ``instance``: The instance of the plugin model
+
+        The default implementation is as follows::
+
+            def icon_alt(self, instance):
+                return "%s - %s" % (force_text(self.name), force_text(instance))
+
+        See also: :attr:`text_enabled`, :attr:`icon_src`.
+
+
+    .. method:: icon_src(instance)
+
+        By default, this returns an empty string, which, if left unoverridden would
+        result in no icon rendered at all, which, in turn, would render the plugin
+        uneditable by the operator inside a parent text plugin.
+
+        Therefore, this should be overridden when the plugin has ``text_enabled`` set to
+        ``True`` to return the path to an icon to display in the text of the text
+        plugin.
+
+        icon_src takes 1 argument:
+
+        * ``instance``: The instance of the plugin model
+
+        Example::
+
+            def icon_src(self, instance):
+                return settings.STATIC_URL + "cms/img/icons/plugins/link.png"
+
+        See also: :attr:`text_enabled`, :meth:`icon_alt`
+
+
+    .. method:: render(context, instance, placeholder)
+
+        This method returns the context to be used to render the template
+        specified in :attr:`render_template`.
+
+        The :meth:`render` method takes three arguments:
+
+        * ``context``: The context with which the page is rendered.
+        * ``instance``: The instance of your plugin that is rendered.
+        * ``placeholder``: The name of the placeholder that is rendered.
+
+        This method must return a dictionary or an instance of
+        :class:`django.template.Context`, which will be used as context to render the
+        plugin template.
+
+        .. versionadded:: 2.4
+
+        By default this method will add ``instance`` and ``placeholder`` to the
+        context, which means for simple plugins, there is no need to overwrite this
+        method.
+
+        If you overwrite this method it's recommended to always populate the context
+        with default values by calling the render method of the super class::
+
+            def render(self, context, instance, placeholder):
+                context = super(MyPlugin, self).render(context, instance, placeholder)
+                ...
+                return context
+
+        :param context: Current template context.
+        :param instance: Plugin instance that is being rendered.
+        :param placeholder: Name of the placeholder the plugin is in.
+        :rtype: ``dict``
+
+
+    ..  method:: text_editor_button_icon()
+
+        When :attr:`text_enabled` is ``True``, this plugin can be added in a text editor and
+        there might be an icon button for that purpose. This method allows to override
+        this icon.
+
+        By default, it returns ``None`` and each text editor plugin may have its own
+        fallback icon.
+
+        :meth:`text_editor_button_icon` takes 2 arguments:
+
+        * ``editor_name``: The plugin name of the text editor
+        * ``icon_context``: A dictionary containing information about the needed icon
+          like `width`, `height`, `theme`, etc
+
+        Usually this method should return the icon URL. But, it may depends on the text
+        editor because what is needed may differ. Please consult the documentation of
+        your text editor plugin.
+
+        This requires support from the text plugin; support for this is currently planned
+        for `djangocms-text-ckeditor <https://github.com/divio/djangocms-text-ckeditor/>`_ 2.5.0.
+
+        See also: :attr:`text_enabled`.
+
+
+.. class:: cms.plugin_base.PluginMenuItem
+
+    .. method:: __init___(name, url, data, question=None, action='ajax', attributes=None)
+
+        Creates an item in the plugin / placeholder menu
+
+        :param name: Item name (label)
+        :param url: URL the item points to. This URL will be called using POST
+        :param data: Data to be POSTed to the above URL
+        :param question: Confirmation text to be shown to the user prior to call the given URL (optional)
+        :param action: Custom action to be called on click; currently supported: 'ajax', 'ajax_add'
+        :param attributes: Dictionary whose content will be addes as data-attributes to the menu item
 
 
 ******************************************
 CMSPlugin Attributes and Methods Reference
 ******************************************
 
-These are a list of attributes and methods that can (or should) be overridden
-on your plugin's `model` definition.
+..  class:: cms.models.pluginmodel.CMSPlugin
 
-See also: :ref:`storing configuration`
+    See also: :ref:`storing configuration`
 
+    **Attributes**
 
-Attributes
-==========
+    ..  attribute:: translatable_content_excluded_fields
 
+    Default: ``[ ]``
 
-translatable_content_excluded_fields
-------------------------------------
+    A list of plugin fields which will not be exported while using :meth:`get_translatable_content`.
 
-Default: ``[ ]``
+    See also: :meth:`get_translatable_content`, :meth:`set_translatable_content`.
 
-A list of plugin fields which will not be exported while using :meth:`get_translatable_content`.
+    **Methods**
 
-See also: `get_translatable_content`_, `set_translatable_content`_
+    ..  method:: copy_relations()
 
+        Handle copying of any relations attached to this plugin. Custom plugins have
+        to do this themselves.
 
-Methods
-=======
+        ``copy_relations`` takes 1 argument:
 
+        * ``old_instance``: The source plugin instance
 
-copy_relations
---------------
+        See also: :ref:`Handling-Relations`, :meth:`post_copy`.
 
-Handle copying of any relations attached to this plugin. Custom plugins have
-to do this themselves.
+    ..  method:: get_translatable_content()
 
-``copy_relations`` takes 1 argument:
+        Get a dictionary of all content fields (field name / field value pairs) from
+        the plugin.
 
-* ``old_instance``: The source plugin instance
+        Example::
 
-See also: :ref:`Handling-Relations`, `post_copy`_
+            from djangocms_text_ckeditor.models import Text
 
+            plugin = Text.objects.get(pk=1).get_plugin_instance()[0]
+            plugin.get_translatable_content()
+            # returns {'body': u'<p>I am text!</p>\n'}
 
-get_translatable_content
-------------------------
+        See also: :attr:`translatable_content_excluded_fields`, :attr:`set_translatable_content`.
 
-Get a dictionary of all content fields (field name / field value pairs) from
-the plugin.
 
-Example::
+    ..  method:: post_copy()
 
-    from djangocms_text_ckeditor.models import Text
+        Can (should) be overridden to handle the copying of plugins which contain
+        children plugins after the original parent has been copied.
 
-    plugin = Text.objects.get(pk=1).get_plugin_instance()[0]
-    plugin.get_translatable_content()
-    # returns {'body': u'<p>I am text!</p>\n'}
+        ``post_copy`` takes 2 arguments:
 
+        * ``old_instance``: The old plugin instance instance
+        * ``new_old_ziplist``: A list of tuples containing new copies and the old existing child plugins.
 
-See also: `translatable_content_excluded_fields`_, `set_translatable_content`_
+        See also: :ref:`Handling-Relations`, :meth:`copy_relations`.
 
 
-post_copy
----------
+    ..  method:: set_translatable_content()
 
-Can (should) be overridden to handle the copying of plugins which contain
-children plugins after the original parent has been copied.
+        Takes a dictionary of plugin fields (field name / field value pairs) and
+        overwrites the plugin's fields. Returns ``True`` if all fields have been
+        written successfully, and ``False`` otherwise.
 
-``post_copy`` takes 2 arguments:
+        ``set_translatable_content`` takes 1 argument:
 
-* ``old_instance``: The old plugin instance instance
-* ``new_old_ziplist``: A list of tuples containing new copies and the old existing child plugins.
+        * ``fields``: A dictionary containing the field names and translated content for each.
 
-See also: :ref:`Handling-Relations`, `copy_relations`_
+        * :meth:`get_translatable_content()`
 
+        Example::
 
-set_translatable_content
-------------------------
+            from djangocms_text_ckeditor.models import Text
 
-Takes a dictionary of plugin fields (field name / field value pairs) and
-overwrites the plugin's fields. Returns ``True`` if all fields have been
-written successfully, and ``False`` otherwise.
+            plugin = Text.objects.get(pk=1).get_plugin_instance()[0]
+            plugin.set_translatable_content({'body': u'<p>This is a different text!</p>\n'})
+            # returns True
 
-set_translatable_content takes 1 argument:
+        See also: :attr:`translatable_content_excluded_fields`, :meth:`get_translatable_content`.
 
-* ``fields``: A dictionary containing the field names and translated content for each.
 
-Example::
+    ..  method:: get_add_url()
 
-    from djangocms_text_ckeditor.models import Text
+        Returns the URL to call to add a plugin instance; useful to implement plugin-specific
+        logic in a custom view.
 
-    plugin = Text.objects.get(pk=1).get_plugin_instance()[0]
-    plugin.set_translatable_content({'body': u'<p>This is a different text!</p>\n'})
-    # returns True
 
-See also: `translatable_content_excluded_fields`_, `get_translatable_content`_
+    ..  method:: get_edit_url()
 
+        Returns the URL to call to edit a plugin instance; useful to implement plugin-specific
+        logic in a custom view.
 
-get_add_url
------------
 
-Returns the URL to call to add a plugin instance; useful to implement plugin-specific
-logic in a custom view.
+    ..  method:: get_move_url()
 
-get_edit_url
-------------
+        Returns the URL to call to move a plugin instance; useful to implement plugin-specific
+        logic in a custom view.
 
-Returns the URL to call to edit a plugin instance; useful to implement plugin-specific
-logic in a custom view.
 
-get_move_url
-------------
+    ..  method:: get_delete_url()
 
-Returns the URL to call to move a plugin instance; useful to implement plugin-specific
-logic in a custom view.
+        Returns the URL to call to delete a plugin instance; useful to implement plugin-specific
+        logic in a custom view.
 
-get_delete_url
---------------
 
-Returns the URL to call to delete a plugin instance; useful to implement plugin-specific
-logic in a custom view.
+    ..  method:: get_copy_url()
 
-get_copy_url
-------------
+        Returns the URL to call to copy a plugin instance; useful to implement plugin-specific
+        logic in a custom view.
 
-Returns the URL to call to copy a plugin instance; useful to implement plugin-specific
-logic in a custom view.
 
+    ..  method:: add_url()
 
-add_url
--------
+        Returns the URL to call to add a plugin instance; useful to implement plugin-specific
+        logic in a custom view.
 
-Returns the URL to call to add a plugin instance; useful to implement plugin-specific
-logic in a custom view.
+        This property is now deprecated. Will be removed in 3.4.
+        Use the ``get_add_url`` method instead.
 
-This property is now deprecated. Will be removed in 3.4.
-Use the ``get_add_url`` method instead.
+        Default: None (``cms_page_add_plugin`` view is used)
 
-Default: None (``cms_page_add_plugin`` view is used)
 
-edit_url
---------
+    ..  method:: edit_url()
 
-Returns the URL to call to edit a plugin instance; useful to implement plugin-specific
-logic in a custom view.
+        Returns the URL to call to edit a plugin instance; useful to implement plugin-specific
+        logic in a custom view.
 
-This property is now deprecated. Will be removed in 3.4.
-Use the ``get_edit_url`` method instead.
+        This property is now deprecated. Will be removed in 3.4.
+        Use the ``get_edit_url`` method instead.
 
-Default: None (``cms_page_edit_plugin`` view is used)
+        Default: None (``cms_page_edit_plugin`` view is used)
 
-move_url
---------
 
-Returns the URL to call to move a plugin instance; useful to implement plugin-specific
-logic in a custom view.
+    ..  method:: move_url()
 
-This property is now deprecated. Will be removed in 3.4.
-Use the ``get_move_url`` method instead.
+        Returns the URL to call to move a plugin instance; useful to implement plugin-specific
+        logic in a custom view.
 
-Default: None (``cms_page_move_plugin`` view is used)
+        This property is now deprecated. Will be removed in 3.4.
+        Use the ``get_move_url`` method instead.
 
-delete_url
-----------
+        Default: None (``cms_page_move_plugin`` view is used)
 
-Returns the URL to call to delete a plugin instance; useful to implement plugin-specific
-logic in a custom view.
 
-This property is now deprecated. Will be removed in 3.4.
-Use the ``get_delete_url`` method instead.
+    ..  method:: delete_url()
 
-Default: None (``cms_page_delete_plugin`` view is used)
+        Returns the URL to call to delete a plugin instance; useful to implement plugin-specific
+        logic in a custom view.
 
-copy_url
---------
+        This property is now deprecated. Will be removed in 3.4.
+        Use the ``get_delete_url`` method instead.
 
-Returns the URL to call to copy a plugin instance; useful to implement plugin-specific
-logic in a custom view.
+        Default: None (``cms_page_delete_plugin`` view is used)
 
-This property is now deprecated. Will be removed in 3.4.
-Use the ``get_copy_url`` method instead.
 
-Default: None (``cms_page_copy_plugins`` view is used)
+    ..  method:: copy_url()
+
+        Returns the URL to call to copy a plugin instance; useful to implement plugin-specific
+        logic in a custom view.
+
+        This property is now deprecated. Will be removed in 3.4.
+        Use the ``get_copy_url`` method instead.
+
+        Default: None (``cms_page_copy_plugins`` view is used)
+
+
+..  class:: cms.plugin_pool.PluginPool

--- a/docs/reference/sitemaps.rst
+++ b/docs/reference/sitemaps.rst
@@ -1,0 +1,6 @@
+########
+Sitemaps
+########
+
+..  class:: cms.sitemaps.CMSSitemap
+

--- a/docs/reference/templatetags.rst
+++ b/docs/reference/templatetags.rst
@@ -2,6 +2,8 @@
 Template Tags
 #############
 
+..  module:: cms.templatetags.cms_tags
+
 *****************
 CMS template tags
 *****************
@@ -13,11 +15,13 @@ top of your template::
 
     {% load cms_tags %}
 
-.. template tag:: placeholder
+..  templatetag:: placeholder
 
 placeholder
 ===========
+
 .. versionchanged:: 2.1
+
     The placeholder name became case sensitive.
 
 The ``placeholder`` template tag defines a placeholder on a page. All
@@ -63,7 +67,7 @@ pages have plugins that generate content::
 See also the :setting:`CMS_PLACEHOLDER_CONF` setting where you can also add extra
 context variables and change some other placeholder behaviour.
 
-.. template tag:: static_placeholder
+..  templatetag:: static_placeholder
 
 static_placeholder
 ==================
@@ -221,7 +225,7 @@ page_lookup
 The ``page_lookup`` argument, passed to several template tags to retrieve a
 page, can be of any of the following types:
 
-* :class:`str <basestring>`: interpreted as the ``reverse_id`` field of the desired page, which
+* :class:`str`: interpreted as the ``reverse_id`` field of the desired page, which
   can be set in the "Advanced" section when editing a page.
 * :class:`int`: interpreted as the primary key (``pk`` field) of the desired page
 * :class:`dict`: a dictionary containing keyword arguments to find the desired page
@@ -279,12 +283,10 @@ Example::
 
 If a matching page isn't found and :setting:`django:DEBUG` is ``True``, an
 exception will be raised. However, if :setting:`django:DEBUG` is ``False``, an
-exception will not be raised. Additionally, if
-:setting:`django:SEND_BROKEN_LINK_EMAILS` is ``True`` and you have specified
-some addresses in :setting:`django:MANAGERS`, an email will be sent to those
-addresses to inform them of the broken link.
+exception will not be raised.
 
 .. versionadded:: 3.0
+
     page_url now supports the ``as`` argument. When used this way, the tag
     emits nothing, but sets a variable in the context with the specified name
     to the resulting value.

--- a/docs/reference/titles.rst
+++ b/docs/reference/titles.rst
@@ -1,0 +1,6 @@
+######
+Titles
+######
+
+..  class:: cms.models.Title
+

--- a/docs/reference/toolbar.rst
+++ b/docs/reference/toolbar.rst
@@ -1,0 +1,336 @@
+.. _toolbar-api-reference:
+
+###########
+The Toolbar
+###########
+
+
+All methods taking a ``side`` argument expect either
+:data:`cms.constants.LEFT` or :data:`cms.constants.RIGHT` for that
+argument.
+
+Methods accepting the ``position`` argument can insert items at a specific
+position. This can be either ``None`` to insert at the end, an integer
+index at which to insert the item, a :class:`cms.toolbar.items.ItemSearchResult` to insert
+it *before* that search result or a :class:`cms.toolbar.items.BaseItem` instance to insert
+it *before* that item.
+
+
+cms.toolbar.toolbar
+===================
+
+..  module:: cms.toolbar.toolbar
+
+..  class:: CMSToolbar
+
+    The toolbar class providing a Python API to manipulate the toolbar. Note
+    that some internal attributes are not documented here.
+
+    All methods taking a ``position`` argument expect either
+    :data:`cms.constants.LEFT` or :data:`cms.constants.RIGHT` for that
+    argument.
+
+    This class inherits :class:`cms.toolbar.items.ToolbarMixin`, so please
+    check that reference as well.
+
+    .. attribute:: is_staff
+
+        Whether the current user is a staff user or not.
+
+    .. attribute:: edit_mode
+
+        Whether the toolbar is in edit mode.
+
+    .. attribute:: build_mode
+
+        Whether the toolbar is in build mode.
+
+    .. attribute:: show_toolbar
+
+        Whether the toolbar should be shown or not.
+
+    .. attribute:: csrf_token
+
+        The CSRF token of this request
+
+    .. attribute:: toolbar_language
+
+        Language used by the toolbar.
+
+    .. attribute:: watch_models
+
+        A list of models this toolbar works on; used for redirection after editing
+        (:ref:`url_changes`).
+
+    .. method:: add_item(item, position=None)
+
+        Low level API to add items.
+
+        Adds an item, which must be an instance of
+        :class:`cms.toolbar.items.BaseItem`, to the toolbar.
+
+        This method should only be used for custom item classes, as all built-in
+        item classes have higher level APIs.
+
+        Read above for information on ``position``.
+
+    .. method:: remove_item(item)
+
+        Removes an item from the toolbar or raises a :exc:`KeyError` if it's
+        not found.
+
+    .. method:: get_or_create_menu(key. verbose_name, side=LEFT, position=None)
+
+        If a menu with ``key`` already exists, this method will return that
+        menu. Otherwise it will create a menu for that ``key`` with the given
+        ``verbose_name`` on ``side`` at ``position`` and return it.
+
+
+    ..  method:: get_menu(self, key, verbose_name=None, side=LEFT, position=None)
+
+        If a menu with ``key`` already exists, this method will return that
+        menu.
+
+
+    .. method:: add_button(name, url, active=False, disabled=False, extra_classes=None, extra_wrapper_classes=None, side=LEFT, position=None)
+
+        Adds a button to the toolbar. ``extra_wrapper_classes`` will be applied
+        to the wrapping ``div`` while ``extra_classes`` are applied to the
+        ``<a>``.
+
+    .. method:: add_button_list(extra_classes=None, side=LEFT, position=None)
+
+        Adds an (empty) button list to the toolbar and returns it. See
+        :class:`cms.toolbar.items.ButtonList` for further information.
+
+
+
+cms.toolbar.items
+=================
+
+.. important:: **Overlay** and **sideframe**
+
+    Then django CMS *sideframe* has been replaced with an *overlay* mechanism. The API still refers
+    to the ``sideframe``, because it is invoked in the same way, and what has changed is merely the
+    behaviour in the user's browser.
+
+    In other words, *sideframe* and the *overlay* refer to different versions of the same thing.
+
+.. module:: cms.toolbar.items
+
+
+.. class:: ItemSearchResult
+
+    Used for the find APIs in :class:`ToolbarMixin`. Supports addition and
+    subtraction of numbers. Can be cast to an integer.
+
+    .. attribute:: item
+
+        The item found.
+
+    .. attribute:: index
+
+        The index of the item.
+
+.. class:: ToolbarMixin
+
+    Provides APIs shared between :class:`cms.toolbar.toolbar.CMSToolbar` and
+    :class:`Menu`.
+
+    The ``active`` and ``disabled`` flags taken by all methods of this class
+    specify the state of the item added.
+
+    ``extra_classes`` should be either ``None`` or a list of class names as
+    strings.
+
+    .. attribute:: REFRESH_PAGE
+
+        Constant to be used with ``on_close`` to refresh the current page when
+        the frame is closed.
+
+    .. attribute:: LEFT
+
+        Constant to be used with ``side``.
+
+    .. attribute:: RIGHT
+
+        Constant to be used with ``side``.
+
+    .. method:: get_item_count
+
+        Returns the number of items in the toolbar or menu.
+
+    ..  method:: get_alphabetical_insert_position(self, new_menu_name, item_type, default=0)
+
+    .. method:: add_item(item, position=None)
+
+        Low level API to add items, adds the ``item`` to the toolbar or menu
+        and makes it searchable. ``item`` must be an instance of
+        :class:`BaseItem`. Read above for information about the ``position``
+        argument.
+
+    .. method:: remove_item(item)
+
+        Removes ``item`` from the toolbar or menu. If the item can't be found,
+        a :exc:`KeyError` is raised.
+
+    .. method:: find_items(item_type, **attributes)
+
+        Returns a list of :class:`ItemSearchResult` objects matching all items
+        of ``item_type``, which must be a sub-class of :class:`BaseItem`, where
+        all attributes in ``attributes`` match.
+
+    .. method:: find_first(item_type, **attributes)
+
+        Returns the first :class:`ItemSearchResult` that matches the search or
+        ``None``. The search strategy is the same as in :meth:`find_items`.
+        Since positional insertion allows ``None``, it's safe to use the return
+        value of this method as the position argument to insertion APIs.
+
+    .. method:: add_sideframe_item(name, url, active=False, disabled=False, extra_classes=None, on_close=None, side=LEFT, position=None)
+
+        Adds an item which opens ``url`` in the sideframe and returns it.
+
+        ``on_close`` can be set to ``None`` to do nothing when the sideframe
+        closes, :attr:`REFRESH_PAGE` to refresh the page when it
+        closes or a URL to open once it closes.
+
+    .. method:: add_modal_item(name, url, active=False, disabled=False, extra_classes=None, on_close=REFRESH_PAGE, side=LEFT, position=None)
+
+        The same as :meth:`add_sideframe_item`, but opens the ``url`` in a
+        modal dialog instead of the sideframe.
+
+        ``on_close`` can be set to ``None`` to do nothing when the side modal
+        closes, :attr:`REFRESH_PAGE` to refresh the page when it
+        closes or a URL to open once it closes.
+
+        Note: The default value for ``on_close`` is different in :meth:`add_sideframe_item` then in :meth:`add_modal_item`
+
+    .. method:: add_link_item(name, url, active=False, disabled=False, extra_classes=None, side=LEFT, position=None)
+
+        Adds an item that simply opens ``url`` and returns it.
+
+    .. method:: add_ajax_item(name, action, active=False, disabled=False, extra_classes=None, data=None, question=None, side=LEFT, position=None)
+
+        Adds an item which sends a POST request to ``action`` with ``data``.
+        ``data`` should be ``None`` or a dictionary, the CSRF token will
+        automatically be added to it.
+
+        If ``question`` is set to a string, it will be asked before the
+        request is sent to confirm the user wants to complete this action.
+
+
+.. class:: BaseItem(position)
+
+    Base item class.
+
+    .. attribute:: template
+
+        Must be set by sub-classes and point to a Django template
+
+    .. attribute:: side
+
+        Must be either :data:`cms.constants.LEFT` or
+        :data:`cms.constants.RIGHT`.
+
+    .. method:: render()
+
+        Renders the item and returns it as a string. By default calls
+        :meth:`get_context` and renders :attr:`template` with the context
+        returned.
+
+    .. method:: get_context()
+
+        Returns the context (as dictionary) for this item.
+
+
+.. class:: Menu(name, csrf_token, side=LEFT, position=None)
+
+    The menu item class. Inherits :class:`ToolbarMixin` and provides the APIs
+    documented on it.
+
+    The ``csrf_token`` must be set as this class provides high level APIs to
+    add items to it.
+
+    .. method:: get_or_create_menu(key, verbose_name, side=LEFT, position=None)
+
+        The same as :meth:`cms.toolbar.toolbar.CMSToolbar.get_or_create_menu` but adds
+        the menu as a sub menu and returns a :class:`SubMenu`.
+
+    .. method:: add_break(identifier=None, position=None)
+
+        Adds a visual break in the menu, useful for grouping items, and
+        returns it. ``identifier`` may be used to make this item searchable.
+
+
+.. class:: SubMenu(name, csrf_token, side=LEFT, position=None)
+
+    Same as :class:`Menu` but without the :meth:`Menu.get_or_create_menu` method.
+
+
+.. class:: LinkItem(name, url, active=False, disabled=False, extra_classes=None, side=LEFT)
+
+    Simple link item.
+
+
+.. class:: SideframeItem(name, url, active=False, disabled=False, extra_classes=None, on_close=None, side=LEFT)
+
+    Item that opens ``url`` in sideframe.
+
+
+.. class:: AjaxItem(name, action, csrf_token, data=None, active=False, disabled=False, extra_classes=None, question=None, side=LEFT)
+
+    An item which posts ``data`` to ``action``.
+
+
+.. class:: ModalItem(name, url, active=False, disabled=False, extra_classes=None, on_close=None, side=LEFT)
+
+    Item that opens ``url`` in the modal.
+
+
+.. class:: Break(identifier=None)
+
+    A visual break for menus. ``identifier`` may be provided to make this item
+    searchable. Since breaks can only be within menus, they have no ``side``
+    attribute.
+
+
+.. class:: ButtonList(identifier=None, extra_classes=None, side=LEFT)
+
+    A list of one or more buttons.
+
+    The ``identifier`` may be provided to make this item searchable.
+
+    .. method:: add_item(item)
+
+        Adds ``item`` to the list of buttons. ``item`` must be an instance of
+        :class:`Button`.
+
+    .. method:: add_button(name, url, active=False, disabled=False, extra_classes=None)
+
+        Adds a :class:`Button` to the list of buttons and returns it.
+
+
+.. class:: Button(name, url, active=False, disabled=False, extra_classes=None)
+
+    A button to be used with :class:`ButtonList`. Opens ``url`` when selected.
+
+
+..  module:: cms.toolbar_pool
+
+..  class:: ToolbarPool
+
+    ..  method:: register(self, toolbar)
+
+        Register this toolbar.
+
+
+..  module:: cms.extensions.toolbar
+
+..  class:: ExtensionToolbar
+
+    ..  method:: get_page_extension_admin()
+
+    ..  method:: _setup_extension_toolbar()
+
+    ..  method:: get_title_extension_admin()

--- a/docs/topics/commonly_used_plugins.rst
+++ b/docs/topics/commonly_used_plugins.rst
@@ -10,11 +10,11 @@ Some commonly-used plugins
 
 These are the recommended plugins to use with django CMS.
 
-.. :module:: djangocms_file
+..  module:: djangocms_file
 
-.. :class:: djangocms_file.cms_plugins.FilePlugin
+..  class:: djangocms_file.cms_plugins.FilePlugin
 
-.. important::
+..  important::
     See the note on :ref:`installed_apps` about ordering.
 
 ****
@@ -85,9 +85,9 @@ setting in your project's ``settings.py`` file::
     )
 
 
-.. :module:: djangocms_picture
+..  module:: djangocms_picture
 
-.. :class:: djangocms_picture.cms_plugins.PicturePlugin
+..  class:: djangocms_picture.cms_plugins.PicturePlugin
 
 *******
 Picture
@@ -153,6 +153,8 @@ running.
 Teaser
 ******
 
+..  module:: djangocms_teaser
+
 Available on `GitHub (divio/djangocms-teaser) <http://github.com/divio/djangocms-teaser>`_
 and on `PyPi (djangocms-teaser) <https://pypi.python.org/pypi/djangocms-teaser>`_.
 
@@ -189,9 +191,9 @@ Consider using `djangocms-text-ckeditor
 <https://github.com/divio/djangocms-text-ckeditor>`_ for displaying text. You
 may of course use your preferred editor; others are available.
 
-.. :module:: djangocms_video
+..  module:: djangocms_video
 
-.. :class:: djangocms_video.cms_plugins.VideoPlugin
+..  class:: djangocms_video.cms_plugins.VideoPlugin
 
 *****
 Video
@@ -243,11 +245,11 @@ running.
 .. _django-filer: https://github.com/stefanfoulis/django-filer
 .. _django filer CMS plugin: https://github.com/stefanfoulis/cmsplugin-filer
 
-.. :module:: djangocms_twitter
+..  module:: djangocms_twitter
 
-.. :class:: djangocms_twitter.cms_plugins.TwitterRecentEntriesPlugin
+..  class:: djangocms_twitter.cms_plugins.TwitterRecentEntriesPlugin
 
-.. :class:: djangocms_twitter.cms_plugins.TwitterSearchPlugin
+..  class:: djangocms_twitter.cms_plugins.TwitterSearchPlugin
 
 *******
 Twitter
@@ -260,9 +262,9 @@ We recommend one of the following plugins:
 
 .. warning:: These plugins are not currently compatible with Django 1.7.
 
-.. :module:: djangocms_inherit
+..  module:: djangocms_inherit
 
-.. :class:: djangocms_inherit.cms_plugins.InheritPagePlaceholderPlugin
+..  class:: djangocms_inherit.cms_plugins.InheritPagePlaceholderPlugin
 
 *******
 Inherit

--- a/docs/topics/menu_system.rst
+++ b/docs/topics/menu_system.rst
@@ -101,7 +101,7 @@ There is one in cms for example, which examines the Pages in the database and ad
 
 These classes are sub-classes of :py:class:`menus.base.Menu`. The one in cms is :py:class:`cms.menu.CMSMenu`.
 
-In order to use a generator, its :py:meth:`get_nodes` method must be called.
+In order to use a generator, its :py:meth:`~menus.base.Menu.get_nodes()` method must be called.
 
 Modifiers
 ---------
@@ -112,23 +112,23 @@ An important one in cms (:py:class:`cms.menu.SoftRootCutter`) removes the nodes 
 
 These classes are sub-classes of :py:class:`menus.base.Modifier`. Examples are :py:class:`cms.menu.NavExtender` and :py:class:`cms.menu.SoftRootCutter`.
 
-In order to use a modifier, its :py:meth:`modify()` method must be called.
+In order to use a modifier, its :py:meth:`~menus.base.Modifier.modify()` method must be called.
 
-Note that each Modifier's :py:meth:`modify()` method can be called *twice*, before and after the menu has been trimmed.
+Note that each Modifier's :py:meth:`~menus.base.Modifier.modify()` method can be called *twice*, before and after the menu has been trimmed.
 
-For example when using the {% show_menu %} template tag, it's called:
+For example when using the ``{% show_menu %}`` template tag, it's called:
 
-* first, by :py:meth:`menus.menu_pool.MenuPool.get_nodes()`, with the argument post_cut = False
-* later, by the template tag, with the argument post_cut = True
+* first, by :py:meth:`menus.menu_pool.MenuPool.get_nodes()`, with the argument ``post_cut = False``
+* later, by the template tag, with the argument ``post_cut = True``
 
-This corresponds to the state of the nodes list before and after :py:meth:`menus.templatetags.menu_tags.cut_levels()`, which removes nodes from the menu according to the arguments provided by the template tag.
+This corresponds to the state of the nodes list before and after :py:func:`menus.templatetags.menu_tags.cut_levels()`, which removes nodes from the menu according to the arguments provided by the template tag.
 
 This is because some modification might be required on *all* nodes, and some might only be required on the subset of nodes left after cutting.
 
 Nodes
 =====
 
-Nodes are assembled in a tree. Each node is an instance of the :py:class:`menus.base.NavigationNode` class.
+Nodes are assembled in a tree. Each node is an instance of the :class:`menus.base.NavigationNode` class.
 
 A NavigationNode has attributes such as URL, title, parent and children - as one would expect in a navigation tree.
 
@@ -138,8 +138,8 @@ to, rather than placing them directly on the node itself, where they might clash
 .. warning::
     You can't assume that a :py:class:`menus.base.NavigationNode` represents a django CMS Page. Firstly, some nodes may
     represent objects from other applications. Secondly, you can't expect to be able to access Page objects via
-    NavigationNodes. To check if node represents a CMS Page, check for 'is_page' in :py:attr:`menus.base.NavigationNode.attr`
-    and that it is True.
+    NavigationNodes. To check if node represents a CMS Page, check for ``is_page`` in :py:attr:`menus.base.NavigationNode.attr`
+    and that it is ``True``.
 
 *****************
 Menu system logic
@@ -162,23 +162,23 @@ Don't forget that show_menu recurses - so it will do *all* of the below for *eac
             * :py:meth:`menus.menu_pool.MenuPool._build_nodes()`
                 * checks the cache to see if it should return cached nodes
                 * loops over the Menus in self.menus (note: by default the only generator is :py:class:`cms.menu.CMSMenu`); for each:
-                    * call its :py:meth:`get_nodes()` - the menu generator
-                    * :py:meth:`menus.menu_pool._build_nodes_inner_for_one_menu()`
+                    * call its :py:meth:`menus.base.Menu.get_nodes()` - the menu generator
+                    * :py:func:`menus.menu_pool._build_nodes_inner_for_one_menu()`
                     * adds all nodes into a big list
             * :py:meth:`menus.menu_pool.MenuPool.apply_modifiers()`
                 * :py:meth:`menus.menu_pool.MenuPool._mark_selected()`
                 * loops over each node, comparing its URL with the request.path_info, and marks the best match as ``selected``
-                * loops over the Modifiers in self.modifiers calling each one's :py:meth:`modify(post_cut=False)`. The default Modifiers are:
+                * loops over the Modifiers in ``self.modifiers`` calling each one's :py:meth:`~menus.base.Modifier.modify()` with ``post_cut=False``. The default Modifiers are:
                     * :py:class:`cms.menu.NavExtender`
                     * :py:class:`cms.menu.SoftRootCutter` removes all nodes below the appropriate soft root
                     * :py:class:`menus.modifiers.Marker` loops over all nodes; finds selected, marks its ancestors, siblings and children
                     * :py:class:`menus.modifiers.AuthVisibility` removes nodes that require authorisation to see
-                    * :py:class:`menus.modifiers.Level` loops over all nodes; for each one that is a root node (level = 0) passes it to:
-                        * :py:meth:`menus.modifiers.Level.mark_levels()` recurses over a node's descendants marking their levels
+                    * :py:class:`menus.modifiers.Level` loops over all nodes; for each one that is a root node (``level == 0``) passes it to:
+                        * :py:meth:`~menus.modifiers.Level.mark_levels()` recurses over a node's descendants marking their levels
         * we're now back in :py:meth:`menus.templatetags.menu_tags.ShowMenu.get_context()` again
         * if we have been provided a root_id, get rid of any nodes other than its descendants
         * :py:meth:`menus.templatetags.menu_tags.cut_levels()` removes nodes from the menu according to the arguments provided by the template tag
-        * :py:meth:`menu_pool.MenuPool.apply_modifiers(post_cut = True)` loops over all the Modifiers again
+        * :py:meth:`menus.menu_pool.MenuPool.apply_modifiers()` with ``post_cut = True`` loops over all the Modifiers again
             * :py:class:`cms.menu.NavExtender`
             * :py:class:`cms.menu.SoftRootCutter`
             * :py:class:`menus.modifiers.Marker`

--- a/docs/upgrade/2.1.rst
+++ b/docs/upgrade/2.1.rst
@@ -52,11 +52,11 @@ The following changes will need to be made in your ``settings.py`` file::
 
     PROJECT_PATH is the absolute path to your project.  See :ref:`configure-django-cms` for instructions on how to set PROJECT_PATH.
 
-**Remove** the following from :setting:`django:TEMPLATE_CONTEXT_PROCESSORS`::
+**Remove** the following from ``TEMPLATE_CONTEXT_PROCESSORS``:
 
     django.core.context_processors.auth
 
-**Add** the following to :setting:`django:TEMPLATE_CONTEXT_PROCESSORS`::
+**Add** the following to ``TEMPLATE_CONTEXT_PROCESSORS``::
 
     django.contrib.auth.context_processors.auth
     django.core.context_processors.static

--- a/docs/upgrade/2.2.rst
+++ b/docs/upgrade/2.2.rst
@@ -48,20 +48,20 @@ Due to the sorry state of the old plugin media framework, it has been dropped in
 favour of the more stable and more flexible django-sekizai, which is a new
 dependency for the django CMS 2.2.
 
-The following methods and properties of :class:`cms.plugins_base.CMSPluginBase`
+The following methods and properties of :class:`cms.plugin_base.CMSPluginBase`
 are affected:
 
-* :class:`cms.plugins_base.CMSPluginBase.PluginMedia`
-* :attr:`cms.plugins_base.CMSPluginBase.pluginmedia`
-* :meth:`cms.plugins_base.CMSPluginBase.get_plugin_media`
+* ``cms.plugins_base.CMSPluginBase.PluginMedia``
+* ``cms.plugins_base.CMSPluginBase.pluginmedia``
+* ``cms.plugins_base.CMSPluginBase.get_plugin_media``
 
 Accessing those attributes or methods will raise a
-:exc:`cms.exceptions.Deprecated` error.
+``cms.exceptions.Deprecated`` error.
 
-The :class:`cms.middleware.media.PlaceholderMediaMiddleware` middleware was also
+The ``cms.middleware.media.PlaceholderMediaMiddleware`` middleware was also
 removed in this process and is therefore no longer required. However you are now
-required to have the ``'sekizai.context_processors.sekizai'`` context processor
-in your :setting:`django:TEMPLATE_CONTEXT_PROCESSORS` setting.
+required to have the ``sekizai.context_processors.sekizai`` context processor
+in your ``TEMPLATE_CONTEXT_PROCESSORS`` setting.
 
 All templates in :setting:`CMS_TEMPLATES` must at least contain the ``js`` and
 ``css`` sekizai namespaces.

--- a/docs/upgrade/2.4.rst
+++ b/docs/upgrade/2.4.rst
@@ -107,8 +107,8 @@ can publish changes to the public site.
     will fail and leave bad data in your database. See :ref:`cms-list-command`
     and :ref:`cms-delete-orphaned-plugins-command`.
 
-    Also, check if all your plugins define a
-    :meth:`~cms.models.CMSPlugin.copy_relations` method if required. You can do
+    Also, check that all your plugins define a
+    :meth:`~cms.models.pluginmodel.CMSPlugin.copy_relations()` method if required. You can do
     this by running ``manage.py cms check`` and read the *Presence of
     "copy_relations"* section. See :ref:`handling-relations` for guidance on
     this topic.
@@ -360,7 +360,7 @@ to the way revisions are handled for pages.
 Changes to the show_sub_menu template tag
 =========================================
 
-the :ttag:`show_sub_menu` has received two new parameters.
+The :ttag:`show_sub_menu` has received two new parameters.
 The first stays the same and is still: how many levels of menu should be displayed.
 
 The second: ``root_level`` (default=None), specifies at what level, if any, the menu should root at.
@@ -372,9 +372,8 @@ The third argument: ``nephews`` (default=100), specifies how many levels of neph
 PlaceholderAdmin support i18n
 =============================
 
-
 If you use placeholders in other apps or models we now support more than one language out of the box.
-If you just use the :class:`PlaceholderAdmin` it will display language tabs like the cms. If you
+If you just use ``PlaceholderAdmin`` it will display language tabs like the cms. If you
 use `django-hvad`_ it uses the hvad language tabs.
 
 If you want to disable this behaviour you can set ``render_placeholder_language_tabs = False`` on your Admin

--- a/docs/upgrade/3.0.rst
+++ b/docs/upgrade/3.0.rst
@@ -357,8 +357,8 @@ template tags you can just do:
 ``getter`` and ``setter`` for translatable plugin content
 =========================================================
 
-A plugin's translatable content can now be read and set through :meth:`get_translatable_content`
-and :meth:`set_translatable_content`. See :ref:`Custom Plugins <custom-plugins>` for more info.
+A plugin's translatable content can now be read and set through :meth:`~cms.models.pluginmodel.CMSPlugin.get_translatable_content()`
+and :meth:`~cms.models.pluginmodel.CMSPlugin.set_translatable_content()`. See :ref:`Custom Plugins <custom-plugins>` for more info.
 
 No more DB table-name magic for plugins
 =======================================


### PR DESCRIPTION
In many places in the documentation, we have used references
of the form:

    :meth:`~cms.models.pluginmodel.CMSPlugin.copy_relations()`

to the referent:

    ..  class:: cms.models.pluginmodel.CMSPlugin

        [...]

        ..  method:: copy_relations()

Often, this has not been done correctly, with either the
directive or the role that links to it incorrectly formatted, and
the directive often simply missing.

This patch fixes 176 warnings across the documentation.

It's a first step to improving the reference documentation more generally. The next step will be to rationalise and reorganise the ``/reference`` section. 