### PR TITLE
Fixes for CMSApp

### DIFF
--- a/cms/app_base.py
+++ b/cms/app_base.py
@@ -75,6 +75,9 @@ class CMSApp(object):
 
     @legacy_menus.setter
     def menus(self, value):
+        warnings.warn('Accessing CMSApp.menus directly is deprecated, '
+                      'and it will be removed in version 3.5; CMSApp.get_menus method',
+                      DeprecationWarning)
         self._menus = value
 
     def get_menus(self, page=None, language=None, **kwargs):

--- a/docs/how_to/apphooks.rst
+++ b/docs/how_to/apphooks.rst
@@ -204,8 +204,10 @@ To disable this behaviour set ``permissions = False`` on your apphook::
 
     class SampleApp(CMSApp):
         name = _("Sample App")
-        _urls = ["project.sampleapp.urls"]
         permissions = False
+
+        def get_urls(self, page=None, language=None, **kwargs):
+            return ["project.sampleapp.urls"]
 
 If you still want some of your views to use the CMS's permission checks you can enable them via a decorator, ``cms.utils.decorators.cms_perms``
 


### PR DESCRIPTION
This adds a missing deprecation warning.

I also changed the docs to encourage the use of `get_menus()` vs setting `_menus` directly.

However, the API docs document both. Should developers only use `get_menus()` and `get_urls()` and treat `_menus` & `_urls` as internal APIs? Or should the docs encourage two different ways to configure the menus and urls for an Apphook?
