### PR TITLE
Fixed #5401 -- Adapt code to avoid context related deprecation warnings

### DIFF
--- a/cms/plugin_rendering.py
+++ b/cms/plugin_rendering.py
@@ -65,10 +65,11 @@ def render_plugin(context, instance, placeholder, template, processors=None, cur
     if toolbar and isinstance(template, six.string_types):
         template = toolbar.get_cached_template(template)
 
+    context = flatten_context(context)
     if not processors:
         processors = []
     if isinstance(template, six.string_types):
-        content = render_to_string(template, flatten_context(context))
+        content = render_to_string(template, context)
     elif (isinstance(template, Template) or (hasattr(template, 'template') and
           hasattr(template, 'render') and isinstance(template.template, Template))):
         content = template.render(context)
@@ -207,7 +208,7 @@ def render_placeholder(placeholder, context_to_copy, name_fallback="Placeholder"
         content = mark_safe("".join(content))
     elif default:
         # should be nodelist from a template
-        content = mark_safe(default.render(context_to_copy))
+        content = mark_safe(default.render(flatten_context(context_to_copy)))
     else:
         content = ''
     context['content'] = content

--- a/cms/templatetags/cms_tags.py
+++ b/cms/templatetags/cms_tags.py
@@ -422,7 +422,7 @@ def render_extra_menu_items(context, obj, template='cms/toolbar/dragitem_extra_m
 
     if not items:
         return ''
-    return template.render(Context({'items': items}))
+    return template.render({'items': items})
 
 
 class PageAttribute(AsTag):

--- a/cms/templatetags/cms_tags.py
+++ b/cms/templatetags/cms_tags.py
@@ -13,7 +13,6 @@ from django.core.mail import mail_managers
 from django.core.urlresolvers import reverse
 from django.db.models import Model
 from django.middleware.common import BrokenLinkEmailsMiddleware
-from django.template import Context
 from django.template.defaultfilters import safe
 from django.template.loader import render_to_string
 from django.utils import six

--- a/cms/test_utils/testcases.py
+++ b/cms/test_utils/testcases.py
@@ -395,8 +395,11 @@ class BaseCMSTestCase(object):
 
     assertWarns = failUnlessWarns
 
+    def template_from_string(self, template):
+        return engines['django'].from_string(template)
+
     def render_template_obj(self, template, context, request):
-        template_obj = engines['django'].from_string(template)
+        template_obj = self.template_from_string(template)
         return template_obj.render(context, request)
 
     def apphook_clear(self):

--- a/cms/tests/test_rendering.py
+++ b/cms/tests/test_rendering.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from django.core.cache import cache
-from django.template import Template
 from django.test.utils import override_settings
 from sekizai.context import SekizaiContext
 
@@ -206,9 +205,13 @@ class RenderingTestCase(CMSTestCase):
         t = u'{% load cms_tags %}' + \
             u'{{ plugin.counter }}|{{ plugin.instance.body }}|{{ test_passed_plugin_context_processor }}|{{ test_plugin_context_processor }}'
         instance, plugin = CMSPlugin.objects.all()[0].get_plugin_instance()
-        instance.render_template = Template(t)
-        context = PluginContext({'original_context_var': 'original_context_var_ok'}, instance,
-                                self.test_placeholders['main'], processors=(test_passed_plugin_context_processor,))
+        instance.render_template = self.template_from_string(t)
+        context = SekizaiContext()
+        context['original_context_var'] = 'original_context_var_ok'
+        context = PluginContext(
+            context, instance, self.test_placeholders['main'],
+            processors=(test_passed_plugin_context_processor,)
+        )
         plugin_rendering._standard_processors = {}
         c = render_plugins((instance,), context, self.test_placeholders['main'])
         r = "".join(c)

--- a/cms/tests/test_toolbar.py
+++ b/cms/tests/test_toolbar.py
@@ -926,8 +926,8 @@ class ToolbarTests(ToolbarTestBase):
             self.assertEquals(admin_menu.find_first(AjaxItem, name=menu_name).item.on_success, '/')
 
 
+@override_settings(ROOT_URLCONF='cms.test_utils.project.placeholderapp_urls')
 class EditModelTemplateTagTest(ToolbarTestBase):
-    urls = 'cms.test_utils.project.placeholderapp_urls'
     edit_fields_rx = "(\?|&amp;)edit_fields=%s"
 
     def tearDown(self):


### PR DESCRIPTION
This is sill WiP

This is getting indistinguishable from porting to Django 1.10 ..

It's on hold until test dependencies are ported to Django 1.10