### PR TITLE
Fixed dropdowns not showing up when user has limited permissions.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -30,6 +30,8 @@
 * Added support for tiered ``CMS_PLACEHOLDER_CONF``.
 * Fixed a useless placeholders edit permissions checking when not in edit
   mode.
+* Fixed a bug where users with limited permissions could not interact with
+  page tree dropdowns.
 
 
 === 3.3.0 (2016-05-26) ===

--- a/cms/templates/admin/cms/page/tree/menu.html
+++ b/cms/templates/admin/cms/page/tree/menu.html
@@ -69,7 +69,7 @@
     data-col{{ lang|lower|cut:'-' }}='
         <div class="cms-tree-col">
             <div class="cms-tree-item cms-tree-item-lang">
-                <div class="cms-tree-item-inner cms-pagetree-dropdown js-cms-pagetree-dropdown">
+                <div class="cms-tree-item-inner cms-pagetree-dropdown{% if has_change_permission and has_publish_permission %} js-cms-pagetree-dropdown{% endif %}">
                     {% if has_change_permission and has_publish_permission %}
                         <a href="{% url 'admin:cms_page_preview_page' page.id lang %}"
                             class="cms-pagetree-dropdown-trigger js-cms-pagetree-dropdown-trigger"


### PR DESCRIPTION
The dropdowns show up as a result of a combination of css classes
added to correct nodes. This functionality relies on having the
same amount of triggers and dropdowns on the page, since they are
referenced by their index and not by parent.

Should fix https://github.com/divio/django-cms/issues/5449