### PR TITLE
Apphook config multisite

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -36,6 +36,7 @@
   block.
 * Fixed an issue when plugin that is aliased on the same page couldn't be
   operated upon in the structure mode.
+* Removed globally unique constraint for Apphook configs.
 
 
 === 3.3.0 (2016-05-26) ===

--- a/cms/admin/forms.py
+++ b/cms/admin/forms.py
@@ -295,6 +295,7 @@ class AdvancedSettingsForm(forms.ModelForm):
     def _check_unique_namespace_instance(self, namespace):
         return Page.objects.filter(
             publisher_is_draft=True,
+            site_id=self.instance.site_id,
             application_namespace=namespace
         ).exclude(pk=self.instance.pk).exists()
 


### PR DESCRIPTION
Admittedly this was a choice made upon introduction of apphook config, but I can't see a good reason to not allow to reuse the same apphook config on different sites. ``application_namespace`` is already marked as unique only for each site (https://github.com/divio/django-cms/blob/release/3.3.x/cms/models/pagemodel.py#L124) thus I don't think apphook config should be more restrictive. I'd backport this at least to 3.2.x branch too