### PR TITLE
Moved child-plugin-classes templates out of "js" sekizai block

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -32,6 +32,8 @@
   mode.
 * Fixed a bug where users with limited permissions could not interact with
   page tree dropdowns.
+* Fixed a bug where Django Compressor could not be used on the sekizai ``js``
+  block.
 
 
 === 3.3.0 (2016-05-26) ===

--- a/cms/templates/cms/toolbar/placeholder.html
+++ b/cms/templates/cms/toolbar/placeholder.html
@@ -2,6 +2,11 @@
 {% load i18n l10n sekizai_tags %}
 
 <div class="cms-placeholder cms-placeholder-{{ placeholder.pk|unlocalize }}"></div>
+{% language request.toolbar.toolbar_language %}
+<script id="cms-plugin-child-classes-{{ placeholder.pk|unlocalize }}" type="text/cms-template">
+    {% include request.toolbar.drag_item_menu_template %}
+</script>
+{% endlanguage %}
 
 {% endspaceless %}{% addtoblock "js" %}
 {% language request.toolbar.toolbar_language %}
@@ -19,9 +24,6 @@ CMS._plugins.push(['cms-placeholder-{{ placeholder.pk|unlocalize }}', {
         copy_plugin: '{{ placeholder.get_copy_url }}'
     }
 }]);
-</script>
-<script id="cms-plugin-child-classes-{{ placeholder.pk|unlocalize }}" type="text/cms-template">
-    {% include request.toolbar.drag_item_menu_template %}
 </script>
 {% endlanguage %}
 {% endaddtoblock %}

--- a/cms/tests/test_toolbar.py
+++ b/cms/tests/test_toolbar.py
@@ -1058,10 +1058,15 @@ class EditModelTemplateTagTest(ToolbarTestBase):
         response = detail_view(request, ex1.pk, template_string=template_text)
         self.assertContains(
             response,
-            '<h1><div class="cms-placeholder cms-placeholder-{0}"></div>\n'
-            '<div class="cms-plugin cms-plugin-{1}">{2}</div></h1>'.format(ex1.placeholder.pk,
-                                                                           plugin.pk, render_placeholder_body)
-            )
+            '<h1><div class="cms-placeholder cms-placeholder-{0}"></div>'.format(ex1.placeholder.pk))
+
+        self.assertContains(
+            response,
+            '<script id="cms-plugin-child-classes-{0}" type="text/cms-template">'.format(ex1.placeholder.pk))
+
+        self.assertContains(
+            response,
+            '<div class="cms-plugin cms-plugin-{0}">{1}</div></h1>'.format(plugin.pk, render_placeholder_body))
 
         self.assertContains(
             response,


### PR DESCRIPTION
In commit 4f2ec23, a ``<script type="text/cms-template">`` (for
holding client-side content that is not to be rendered until
runtime, and which we will use until the HTML element
``<template>`` is fully supported) was placed inside a Sekizai
block where it would not interfere with page rendering.

Unfortunately, this turned out to be incompatible with Django
Compressor divio#5454, which
raises an error on the (deliberately invalid)
``type="text/cms-template"``.

It has been moved out of the Sekizai block to fix this problem. The
render-blocking effects of the script are negligible.