### PR TITLE
Permissions cleanup (part 1)

### DIFF
--- a/cms/admin/forms.py
+++ b/cms/admin/forms.py
@@ -18,6 +18,7 @@ from cms.constants import PAGE_TYPES_ID
 from cms.forms.widgets import UserSelectAdminWidget, AppHookSelect, ApplicationConfigSelect
 from cms.models import (CMSPlugin, Page, PagePermission, PageUser, ACCESS_PAGE, PageUserGroup, Title,
                         Placeholder, EmptyTitle, GlobalPagePermission)
+from cms.plugin_pool import plugin_pool
 from cms.utils.compat.forms import UserCreationForm
 from cms.utils.conf import get_cms_setting
 from cms.utils.i18n import get_language_list, get_language_object, get_language_tuple
@@ -696,10 +697,17 @@ class PluginAddValidationForm(forms.Form):
         CMSPlugin.objects.all(),
         required=False,
     )
+    plugin_type = forms.CharField(required=True)
 
-    def __init__(self, *args, **kwargs):
-        self.plugin_type = kwargs.pop('plugin_type')
-        super(PluginAddValidationForm, self).__init__(*args, **kwargs)
+    def clean_plugin_type(self):
+        plugin_type = self.cleaned_data['plugin_type']
+
+        try:
+            plugin_pool.get_plugin(plugin_type)
+        except KeyError:
+            message = ugettext("Invalid plugin type '%s'") % plugin_type
+            raise ValidationError(message)
+        return plugin_type
 
     def clean(self):
         from cms.utils.plugins import has_reached_plugin_limit
@@ -737,7 +745,7 @@ class PluginAddValidationForm(forms.Form):
         try:
             has_reached_plugin_limit(
                 placeholder,
-                self.plugin_type,
+                data['plugin_type'],
                 language,
                 template=template
             )

--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -630,6 +630,19 @@ class PageAdmin(PlaceholderAdminMixin, ModelAdmin):
             return False
         return True
 
+    def has_paste_plugin_permission(self, request, plugins, target_placeholder):
+        for plugin in plugins:
+            if not permissions.has_plugin_permission(request.user, plugin.plugin_type, "add"):
+                return False
+
+        page = target_placeholder.page
+
+        if page and not page.has_change_permission(request):
+            return False
+        if page and not page.publisher_is_draft:
+            return False
+        return True
+
     def has_move_plugin_permission(self, request, plugin, target_placeholder):
         if not permissions.has_plugin_permission(request.user, plugin.plugin_type, "change"):
             return False

--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -1150,7 +1150,7 @@ class PageAdmin(PlaceholderAdminMixin, ModelAdmin):
                 return HttpResponseBadRequest(force_text(_("Language must be set to a supported language!")))
             for placeholder in placeholders:
                 plugins = list(
-                    placeholder.cmsplugin_set.filter(language=source_language).order_by('path'))
+                    placeholder.get_plugins(language=source_language).order_by('path'))
                 if not self.has_copy_plugin_permission(request, placeholder, placeholder, plugins):
                     return HttpResponseForbidden(force_text(_('You do not have permission to copy these plugins.')))
                 copy_plugins.copy_plugins_to(plugins, placeholder, target_language)

--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -540,21 +540,25 @@ class PageAdmin(PlaceholderAdminMixin, ModelAdmin):
         """
         Return true if the current user has permission to add a new page.
         """
-        if get_cms_setting('PERMISSION'):
+        can_add = super(PageAdmin, self).has_add_permission(request)
+
+        if can_add and get_cms_setting('PERMISSION'):
             return permissions.has_page_add_permission_from_request(request)
-        return super(PageAdmin, self).has_add_permission(request)
+        return can_add
 
     def has_change_permission(self, request, obj=None):
         """
         Return true if the current user has permission on the page.
         Return the string 'All' if the user has all rights.
         """
-        if get_cms_setting('PERMISSION'):
+        can_change = super(PageAdmin, self).has_change_permission(request, obj)
+
+        if can_change and get_cms_setting('PERMISSION'):
             if obj:
                 return obj.has_change_permission(request)
             else:
                 return permissions.has_page_change_permission(request)
-        return super(PageAdmin, self).has_change_permission(request, obj)
+        return can_change
 
     def has_delete_permission(self, request, obj=None):
         """
@@ -562,12 +566,12 @@ class PageAdmin(PlaceholderAdminMixin, ModelAdmin):
         Django model instance. If CMS_PERMISSION are in use also takes look to
         object permissions.
         """
-        if get_cms_setting('PERMISSION') and obj is not None:
-            return obj.has_delete_permission(request)
-
         can_delete = super(PageAdmin, self).has_delete_permission(request, obj)
 
         if not can_delete or not obj:
+            return False
+
+        if get_cms_setting('PERMISSION') and not obj.has_delete_permission(request):
             return False
 
         user = request.user
@@ -580,12 +584,12 @@ class PageAdmin(PlaceholderAdminMixin, ModelAdmin):
         return True
 
     def has_delete_translation_permission(self, request, language, obj=None):
-        if get_cms_setting('PERMISSION') and obj is not None:
-            return obj.has_delete_permission(request)
-
         can_delete = permissions.has_auth_page_permission(request.user, action='delete')
 
         if not can_delete or not obj:
+            return False
+
+        if get_cms_setting('PERMISSION') and not obj.has_delete_permission(request):
             return False
 
         user = request.user

--- a/cms/admin/permissionadmin.py
+++ b/cms/admin/permissionadmin.py
@@ -212,12 +212,25 @@ class GenericCmsPermissionAdmin(object):
         return True
 
     def has_add_permission(self, request):
-        return self._has_change_permissions_permission(request) and \
-               super(self.__class__, self).has_add_permission(request)
+        has_model_perm = super(GenericCmsPermissionAdmin, self).has_add_permission(request)
+
+        if not has_model_perm:
+            return False
+        return self._has_change_permissions_permission(request)
 
     def has_change_permission(self, request, obj=None):
-        return self._has_change_permissions_permission(request) and \
-               super(self.__class__, self).has_change_permission(request, obj)
+        has_model_perm = super(GenericCmsPermissionAdmin, self).has_change_permission(request, obj)
+
+        if not has_model_perm:
+            return False
+        return self._has_change_permissions_permission(request)
+
+    def has_delete_permission(self, request, obj=None):
+        has_model_perm = super(GenericCmsPermissionAdmin, self).has_delete_permission(request, obj)
+
+        if not has_model_perm:
+            return False
+        return self._has_change_permissions_permission(request)
 
 
 if get_cms_setting('PERMISSION'):

--- a/cms/admin/permissionadmin.py
+++ b/cms/admin/permissionadmin.py
@@ -55,9 +55,9 @@ class PagePermissionInlineAdmin(TabularInline):
     def get_queryset(self, request):
         """
         Queryset change, so user with global change permissions can see
-        all permissions. Otherwise can user see only permissions for
+        all permissions. Otherwise user can see only permissions for
         peoples which are under him (he can't see his permissions, because
-        this will lead to violation, when he can add more power to itself)
+        this will lead to violation, when he can add more power to himself)
         """
         # can see only permissions for users which are under him in tree
 

--- a/cms/admin/permissionadmin.py
+++ b/cms/admin/permissionadmin.py
@@ -66,7 +66,7 @@ class PagePermissionInlineAdmin(TabularInline):
             qs = self.model.objects.subordinate_to_user(request.user)
             return qs.filter(can_view=False)
         except NoPermissionsException:
-            return self.objects.get_empty_query_set()
+            return self.objects.none()
 
     def get_formset(self, request, obj=None, **kwargs):
         """
@@ -107,11 +107,6 @@ class ViewRestrictionInlineAdmin(PagePermissionInlineAdmin):
     ]
 
     def get_formset(self, request, obj=None, **kwargs):
-        """
-        Some fields may be excluded here. User can change only permissions
-        which are available for him. E.g. if user does not haves can_publish
-        flag, he can't change assign can_publish permissions.
-        """
         formset_cls = super(PagePermissionInlineAdmin, self).get_formset(request, obj, **kwargs)
         qs = self.get_queryset(request)
         if obj is not None:
@@ -120,10 +115,6 @@ class ViewRestrictionInlineAdmin(PagePermissionInlineAdmin):
         return formset_cls
 
     def get_queryset(self, request):
-        """
-        Returns a QuerySet of all model instances that can be edited by the
-        admin site. This is used by changelist_view.
-        """
         qs = self.model.objects.subordinate_to_user(request.user)
         return qs.filter(can_view=True)
 

--- a/cms/admin/placeholderadmin.py
+++ b/cms/admin/placeholderadmin.py
@@ -13,7 +13,7 @@ from django.http import (
     HttpResponseNotFound,
     HttpResponseRedirect,
 )
-from django.shortcuts import get_object_or_404, render
+from django.shortcuts import get_list_or_404, get_object_or_404, render
 from django.template.response import TemplateResponse
 from django.utils.decorators import method_decorator
 from django.utils.encoding import force_text
@@ -21,6 +21,7 @@ from django.utils.translation import ugettext as _
 from django.views.decorators.clickjacking import xframe_options_sameorigin
 from django.views.decorators.http import require_POST
 
+from cms.admin.forms import PluginAddValidationForm
 from cms.constants import PLUGIN_COPY_ACTION, PLUGIN_MOVE_ACTION, SLUG_REGEXP
 from cms.exceptions import PluginLimitReached
 from cms.models.placeholdermodel import Placeholder
@@ -244,21 +245,49 @@ class PlaceholderAdminMixin(object):
             - plugin_parent (optional)
             - plugin_position (optional)
         """
-        plugin_type = request.GET.get('plugin_type')
+        form = PluginAddValidationForm(request.GET)
 
-        if not plugin_type:
-            return HttpResponseBadRequest(force_text(
-                    _("Invalid request, missing plugin_type parameter")
-                ))
+        if not form.is_valid():
+            # list() is necessary for python 3 compatibility.
+            # errors is s dict mapping fields to a list of errors
+            # for that field.
+            error = list(form.errors.values())[0][0]
+            return HttpResponseBadRequest(force_text(error))
 
-        try:
-            plugin_class = plugin_pool.get_plugin(plugin_type)
-        except KeyError:
-            return HttpResponseBadRequest(force_text(
-                _("Invalid plugin type '%s'") % plugin_type
-            ))
+        plugin_data = form.cleaned_data
+        placeholder = plugin_data['placeholder_id']
+        plugin_type = plugin_data['plugin_type']
 
+        if not self.has_add_plugin_permission(request, placeholder, plugin_type):
+            message = force_text(_('You do not have permission to add a plugin'))
+            return HttpResponseForbidden(message)
+
+        parent = plugin_data.get('plugin_parent')
+
+        if parent:
+            position = parent.cmsplugin_set.count()
+        else:
+            position = CMSPlugin.objects.filter(
+                parent__isnull=True,
+                language=plugin_data['plugin_language'],
+                placeholder=placeholder,
+            ).count()
+
+        plugin_data['position'] = position
+
+        plugin_class = plugin_pool.get_plugin(plugin_type)
         plugin_admin = plugin_class(admin_site=self.admin_site)
+
+        # Setting attributes on the form class is perfectly fine.
+        # The form class is created by modelform factory every time
+        # this get_form() method is called.
+        plugin_admin._cms_initial_attributes = {
+            'language': plugin_data['plugin_language'],
+            'placeholder': plugin_data['placeholder_id'],
+            'parent': plugin_data.get('plugin_parent', None),
+            'plugin_type': plugin_data['plugin_type'],
+            'position': plugin_data['position'],
+        }
 
         response = plugin_admin.add_view(request)
 
@@ -299,14 +328,13 @@ class PlaceholderAdminMixin(object):
                 plugins = inst.placeholder_ref.get_plugins_list()
             else:
                 plugins = list(
-                    source_placeholder.cmsplugin_set.filter(
+                    source_placeholder.get_plugins().filter(
                         path__startswith=source_plugin.path,
                         depth__gte=source_plugin.depth).order_by('path')
                 )
         else:
             plugins = list(
-                source_placeholder.cmsplugin_set.filter(
-                    language=source_language).order_by('path'))
+                source_placeholder.get_plugins(language=source_language).order_by('path'))
             reload_required = requires_reload(PLUGIN_COPY_ACTION, plugins)
         if not self.has_copy_plugin_permission(
                 request, source_placeholder, target_placeholder, plugins):
@@ -371,28 +399,23 @@ class PlaceholderAdminMixin(object):
             plugin_id = int(plugin_id)
         except ValueError:
             return HttpResponseNotFound(force_text(_("Plugin not found")))
-        cms_plugin = get_object_or_404(CMSPlugin.objects.select_related('placeholder'), pk=plugin_id)
 
-        instance, plugin_admin = cms_plugin.get_plugin_instance(self.admin_site)
+        queryset = CMSPlugin.objects.values_list('plugin_type', flat=True)
+        plugin_type = get_list_or_404(queryset, pk=plugin_id)[0]
+        # CMSPluginBase subclass
+        plugin_class = plugin_pool.get_plugin(plugin_type)
+        # CMSPluginBase subclass instance
+        plugin_instance = plugin_class(plugin_class.model, self.admin_site)
+        # CMSPlugin subclass instance
+        obj = get_object_or_404(plugin_class.model, pk=plugin_id)
 
-        if not self.has_change_plugin_permission(request, cms_plugin):
+        if not self.has_change_plugin_permission(request, obj):
             return HttpResponseForbidden(force_text(_("You do not have permission to edit this plugin")))
 
-        plugin_admin.cms_plugin_instance = cms_plugin
-        plugin_admin.placeholder = cms_plugin.placeholder
+        response = plugin_instance.change_view(request, str(plugin_id))
 
-        if not instance:
-            # instance doesn't exist, call add view
-            response = plugin_admin.add_view(request)
-        else:
-            # already saved before, call change view
-            # we actually have the instance here, but since i won't override
-            # change_view method, is better if it will be loaded again, so
-            # just pass id to plugin_admin
-            response = plugin_admin.change_view(request, str(plugin_id))
-
-        if request.method == "POST" and plugin_admin.object_successfully_changed:
-            self.post_edit_plugin(request, plugin_admin.saved_object)
+        if request.method == "POST" and plugin_instance.object_successfully_changed:
+            self.post_edit_plugin(request, plugin_instance.saved_object)
         return response
 
     @method_decorator(require_POST)

--- a/cms/admin/useradmin.py
+++ b/cms/admin/useradmin.py
@@ -17,7 +17,8 @@ for model, admin_instance in site._registry.items():
     if model == user_model:
         admin_class = admin_instance.__class__
 
-class PageUserAdmin(admin_class, GenericCmsPermissionAdmin):
+
+class PageUserAdmin(GenericCmsPermissionAdmin, admin_class):
     form = PageUserForm
     add_form = PageUserForm
     model = PageUser

--- a/cms/admin/useradmin.py
+++ b/cms/admin/useradmin.py
@@ -31,7 +31,7 @@ class PageUserAdmin(admin_class, GenericCmsPermissionAdmin):
             return self.model.objects.get_empty_query_set()
 
 
-class PageUserGroupAdmin(admin.ModelAdmin, GenericCmsPermissionAdmin):
+class PageUserGroupAdmin(GenericCmsPermissionAdmin, admin.ModelAdmin):
     form = PageUserGroupForm
     list_display = ('name', 'created_by')
 

--- a/cms/api.py
+++ b/cms/api.py
@@ -568,9 +568,9 @@ def copy_plugins_to_language(page, source_language, target_language,
     for placeholder in placeholders:
         # only_empty is True we check if the placeholder already has plugins and
         # we skip it if has some
-        if not only_empty or not placeholder.cmsplugin_set.filter(language=target_language).exists():
+        if not only_empty or not placeholder.get_plugins(language=target_language).exists():
             plugins = list(
-                placeholder.cmsplugin_set.filter(language=source_language).order_by('path'))
+                placeholder.get_plugins(language=source_language).order_by('path'))
             copied_plugins = copy_plugins.copy_plugins_to(plugins, placeholder, target_language)
             copied += len(copied_plugins)
     return copied

--- a/cms/models/managers.py
+++ b/cms/models/managers.py
@@ -279,10 +279,10 @@ class PagePermissionManager(BasicPagePermissionManager):
 
         Result of this is used in admin for page permissions inline.
         """
-        from cms.models import GlobalPagePermission, Page
+        from cms.models import Page
+        from cms.utils.permissions import can_change_global_permissions
 
-        if user.is_superuser or \
-                GlobalPagePermission.objects.with_can_change_permissions(user):
+        if can_change_global_permissions(user):
             # everything for those guys
             return self.all()
 
@@ -293,7 +293,8 @@ class PagePermissionManager(BasicPagePermissionManager):
             user_level = get_user_permission_level(user)
         except NoPermissionsException:
             return self.none()
-            # get current site
+
+        # get current site
         site = Site.objects.get_current()
         # get all permissions
         page_id_allow_list = Page.permissions.get_change_permissions_id_list(user, site)

--- a/cms/models/placeholdermodel.py
+++ b/cms/models/placeholdermodel.py
@@ -118,7 +118,12 @@ class Placeholder(models.Model):
         """
         if user.is_superuser:
             return True
+
         objects = [self.page] if self.page else self._get_attached_objects()
+
+        if not objects:
+            return False
+
         get_permission = self._get_object_permission
         return all(get_permission(obj, user, 'change') for obj in objects)
 

--- a/cms/models/placeholdermodel.py
+++ b/cms/models/placeholdermodel.py
@@ -111,52 +111,30 @@ class Placeholder(models.Model):
             model_name = model.__name__.lower()
             return admin_reverse('%s_%s_%s' % (app_label, model_name, key), args=args)
 
-    def _get_permission(self, request, key):
+    def _has_permission(self, user, key):
         """
-        Generic method to check the permissions for a request for a given key,
-        the key can be: 'add', 'change' or 'delete'. For each attached object
-        permission has to be granted either on attached model or on attached object.
-          * 'add' and 'change' permissions on placeholder need either on add or change
-            permission on attached object to be granted.
-          * 'delete' need either on add, change or delete
+        Returns True if user has permission
+        to change all objects attached to this placeholder.
         """
-        if getattr(request, 'user', None) and request.user.is_superuser:
+        if user.is_superuser:
             return True
-        perm_keys = {
-            'add': ('add', 'change',),
-            'change': ('add', 'change',),
-            'delete': ('add', 'change', 'delete'),
-        }
-        if key not in perm_keys:
-            raise Exception("%s is not a valid perm key. "
-                            "'Only 'add', 'change' and 'delete' are allowed" % key)
         objects = [self.page] if self.page else self._get_attached_objects()
-        obj_perm = None
-        for obj in objects:
-            obj_perm = False
-            for key in perm_keys[key]:
-                if self._get_object_permission(obj, request, key):
-                    obj_perm = True
-                    break
-            if not obj_perm:
-                return False
-        return obj_perm
+        get_permission = self._get_object_permission
+        return all(get_permission(obj, user, 'change') for obj in objects)
 
-    def _get_object_permission(self, obj, request, key):
-        if not getattr(request, 'user', None):
-            return False
+    def _get_object_permission(self, obj, user, key):
         opts = obj._meta
         perm_code = '%s.%s' % (opts.app_label, get_permission_codename(key, opts))
-        return request.user.has_perm(perm_code) or request.user.has_perm(perm_code, obj)
+        return user.has_perm(perm_code) or user.has_perm(perm_code, obj)
 
     def has_change_permission(self, request):
-        return self._get_permission(request, 'change')
+        return self._has_permission(request.user, 'change')
 
     def has_add_permission(self, request):
-        return self._get_permission(request, 'add')
+        return self._has_permission(request.user, 'add')
 
     def has_delete_permission(self, request):
-        return self._get_permission(request, 'delete')
+        return self._has_permission(request.user, 'delete')
 
     def has_clear_permission(self, user, languages):
         plugin_types = (

--- a/cms/models/pluginmodel.py
+++ b/cms/models/pluginmodel.py
@@ -271,7 +271,6 @@ class CMSPlugin(six.with_metaclass(PluginModelBase, MP_Node)):
             page = None
             if request:
                 page = request.current_page
-            plugin.cms_plugin_instance = instance
             context['allowed_child_classes'] = plugin.get_child_classes(placeholder_slot, page)
             context['allowed_parent_classes'] = plugin.get_parent_classes(placeholder_slot, page)
             if plugin.render_plugin:
@@ -281,15 +280,6 @@ class CMSPlugin(six.with_metaclass(PluginModelBase, MP_Node)):
             else:
                 template = None
             return render_plugin(context, instance, placeholder, template, processors, current_app)
-        else:
-            from cms.middleware.toolbar import toolbar_plugin_processor
-
-            if processors and toolbar_plugin_processor in processors:
-                if not placeholder:
-                    placeholder = self.placeholder
-                context = PluginContext(context, self, placeholder, current_app=current_app)
-                template = None
-                return render_plugin(context, self, placeholder, template, processors, current_app)
         return ""
 
     def get_media_path(self, filename):

--- a/cms/signals/page.py
+++ b/cms/signals/page.py
@@ -55,7 +55,7 @@ def post_save_page(instance, **kwargs):
 def pre_delete_page(instance, **kwargs):
     menu_pool.clear(instance.site_id)
     for placeholder in instance.get_placeholders():
-        for plugin in placeholder.cmsplugin_set.all().order_by('-depth'):
+        for plugin in placeholder.get_plugins().order_by('-depth'):
             plugin._no_reorder = True
             plugin.delete(no_mp=True)
         placeholder.delete()

--- a/cms/test_utils/project/customuserapp/admin.py
+++ b/cms/test_utils/project/customuserapp/admin.py
@@ -9,5 +9,12 @@ if getattr(OriginalUser._meta, 'swapped', False):
     class UserAdmin(OriginalUserAdmin):
         list_display = ('username', 'email', 'get_full_name', 'is_staff')
         search_fields = ('username', 'email',)
+        fieldsets = (
+            (None, {'fields': ('username', 'password')}),
+            ('Personal info', {'fields': ('email',)}),
+            ('Permissions', {'fields': ('is_active', 'is_staff', 'is_superuser',
+                                        'groups', 'user_permissions')}),
+            ('Important dates', {'fields': ('last_login',)}),
+        )
 
     admin.site.register(get_user_model(), UserAdmin)

--- a/cms/test_utils/testcases.py
+++ b/cms/test_utils/testcases.py
@@ -20,7 +20,7 @@ from django.utils.six.moves.urllib.parse import unquote, urljoin
 from menus.menu_pool import menu_pool
 
 from cms.models import Page
-from cms.models.permissionmodels import GlobalPagePermission
+from cms.models.permissionmodels import GlobalPagePermission, PagePermission
 from cms.test_utils.util.context_managers import UserLoginContext
 from cms.utils.compat import DJANGO_1_8
 from cms.utils.permissions import set_current_user
@@ -132,12 +132,30 @@ class BaseCMSTestCase(object):
             'can_publish': True,
             'can_change_permissions': False,
             'can_move_page': True,
+            'user': user,
         }
         options.update(**kwargs)
 
-        gpp = GlobalPagePermission.objects.create(user=user, **options)
+        gpp = GlobalPagePermission.objects.create(**options)
         gpp.sites = Site.objects.all()
         return gpp
+
+    def add_page_permission(self, user, page, **kwargs):
+        options = {
+            'can_change': True,
+            'can_delete': True,
+            'can_change_advanced_settings': False,
+            'can_publish': True,
+            'can_change_permissions': False,
+            'can_move_page': True,
+            'page': page,
+            'user': user,
+        }
+        options.update(**kwargs)
+
+        pp = PagePermission.objects.create(**options)
+        pp.sites = Site.objects.all()
+        return pp
 
     def _create_user(self, username, is_staff=False, is_superuser=False,
                      is_active=True, add_default_permissions=False, permissions=None):

--- a/cms/test_utils/testcases.py
+++ b/cms/test_utils/testcases.py
@@ -15,6 +15,7 @@ from django.template import engines
 from django.template.context import Context
 from django.test import testcases
 from django.test.client import RequestFactory
+from django.utils.http import urlencode
 from django.utils.timezone import now
 from django.utils.translation import activate
 from django.utils.six.moves.urllib.parse import unquote, urljoin
@@ -129,6 +130,9 @@ class BaseCMSTestCase(object):
 
     def add_permission(self, user, codename):
         user.user_permissions.add(self.get_permission(codename))
+
+    def remove_permission(self, user, codename):
+        user.user_permissions.remove(Permission.objects.get(codename=codename))
 
     def add_global_permission(self, user, **kwargs):
         options = {
@@ -492,6 +496,15 @@ class BaseCMSTestCase(object):
             reverse_id='permissions',
         )
         return page
+
+    def get_add_plugin_uri(self, placeholder, plugin_type, language='en'):
+        endpoint = placeholder.get_add_url()
+        uri = endpoint + '?' + urlencode({
+            'plugin_type': plugin_type,
+            'placeholder_id': placeholder.pk,
+            'plugin_language': language,
+        })
+        return uri
 
 
 class CMSTestCase(BaseCMSTestCase, testcases.TestCase):

--- a/cms/test_utils/testcases.py
+++ b/cms/test_utils/testcases.py
@@ -19,6 +19,7 @@ from django.utils.translation import activate
 from django.utils.six.moves.urllib.parse import unquote, urljoin
 from menus.menu_pool import menu_pool
 
+from cms.api import create_page
 from cms.models import Page
 from cms.models.permissionmodels import GlobalPagePermission, PagePermission
 from cms.test_utils.util.context_managers import UserLoginContext
@@ -126,12 +127,12 @@ class BaseCMSTestCase(object):
 
     def add_global_permission(self, user, **kwargs):
         options = {
-            'can_change': True,
-            'can_delete': True,
+            'can_change': False,
+            'can_delete': False,
             'can_change_advanced_settings': False,
-            'can_publish': True,
+            'can_publish': False,
             'can_change_permissions': False,
-            'can_move_page': True,
+            'can_move_page': False,
             'user': user,
         }
         options.update(**kwargs)
@@ -452,6 +453,25 @@ class BaseCMSTestCase(object):
         opts = model._meta
         url_name = "{}_{}_{}".format(opts.app_label, opts.model_name, action)
         return admin_reverse(url_name, args=args)
+
+    def get_permissions_test_page(self):
+        admin = self.get_superuser()
+        create_page(
+            "home",
+            "nav_playground.html",
+            "en",
+            created_by=admin,
+            published=True,
+        )
+        page = create_page(
+            "permissions",
+            "nav_playground.html",
+            "en",
+            created_by=admin,
+            published=True,
+            reverse_id='permissions',
+        )
+        return page
 
 
 class CMSTestCase(BaseCMSTestCase, testcases.TestCase):

--- a/cms/test_utils/testcases.py
+++ b/cms/test_utils/testcases.py
@@ -246,14 +246,14 @@ class BaseCMSTestCase(object):
         if not created_by:
             created_by = self.get_superuser()
 
-        if PageUser.USERNAME_FIELD != "email":
-            username = "perms-testuser"
-        else:
-            username = "perms-testuser@django-cms.org"
-
-        user = self._create_user(username, is_staff=True, is_superuser=False)
+        parent_link_field = list(PageUser._meta.parents.values())[0]
+        user = self._create_user(
+            'perms-testuser',
+            is_staff=True,
+            is_superuser=False,
+        )
         data = model_to_dict(user, exclude=['groups', 'user_permissions'])
-        data['user_ptr'] = user
+        data[parent_link_field.name] = user
         data['created_by'] = created_by
         return PageUser.objects.create(**data)
 

--- a/cms/tests/test_admin.py
+++ b/cms/tests/test_admin.py
@@ -15,15 +15,13 @@ from django.http import (Http404, HttpResponseBadRequest, HttpResponseForbidden,
                          QueryDict, HttpResponseNotFound)
 from django.utils.encoding import force_text, smart_str
 from django.utils import timezone
-from django.utils.http import urlencode
 from django.utils.six.moves.urllib.parse import urlparse
 
 from cms.admin.change_list import CMSChangeList
 from cms.admin.forms import PageForm, AdvancedSettingsForm
 from cms.admin.pageadmin import PageAdmin
-from cms.admin.permissionadmin import PagePermissionInlineAdmin
 from cms import api
-from cms.api import create_page, create_title, add_plugin, assign_user_to_page, publish_page
+from cms.api import create_page, create_title, add_plugin, publish_page
 from cms.constants import PLUGIN_MOVE_ACTION, TEMPLATE_INHERITANCE_MAGIC
 from cms.models import UserSettings, StaticPlaceholder
 from cms.models.pagemodel import Page
@@ -35,7 +33,7 @@ from cms.test_utils import testcases as base
 from cms.test_utils.project.placeholderapp.models import Example1
 from cms.test_utils.testcases import (
     CMSTestCase, URL_CMS_PAGE_DELETE, URL_CMS_PAGE,URL_CMS_TRANSLATION_DELETE,
-    URL_CMS_PAGE_CHANGE_LANGUAGE, URL_CMS_PAGE_CHANGE, URL_CMS_PAGE_PERMISSIONS,
+    URL_CMS_PAGE_CHANGE_LANGUAGE, URL_CMS_PAGE_CHANGE,
     URL_CMS_PAGE_ADD, URL_CMS_PAGE_PUBLISHED
 )
 from cms.test_utils.util.fuzzy_int import FuzzyInt
@@ -95,184 +93,6 @@ class AdminTestCase(AdminTestsBase):
             self.assertNotContains(response, '/mytitleextension/')
             self.assertNotContains(response, '/mypageextension/')
 
-    def test_permissioned_page_list(self):
-        """
-        Makes sure that a user with restricted page permissions can view
-        the page list.
-        """
-        admin_user, normal_guy = self._get_guys(use_global_permissions=False)
-
-        current_site = Site.objects.get(pk=1)
-        page = create_page("Test page", "nav_playground.html", "en",
-                           site=current_site, created_by=admin_user)
-
-        PagePermission.objects.create(page=page, user=normal_guy)
-
-        with self.login_user_context(normal_guy):
-            resp = self.client.get(URL_CMS_PAGE)
-            self.assertEqual(resp.status_code, 200)
-
-    def test_edit_does_not_reset_page_adv_fields(self):
-        """
-        Makes sure that if a non-superuser with no rights to edit advanced page
-        fields edits a page, those advanced fields are not touched.
-        """
-        OLD_PAGE_NAME = 'Test Page'
-        NEW_PAGE_NAME = 'Test page 2'
-        REVERSE_ID = 'Test'
-        OVERRIDE_URL = 'my/override/url'
-
-        admin_user, normal_guy = self._get_guys()
-
-        current_site = Site.objects.get(pk=1)
-
-        # The admin creates the page
-        page = create_page(OLD_PAGE_NAME, "nav_playground.html", "en",
-                           site=current_site, created_by=admin_user)
-        page.reverse_id = REVERSE_ID
-        page.save()
-        title = page.get_title_obj()
-        title.has_url_overwrite = True
-        title.path = OVERRIDE_URL
-        title.save()
-
-        self.assertEqual(page.get_title(), OLD_PAGE_NAME)
-        self.assertEqual(page.reverse_id, REVERSE_ID)
-        self.assertEqual(title.overwrite_url, OVERRIDE_URL)
-
-        # The user edits the page (change the page name for ex.)
-        page_data = {
-            'title': NEW_PAGE_NAME,
-            'slug': page.get_slug(),
-            'language': title.language,
-            'site': page.site.pk,
-            'template': page.template,
-            'pagepermission_set-TOTAL_FORMS': 0,
-            'pagepermission_set-INITIAL_FORMS': 0,
-            'pagepermission_set-MAX_NUM_FORMS': 0,
-            'pagepermission_set-2-TOTAL_FORMS': 0,
-            'pagepermission_set-2-INITIAL_FORMS': 0,
-            'pagepermission_set-2-MAX_NUM_FORMS': 0
-        }
-        # required only if user haves can_change_permission
-        with self.login_user_context(normal_guy):
-            resp = self.client.post(base.URL_CMS_PAGE_CHANGE % page.pk, page_data,
-                                    follow=True)
-            self.assertEqual(resp.status_code, 200)
-            self.assertTemplateNotUsed(resp, 'admin/login.html')
-            page = Page.objects.get(pk=page.pk)
-
-            self.assertEqual(page.get_title(), NEW_PAGE_NAME)
-            self.assertEqual(page.reverse_id, REVERSE_ID)
-            title = page.get_title_obj()
-            self.assertEqual(title.overwrite_url, OVERRIDE_URL)
-
-        # The admin edits the page (change the page name for ex.)
-        page_data = {
-            'title': OLD_PAGE_NAME,
-            'slug': page.get_slug(),
-            'language': title.language,
-            'site': page.site.pk,
-            'template': page.template,
-            'reverse_id': page.reverse_id,
-            'pagepermission_set-TOTAL_FORMS': 0,  # required only if user haves can_change_permission
-            'pagepermission_set-INITIAL_FORMS': 0,
-            'pagepermission_set-MAX_NUM_FORMS': 0,
-            'pagepermission_set-2-TOTAL_FORMS': 0,
-            'pagepermission_set-2-INITIAL_FORMS': 0,
-            'pagepermission_set-2-MAX_NUM_FORMS': 0
-        }
-        with self.login_user_context(admin_user):
-            resp = self.client.post(base.URL_CMS_PAGE_CHANGE % page.pk, page_data,
-                                    follow=True)
-            self.assertEqual(resp.status_code, 200)
-            self.assertTemplateNotUsed(resp, 'admin/login.html')
-            page = Page.objects.get(pk=page.pk)
-
-            self.assertEqual(page.get_title(), OLD_PAGE_NAME)
-            self.assertEqual(page.reverse_id, REVERSE_ID)
-            title = page.get_title_obj()
-            self.assertEqual(title.overwrite_url, OVERRIDE_URL)
-
-    def test_edit_does_not_reset_apphook(self):
-        """
-        Makes sure that if a non-superuser with no rights to edit advanced page
-        fields edits a page, those advanced fields are not touched.
-        """
-        OLD_PAGE_NAME = 'Test Page'
-        NEW_PAGE_NAME = 'Test page 2'
-        REVERSE_ID = 'Test'
-        APPLICATION_URLS = 'project.sampleapp.urls'
-
-        admin_user, normal_guy = self._get_guys()
-
-        current_site = Site.objects.get(pk=1)
-
-        # The admin creates the page
-        page = create_page(OLD_PAGE_NAME, "nav_playground.html", "en",
-                           site=current_site, created_by=admin_user)
-        page.reverse_id = REVERSE_ID
-        page.save()
-        title = page.get_title_obj()
-        title.has_url_overwrite = True
-
-        title.save()
-        page.application_urls = APPLICATION_URLS
-        page.save()
-        self.assertEqual(page.get_title(), OLD_PAGE_NAME)
-        self.assertEqual(page.reverse_id, REVERSE_ID)
-        self.assertEqual(page.application_urls, APPLICATION_URLS)
-
-        # The user edits the page (change the page name for ex.)
-        page_data = {
-            'title': NEW_PAGE_NAME,
-            'slug': page.get_slug(),
-            'language': title.language,
-            'site': page.site.pk,
-            'template': page.template,
-            'pagepermission_set-TOTAL_FORMS': 0,
-            'pagepermission_set-INITIAL_FORMS': 0,
-            'pagepermission_set-MAX_NUM_FORMS': 0,
-            'pagepermission_set-2-TOTAL_FORMS': 0,
-            'pagepermission_set-2-INITIAL_FORMS': 0,
-            'pagepermission_set-2-MAX_NUM_FORMS': 0,
-        }
-
-        with self.login_user_context(normal_guy):
-            resp = self.client.post(base.URL_CMS_PAGE_CHANGE % page.pk, page_data,
-                                    follow=True)
-            self.assertEqual(resp.status_code, 200)
-            self.assertTemplateNotUsed(resp, 'admin/login.html')
-            page = Page.objects.get(pk=page.pk)
-            self.assertEqual(page.get_title(), NEW_PAGE_NAME)
-            self.assertEqual(page.reverse_id, REVERSE_ID)
-            self.assertEqual(page.application_urls, APPLICATION_URLS)
-            title = page.get_title_obj()
-            # The admin edits the page (change the page name for ex.)
-            page_data = {
-                'title': OLD_PAGE_NAME,
-                'slug': page.get_slug(),
-                'language': title.language,
-                'site': page.site.pk,
-                'template': page.template,
-                'reverse_id': page.reverse_id,
-            }
-
-        with self.login_user_context(admin_user):
-            resp = self.client.post(base.URL_CMS_PAGE_ADVANCED_CHANGE % page.pk, page_data,
-                                    follow=True)
-            self.assertEqual(resp.status_code, 200)
-            self.assertTemplateNotUsed(resp, 'admin/login.html')
-            resp = self.client.post(base.URL_CMS_PAGE_CHANGE % page.pk, page_data,
-                                    follow=True)
-            self.assertEqual(resp.status_code, 200)
-            self.assertTemplateNotUsed(resp, 'admin/login.html')
-            page = Page.objects.get(pk=page.pk)
-
-            self.assertEqual(page.get_title(), OLD_PAGE_NAME)
-            self.assertEqual(page.reverse_id, REVERSE_ID)
-            self.assertEqual(page.application_urls, '')
-
     def test_2apphooks_with_same_namespace(self):
         PAGE1 = 'Test Page'
         PAGE2 = 'Test page 2'
@@ -331,73 +151,6 @@ class AdminTestCase(AdminTestsBase):
             response = self.client.post(URL_CMS_PAGE_DELETE % page.pk, data)
             self.assertRedirects(response, URL_CMS_PAGE)
 
-    def test_delete_permissions(self):
-        admin_user, staff_user = self._get_guys()
-        create_page("home", "nav_playground.html", "en",
-                           created_by=admin_user, published=True)
-        page = create_page("delete-page", "nav_playground.html", "en",
-                           created_by=admin_user, published=True)
-        body = page.placeholders.get(slot='body')
-        add_plugin(body, 'TextPlugin', 'en', body='text')
-        page.publish('en')
-
-        # CMS_PERMISSION is set to True and staff user
-        # has global permissions set.
-        with self.settings(CMS_PERMISSION=True):
-            with self.login_user_context(staff_user):
-                data = {'post': 'yes'}
-                response = self.client.post(URL_CMS_PAGE_DELETE % page.pk, data)
-
-                # assert deleting page was successful
-                self.assertRedirects(response, URL_CMS_PAGE)
-                self.assertFalse(Page.objects.filter(pk=page.pk).exists())
-
-        page = create_page("delete-page", "nav_playground.html", "en",
-                           created_by=admin_user, published=True)
-
-        # CMS_PERMISSION is set to False and user does not
-        # have permission to delete any plugins but the page
-        # has no plugins.
-        with self.settings(CMS_PERMISSION=False):
-            with self.login_user_context(staff_user):
-                data = {'post': 'yes'}
-                response = self.client.post(URL_CMS_PAGE_DELETE % page.pk, data)
-
-                # assert deleting page was successful
-                self.assertRedirects(response, URL_CMS_PAGE)
-                self.assertFalse(Page.objects.filter(pk=page.pk).exists())
-
-        page = create_page("delete-page", "nav_playground.html", "en",
-                           created_by=admin_user, published=True)
-        body = page.placeholders.get(slot='body')
-        add_plugin(body, 'TextPlugin', 'en', body='text')
-        page.publish('en')
-
-        # CMS_PERMISSION is set to False and user does not
-        # have permission to delete any plugin
-        with self.settings(CMS_PERMISSION=False):
-            with self.login_user_context(staff_user):
-                data = {'post': 'yes'}
-                response = self.client.post(URL_CMS_PAGE_DELETE % page.pk, data)
-
-                # assert deleting page was unsuccessful
-                self.assertEqual(response.status_code, 403)
-                self.assertTrue(Page.objects.filter(pk=page.pk).exists())
-
-        # Give the staff user permission to delete text plugins
-        staff_user.user_permissions.add(Permission.objects.get(codename='delete_text'))
-
-        # CMS_PERMISSION is set to False and user has
-        # permission to delete text plugins
-        with self.settings(CMS_PERMISSION=False):
-            with self.login_user_context(staff_user):
-                data = {'post': 'yes'}
-                response = self.client.post(URL_CMS_PAGE_DELETE % page.pk, data)
-
-                # assert deleting page was successful
-                self.assertRedirects(response, URL_CMS_PAGE)
-                self.assertFalse(Page.objects.filter(pk=page.pk).exists())
-
     def test_delete_diff_language(self):
         admin_user = self.get_superuser()
         create_page("home", "nav_playground.html", "en",
@@ -454,78 +207,6 @@ class AdminTestCase(AdminTestsBase):
             self.assertEqual(response.status_code, 200)
             response = self.client.post(URL_CMS_TRANSLATION_DELETE % page.pk, {'language': 'es-mx'})
             self.assertRedirects(response, URL_CMS_PAGE)
-
-    def test_delete_translation_permissions(self):
-        admin_user, staff_user = self._get_guys()
-        page = create_page("delete-page-translation", "nav_playground.html", "en",
-                           created_by=admin_user, published=True)
-        body = page.placeholders.get(slot='body')
-        create_title("de", "delete-page-translation-2", page, slug="delete-page-translation-2")
-        create_title("fr", "delete-page-translation-fr", page.reload(), slug="delete-page-translation-fr")
-        add_plugin(body, 'TextPlugin', 'de', body='text')
-
-        # add a link plugin but never give the user permission to delete it
-        # all our tests target the german translation.
-        # this asserts that a plugin in another language does not interfere
-        # with deleting.
-        link = add_plugin(body, 'LinkPlugin', 'en', name='link-1')
-
-        # CMS_PERMISSION is set to True and staff user
-        # has global permissions set.
-        with self.settings(CMS_PERMISSION=True):
-            with self.login_user_context(staff_user):
-                response = self.client.post(URL_CMS_TRANSLATION_DELETE % page.pk, {'language': 'de'})
-
-                # assert deleting page was successful
-                self.assertRedirects(response, URL_CMS_PAGE)
-                self.assertFalse(page.title_set.filter(language='de').exists())
-                # LinkPlugin should continue to be
-                self.assertTrue(body.cmsplugin_set.filter(pk=link.pk).exists())
-
-        # the API needs a fresh page object
-        page = page.reload()
-        create_title("de", "delete-page-translation-2", page.reload(), slug="delete-page-translation-2")
-        add_plugin(body, 'TextPlugin', 'de', body='text')
-
-        # CMS_PERMISSION is set to False and user does not
-        # have permission to delete text plugins
-        with self.settings(CMS_PERMISSION=False):
-            with self.login_user_context(staff_user):
-                response = self.client.post(URL_CMS_TRANSLATION_DELETE % page.pk, {'language': 'de'})
-
-                # assert deleting page was successful
-                self.assertEqual(response.status_code, 403)
-                self.assertTrue(page.title_set.filter(language='de').exists())
-                # LinkPlugin should continue to be
-                self.assertTrue(body.cmsplugin_set.filter(pk=link.pk).exists())
-
-        # CMS_PERMISSION is set to False and user does not
-        # have permission to delete any plugins but the translation
-        # does not contain plugins
-        with self.settings(CMS_PERMISSION=False):
-            with self.login_user_context(staff_user):
-                response = self.client.post(URL_CMS_TRANSLATION_DELETE % page.pk, {'language': 'fr'})
-
-                # assert deleting page was successful
-                self.assertRedirects(response, URL_CMS_PAGE)
-                self.assertFalse(page.title_set.filter(language='fr').exists())
-                # LinkPlugin should continue to be
-                self.assertTrue(body.cmsplugin_set.filter(pk=link.pk).exists())
-
-        # Give the staff user permission to delete text plugins
-        staff_user.user_permissions.add(Permission.objects.get(codename='delete_text'))
-
-        # CMS_PERMISSION is set to False and user has
-        # permission to delete text plugins
-        with self.settings(CMS_PERMISSION=False):
-            with self.login_user_context(staff_user):
-                response = self.client.post(URL_CMS_TRANSLATION_DELETE % page.pk, {'language': 'de'})
-
-                # assert deleting page was successful
-                self.assertRedirects(response, URL_CMS_PAGE)
-                self.assertFalse(page.title_set.filter(language='de').exists())
-                # LinkPlugin should continue to be
-                self.assertTrue(body.cmsplugin_set.filter(pk=link.pk).exists())
 
     def test_change_dates(self):
         admin_user, staff = self._get_guys()
@@ -602,18 +283,6 @@ class AdminTestCase(AdminTestsBase):
             self.assertEqual(response.status_code, 400)
             response = self.client.post(url, {'template': get_cms_setting('TEMPLATES')[0][0]})
             self.assertEqual(response.status_code, 200)
-
-    def test_get_permissions(self):
-        page = create_page('test-page', 'nav_playground.html', 'en')
-        url = admin_reverse('cms_page_get_permissions', args=(page.pk,))
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 302)
-        self.assertRedirects(response, '/en/admin/login/?next=%s' % (URL_CMS_PAGE_PERMISSIONS % page.pk))
-        admin_user = self.get_superuser()
-        with self.login_user_context(admin_user):
-            response = self.client.get(url)
-            self.assertEqual(response.status_code, 200)
-            self.assertTemplateNotUsed(response, 'admin/login.html')
 
     def test_changelist_items(self):
         admin_user = self.get_superuser()
@@ -781,53 +450,6 @@ class AdminTestCase(AdminTestsBase):
         # After cleaning the de placeholder, en placeholder must still have all the plugins
         self.assertEqual(ph.get_plugins('en').count(), 2)
         self.assertEqual(ph.get_plugins('de').count(), 0)
-
-    def test_clear_placeholder_permissions_page(self):
-        """
-        Ensures a user without delete plugin permissions
-        cannot clear a page placeholder that contains said plugin.
-        """
-        page_en = create_page("EmptyPlaceholderTestPage (EN)", "nav_playground.html", "en")
-        ph = page_en.placeholders.get(slot="body")
-
-        # add text plugin
-        add_plugin(ph, "TextPlugin", "en", body="Hello World EN 1")
-        add_plugin(ph, "TextPlugin", "en", body="Hello World EN 2")
-
-        # add a link plugin to make sure we test diversity
-        add_plugin(ph, "LinkPlugin", "en", name='link-1')
-        add_plugin(ph, "LinkPlugin", "en", name='link-2')
-
-        # Staff user has basic page permissions but no
-        # plugin permissions.
-        staff = self._get_staff_user()
-        endpoint = '%s?language=en' % admin_reverse('cms_page_clear_placeholder', args=[ph.pk])
-
-        with self.login_user_context(staff):
-            response = self.client.post(endpoint, {'test': 0})
-
-        self.assertEqual(response.status_code, 403)
-        self.assertEqual(ph.get_plugins('en').count(), 4)
-
-        # Give the staff user permission to delete text plugins
-        staff.user_permissions.add(Permission.objects.get(codename='delete_text'))
-
-        with self.login_user_context(staff):
-            response = self.client.post(endpoint, {'test': 0})
-
-        # Operation results in 403 because staff user does not have
-        # permission to delete links
-        self.assertEqual(response.status_code, 403)
-        self.assertEqual(ph.get_plugins('en').count(), 4)
-
-        # Give the staff user permission to delete link plugins
-        staff.user_permissions.add(Permission.objects.get(codename='delete_link'))
-
-        with self.login_user_context(staff):
-            response = self.client.post(endpoint, {'test': 0})
-
-        self.assertEqual(response.status_code, 302)
-        self.assertEqual(ph.get_plugins('en').count(), 0)
 
     def test_clear_placeholder_permissions_generic(self):
         """
@@ -1329,46 +951,6 @@ class PluginPermissionTests(AdminTestsBase):
         plugin = add_plugin(self._placeholder, 'TextPlugin', 'en')
         return plugin
 
-    def test_plugin_add_requires_permissions(self):
-        """User tries to add a plugin but has no permissions. He can add the plugin after he got the permissions"""
-        admin = self._get_admin()
-        self._give_cms_permissions(admin)
-
-        if get_user_model().USERNAME_FIELD == 'email':
-            self.client.login(username='admin@django-cms.org', password='admin')
-        else:
-            self.client.login(username='admin', password='admin')
-
-        url = admin_reverse('cms_page_add_plugin') + '?' + urlencode({
-            'plugin_type': 'TextPlugin',
-            'placeholder_id': self._placeholder.pk,
-            'plugin_language': 'en',
-
-        })
-        response = self.client.post(url, {})
-        self.assertEqual(response.status_code, HttpResponseForbidden.status_code)
-        self._give_permission(admin, Text, 'add')
-        response = self.client.post(url, {})
-        self.assertEqual(response.status_code, 302)
-
-    def test_plugin_edit_requires_permissions(self):
-        """User tries to edit a plugin but has no permissions. He can edit the plugin after he got the permissions"""
-        plugin = self._create_plugin()
-        _, normal_guy = self._get_guys()
-
-        if get_user_model().USERNAME_FIELD == 'email':
-            self.client.login(username='test@test.com', password='test@test.com')
-        else:
-            self.client.login(username='test', password='test')
-
-        url = admin_reverse('cms_page_edit_plugin', args=[plugin.id])
-        response = self.client.post(url, dict())
-        self.assertEqual(response.status_code, HttpResponseForbidden.status_code)
-        # After he got the permissions, he can edit the plugin
-        self._give_permission(normal_guy, Text, 'change')
-        response = self.client.post(url, dict())
-        self.assertEqual(response.status_code, HttpResponse.status_code)
-
     def test_plugin_edit_wrong_url(self):
         """User tries to edit a plugin using a random url. 404 response returned"""
         plugin = self._create_plugin()
@@ -1384,71 +966,6 @@ class PluginPermissionTests(AdminTestsBase):
         response = self.client.post(url, dict())
         self.assertEqual(response.status_code, HttpResponseNotFound.status_code)
         self.assertTrue("Plugin not found" in force_text(response.content))
-
-    def test_plugin_remove_requires_permissions(self):
-        """User tries to remove a plugin but has no permissions. He can remove the plugin after he got the permissions"""
-        plugin = self._create_plugin()
-        _, normal_guy = self._get_guys()
-
-        if get_user_model().USERNAME_FIELD == 'email':
-            self.client.login(username='test@test.com', password='test@test.com')
-        else:
-            self.client.login(username='test', password='test')
-
-        url = admin_reverse('cms_page_delete_plugin', args=[plugin.pk])
-        data = dict(plugin_id=plugin.id)
-        response = self.client.post(url, data)
-        self.assertEqual(response.status_code, HttpResponseForbidden.status_code)
-        # After he got the permissions, he can edit the plugin
-        self._give_permission(normal_guy, Text, 'delete')
-        response = self.client.post(url, data)
-        self.assertEqual(response.status_code, 302)
-
-    def test_plugin_move_requires_permissions(self):
-        """User tries to move a plugin but has no permissions. He can move the plugin after he got the permissions"""
-        plugin = self._create_plugin()
-        _, normal_guy = self._get_guys()
-
-        if get_user_model().USERNAME_FIELD == 'email':
-            self.client.login(username='test@test.com', password='test@test.com')
-        else:
-            self.client.login(username='test', password='test')
-
-        url = admin_reverse('cms_page_move_plugin')
-        data = dict(plugin_id=plugin.id,
-                    placeholder_id=self._placeholder.pk,
-                    plugin_parent='',
-        )
-        response = self.client.post(url, data)
-        self.assertEqual(response.status_code, HttpResponseForbidden.status_code)
-        # After he got the permissions, he can edit the plugin
-        self._give_permission(normal_guy, Text, 'change')
-        response = self.client.post(url, data)
-        self.assertEqual(response.status_code, HttpResponse.status_code)
-
-    def test_plugins_copy_requires_permissions(self):
-        """User tries to copy plugin but has no permissions. He can copy plugins after he got the permissions"""
-        plugin = self._create_plugin()
-        _, normal_guy = self._get_guys()
-
-        if get_user_model().USERNAME_FIELD == 'email':
-            self.client.login(username='test@test.com', password='test@test.com')
-        else:
-            self.client.login(username='test', password='test')
-
-        url = admin_reverse('cms_page_copy_plugins')
-        data = dict(source_plugin_id=plugin.id,
-                    source_placeholder_id=self._placeholder.pk,
-                    source_language='en',
-                    target_language='fr',
-                    target_placeholder_id=self._placeholder.pk,
-        )
-        response = self.client.post(url, data)
-        self.assertEqual(response.status_code, HttpResponseForbidden.status_code)
-        # After he got the permissions, he can edit the plugin
-        self._give_permission(normal_guy, Text, 'add')
-        response = self.client.post(url, data)
-        self.assertEqual(response.status_code, HttpResponse.status_code)
 
     def test_plugins_copy_placeholder_from_page(self):
         """
@@ -1657,112 +1174,6 @@ class PluginPermissionTests(AdminTestsBase):
         # assert plugin count has only increased by two.
         # The two new plugins pasted in french.
         self.assertEqual(plugin_count(), initial_plugin_count + 2)
-
-    def test_plugins_copy_language(self):
-        """User tries to copy plugin but has no permissions. He can copy plugins after he got the permissions"""
-        self._create_plugin()
-        _, normal_guy = self._get_guys()
-
-        if get_user_model().USERNAME_FIELD != 'email':
-            self.client.login(username='test', password='test')
-        else:
-            self.client.login(username='test@test.com', password='test@test.com')
-
-        self.assertEqual(1, CMSPlugin.objects.all().count())
-        url = admin_reverse('cms_page_copy_language', args=[self._page.pk])
-        data = dict(
-            source_language='en',
-            target_language='fr',
-        )
-        response = self.client.post(url, data)
-        self.assertEqual(response.status_code, HttpResponseForbidden.status_code)
-        # After he got the permissions, he can edit the plugin
-        self._give_permission(normal_guy, Text, 'add')
-        response = self.client.post(url, data)
-        self.assertEqual(response.status_code, HttpResponse.status_code)
-        self.assertEqual(2, CMSPlugin.objects.all().count())
-
-    def test_page_permission_inline_visibility(self):
-        User = get_user_model()
-
-        fields = dict(email='user@domain.com', password='user', is_staff=True)
-
-        if get_user_model().USERNAME_FIELD != 'email':
-            fields[get_user_model().USERNAME_FIELD] = 'user'
-
-        user = User(**fields)
-        user.save()
-        self._give_page_permission_rights(user)
-        page = create_page('A', 'nav_playground.html', 'en')
-        page_permission = PagePermission.objects.create(
-            can_change_permissions=True, user=user, page=page)
-        request = self._get_change_page_request(user, page)
-        page_admin = PageAdmin(Page, AdminSite())
-        page_admin._current_page = page
-        # user has can_change_permission
-        # => must see the PagePermissionInline
-        self.assertTrue(
-            any(type(inline) is PagePermissionInlineAdmin
-                for inline in page_admin.get_inline_instances(request, page)))
-
-        page = Page.objects.get(pk=page.pk)
-        # remove can_change_permission
-        page_permission.can_change_permissions = False
-        page_permission.save()
-        request = self._get_change_page_request(user, page)
-        page_admin = PageAdmin(Page, AdminSite())
-        page_admin._current_page = page
-        # => PagePermissionInline is no longer visible
-        self.assertFalse(
-            any(type(inline) is PagePermissionInlineAdmin
-                for inline in page_admin.get_inline_instances(request, page)))
-
-    def test_edit_title_is_allowed_for_staff_user(self):
-        """
-        We check here both the permission on a single page, and the global permissions
-        """
-        user = self._create_user('user', is_staff=True)
-        another_user = self._create_user('another_user', is_staff=True)
-
-        page = create_page('A', 'nav_playground.html', 'en')
-        admin_url = reverse("admin:cms_page_edit_title_fields", args=(
-            page.pk, 'en'
-        ))
-        page_admin = PageAdmin(Page, None)
-        page_admin._current_page = page
-
-        username = getattr(user, get_user_model().USERNAME_FIELD)
-        self.client.login(username=username, password=username)
-        response = self.client.get(admin_url)
-        self.assertEqual(response.status_code, HttpResponseForbidden.status_code)
-
-        assign_user_to_page(page, user, grant_all=True)
-        username = getattr(user, get_user_model().USERNAME_FIELD)
-        self.client.login(username=username, password=username)
-        response = self.client.get(admin_url)
-        self.assertEqual(response.status_code, HttpResponse.status_code)
-
-        self._give_cms_permissions(another_user)
-        username = getattr(another_user, get_user_model().USERNAME_FIELD)
-        self.client.login(username=username, password=username)
-        response = self.client.get(admin_url)
-        self.assertEqual(response.status_code, HttpResponse.status_code)
-
-    def test_plugin_add_with_permissions_redirects(self):
-        admin_user = self._get_admin()
-        self._give_cms_permissions(admin_user)
-        self._give_permission(admin_user, Text, 'add')
-
-        username = getattr(admin_user, get_user_model().USERNAME_FIELD)
-        self.client.login(username=username, password='admin')
-
-        url = admin_reverse('cms_page_add_plugin') + '?' + urlencode({
-            'plugin_type': 'TextPlugin',
-            'placeholder_id': self._placeholder.pk,
-            'plugin_language': 'en',
-        })
-        response = self.client.post(url, {})
-        self.assertEqual(response.status_code, 302)
 
 
 class AdminFormsTests(AdminTestsBase):

--- a/cms/tests/test_multilingual.py
+++ b/cms/tests/test_multilingual.py
@@ -137,15 +137,15 @@ class MultilingualTestCase(CMSTestCase):
         placeholder = page.placeholders.all()[0]
         add_plugin(placeholder, "TextPlugin", TESTLANG2, body="test")
         add_plugin(placeholder, "TextPlugin", TESTLANG, body="test")
-        self.assertEqual(placeholder.cmsplugin_set.filter(language=TESTLANG2).count(), 1)
-        self.assertEqual(placeholder.cmsplugin_set.filter(language=TESTLANG).count(), 1)
+        self.assertEqual(placeholder.get_plugins(language=TESTLANG2).count(), 1)
+        self.assertEqual(placeholder.get_plugins(language=TESTLANG).count(), 1)
         user = get_user_model().objects.create_superuser('super', 'super@django-cms.org', 'super')
         page = publish_page(page, user, TESTLANG)
         page = publish_page(page, user, TESTLANG2)
         public = page.publisher_public
         placeholder = public.placeholders.all()[0]
-        self.assertEqual(placeholder.cmsplugin_set.filter(language=TESTLANG2).count(), 1)
-        self.assertEqual(placeholder.cmsplugin_set.filter(language=TESTLANG).count(), 1)
+        self.assertEqual(placeholder.get_plugins(language=TESTLANG2).count(), 1)
+        self.assertEqual(placeholder.get_plugins(language=TESTLANG).count(), 1)
 
     def test_hide_untranslated(self):
         TESTLANG = get_primary_language()

--- a/cms/tests/test_page.py
+++ b/cms/tests/test_page.py
@@ -2,7 +2,6 @@
 import datetime
 import os.path
 from unittest import skipIf
-from functools import partial
 
 from django.conf import settings
 from django.core.cache import cache

--- a/cms/tests/test_page.py
+++ b/cms/tests/test_page.py
@@ -6,7 +6,6 @@ from functools import partial
 
 from django.conf import settings
 from django.core.cache import cache
-from django.contrib import admin
 from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
 from django.core.exceptions import ValidationError
@@ -14,33 +13,22 @@ from django.core.urlresolvers import reverse
 from django.db import transaction
 from django.db.models import signals
 from django.http import HttpRequest, HttpResponse, HttpResponseNotFound
-from django.test.utils import override_settings
-from django.utils.encoding import force_text
 from django.utils.timezone import now as tz_now
 
 from cms import constants
-from cms.admin.forms import AdvancedSettingsForm
-from cms.admin.pageadmin import PageAdmin
 from cms.api import create_page, add_plugin, create_title, publish_page
-from cms.constants import PUBLISHER_STATE_DEFAULT, PUBLISHER_STATE_DIRTY
 from cms.exceptions import PublicIsUnmodifiable, PublicVersionNeeded
-from cms.middleware.user import CurrentUserMiddleware
-from cms.models import Page, Title, EmptyTitle
+from cms.models import Page, Title
 from cms.models.placeholdermodel import Placeholder
 from cms.models.pluginmodel import CMSPlugin
 from cms.signals import pre_save_page, post_save_page
 from cms.sitemaps import CMSSitemap
 from cms.templatetags.cms_tags import get_placeholder_content
-from cms.test_utils.testcases import (CMSTestCase, URL_CMS_PAGE, URL_CMS_PAGE_ADD,
-                                      URL_CMS_PAGE_CHANGE, URL_CMS_PAGE_ADVANCED_CHANGE,
-                                      URL_CMS_PAGE_MOVE, URL_CMS_PAGE_COPY)
-from cms.test_utils.util.context_managers import LanguageOverride, UserLoginContext
+from cms.test_utils.testcases import CMSTestCase
 from cms.utils import get_cms_setting
-from cms.utils.compat.dj import installed_apps
 from cms.utils.i18n import force_language
 from cms.utils.page_resolver import get_page_from_request, is_valid_url
 from cms.utils.page import is_valid_page_slug, get_available_slug
-from cms.utils.urlutils import admin_reverse
 
 from djangocms_link.cms_plugins import LinkPlugin
 from djangocms_text_ckeditor.cms_plugins import TextPlugin
@@ -62,17 +50,9 @@ def has_no_custom_user():
 
 
 class PagesTestCase(CMSTestCase):
+
     def tearDown(self):
         cache.clear()
-
-    def test_add_page(self):
-        """
-        Test that the add admin page could be displayed via the admin
-        """
-        superuser = self.get_superuser()
-        with self.login_user_context(superuser):
-            response = self.client.get(URL_CMS_PAGE_ADD)
-            self.assertEqual(response.status_code, 200)
 
     def test_absolute_url(self):
         user = self.get_superuser()
@@ -184,69 +164,6 @@ class PagesTestCase(CMSTestCase):
         self.assertEqual(page3_p.numchild, 0)
         self.assertTrue(page3_p.is_leaf())
 
-    def test_create_page_admin(self):
-        """
-        Test that a page can be created via the admin
-        """
-        page_data = self.get_new_page_data()
-
-        superuser = self.get_superuser()
-        with self.login_user_context(superuser):
-            self.assertEqual(Title.objects.all().count(), 0)
-            self.assertEqual(Page.objects.all().count(), 0)
-            # crate home and auto publish
-            response = self.client.post(URL_CMS_PAGE_ADD, page_data)
-            self.assertRedirects(response, URL_CMS_PAGE)
-            page_data = self.get_new_page_data()
-            response = self.client.post(URL_CMS_PAGE_ADD, page_data)
-            self.assertRedirects(response, URL_CMS_PAGE)
-
-            #self.assertEqual(Page.objects.all().count(), 2)
-            #self.assertEqual(Title.objects.all().count(), 2)
-
-            title = Title.objects.drafts().get(slug=page_data['slug'])
-            self.assertRaises(Title.DoesNotExist, Title.objects.public().get, slug=page_data['slug'])
-
-            page = title.page
-            page.save()
-            page.publish('en')
-            self.assertEqual(page.get_title(), page_data['title'])
-            self.assertEqual(page.get_slug(), page_data['slug'])
-            self.assertEqual(page.placeholders.all().count(), 2)
-
-            # were public instances created?
-            self.assertEqual(Title.objects.all().count(), 4)
-            title = Title.objects.drafts().get(slug=page_data['slug'])
-            title = Title.objects.public().get(slug=page_data['slug'])
-
-    def test_create_tree_admin(self):
-        """
-        Test that a tree can be created via the admin
-        """
-        page_1 = self.get_new_page_data()
-
-        superuser = self.get_superuser()
-        with self.login_user_context(superuser):
-            # create home and auto publish
-            response = self.client.post(URL_CMS_PAGE_ADD, page_1)
-            self.assertRedirects(response, URL_CMS_PAGE)
-
-            title_home = Title.objects.drafts().get(slug=page_1['slug'])
-
-            page_2 = self.get_new_page_data(parent_id=title_home.page.pk)
-            page_3 = self.get_new_page_data(parent_id=title_home.page.pk)
-            page_4 = self.get_new_page_data(parent_id=title_home.page.pk)
-
-            response = self.client.post(URL_CMS_PAGE_ADD, page_2)
-            self.assertRedirects(response, URL_CMS_PAGE)
-            response = self.client.post(URL_CMS_PAGE_ADD, page_3)
-            self.assertRedirects(response, URL_CMS_PAGE)
-
-            title_left = Title.objects.drafts().get(slug=page_2['slug'])
-
-            response = self.client.post(URL_CMS_PAGE_ADD + '?target=%s&amp;position=right' % title_left.page.pk, page_4)
-            self.assertRedirects(response, URL_CMS_PAGE)
-
     def test_create_page_api(self):
         page_data = {
             'title': 'root',
@@ -307,64 +224,6 @@ class PagesTestCase(CMSTestCase):
         page.delete()
 
         self.assertEqual(Page.objects.count(), 0)
-
-    def test_slug_collision(self):
-        """
-        Test a slug collision
-        """
-        page_data = self.get_new_page_data()
-        # create first page
-        superuser = self.get_superuser()
-        with self.login_user_context(superuser):
-            response = self.client.post(URL_CMS_PAGE_ADD, page_data)
-            self.assertRedirects(response, URL_CMS_PAGE)
-
-            response = self.client.post(URL_CMS_PAGE_ADD, page_data)
-
-            self.assertEqual(response.status_code, 200)
-            self.assertTrue(response.request['PATH_INFO'].endswith(URL_CMS_PAGE_ADD))
-            self.assertContains(response, '<ul class="errorlist"><li>Another page with this slug already exists</li></ul>')
-
-    def test_child_slug_collision(self):
-        """
-        Test a slug collision
-        """
-        root = create_page("home", 'nav_playground.html', "en", published=True)
-        page = create_page("page", 'nav_playground.html', "en")
-        subPage = create_page("subpage", 'nav_playground.html', "en", parent=page)
-        create_page("child-page", 'nav_playground.html', "en", parent=root)
-        superuser = self.get_superuser()
-        with self.login_user_context(superuser):
-
-            response = self.client.get(URL_CMS_PAGE_ADD+"?target=%s&position=right&site=1" % subPage.pk)
-            self.assertContains(response, 'value="%s"' % page.pk)
-
-            # slug collision between two child pages of the same node
-            page_data = self.get_new_page_data(page.pk)
-            page_data['slug'] = 'subpage'
-            response = self.client.post(URL_CMS_PAGE_ADD, page_data)
-
-            self.assertEqual(response.status_code, 200)
-            self.assertTrue(response.request['PATH_INFO'].endswith(URL_CMS_PAGE_ADD))
-            self.assertContains(response, '<ul class="errorlist"><li>Another page with this slug already exists</li></ul>')
-
-            # slug collision between page with no parent and a child page of root
-            page_data = self.get_new_page_data()
-            page_data['slug'] = 'child-page'
-            response = self.client.post(URL_CMS_PAGE_ADD, page_data)
-
-            self.assertEqual(response.status_code, 200)
-            self.assertTrue(response.request['PATH_INFO'].endswith(URL_CMS_PAGE_ADD))
-            self.assertContains(response, '<ul class="errorlist"><li>Another page with this slug already exists</li></ul>')
-
-            # slug collision between two top-level pages
-            page_data = self.get_new_page_data()
-            page_data['slug'] = 'page'
-            response = self.client.post(URL_CMS_PAGE_ADD, page_data)
-
-            self.assertEqual(response.status_code, 200)
-            self.assertTrue(response.request['PATH_INFO'].endswith(URL_CMS_PAGE_ADD))
-            self.assertContains(response, '<ul class="errorlist"><li>Another page with this slug already exists</li></ul>')
 
     def test_get_available_slug_recursion(self):
         """ Checks cms.utils.page.get_available_slug for infinite recursion
@@ -446,230 +305,6 @@ class PagesTestCase(CMSTestCase):
             response = self.client.get(page2.get_absolute_url())
             self.assertEqual(response.status_code, 200)
 
-    def test_edit_page(self):
-        """
-        Test that a page can edited via the admin
-        """
-        superuser = self.get_superuser()
-        with self.login_user_context(superuser):
-            page_data = self.get_new_page_data()
-            response = self.client.post(URL_CMS_PAGE_ADD, page_data)
-            page = Page.objects.get(title_set__slug=page_data['slug'], publisher_is_draft=True)
-            response = self.client.get(URL_CMS_PAGE_CHANGE % page.id)
-            self.assertEqual(response.status_code, 200)
-            page_data['title'] = 'changed title'
-            response = self.client.post(URL_CMS_PAGE_CHANGE % page.id, page_data)
-            self.assertRedirects(response, URL_CMS_PAGE)
-            self.assertEqual(page.get_title(), 'changed title')
-
-    def test_moderator_edit_page_redirect(self):
-        """
-        Test that a page can be edited multiple times with moderator
-        """
-        create_page("home", "nav_playground.html", "en", published=True)
-        superuser = self.get_superuser()
-        with self.login_user_context(superuser):
-            page_data = self.get_new_page_data()
-            response = self.client.post(URL_CMS_PAGE_ADD, page_data)
-            self.assertEqual(response.status_code, 302)
-            page = Page.objects.get(title_set__slug=page_data['slug'])
-            response = self.client.get(URL_CMS_PAGE_CHANGE % page.id)
-            self.assertEqual(response.status_code, 200)
-            page_data['overwrite_url'] = '/hello/'
-            page_data['has_url_overwrite'] = True
-            response = self.client.post(URL_CMS_PAGE_ADVANCED_CHANGE % page.id, page_data)
-            self.assertRedirects(response, URL_CMS_PAGE)
-            self.assertEqual(page.get_absolute_url(), '/en/hello/')
-            Title.objects.all()[0]
-            page = page.reload()
-            page.publish('en')
-            page_data['title'] = 'new title'
-            response = self.client.post(URL_CMS_PAGE_CHANGE % page.id, page_data)
-            page = Page.objects.get(title_set__slug=page_data['slug'], publisher_is_draft=True)
-            self.assertRedirects(response, URL_CMS_PAGE)
-            self.assertEqual(page.get_title(), 'new title')
-
-    def test_meta_description_fields_from_admin(self):
-        """
-        Test that description and keywords tags can be set via the admin
-        """
-        superuser = self.get_superuser()
-        with self.login_user_context(superuser):
-            page_data = self.get_new_page_data()
-            page_data["meta_description"] = "I am a page"
-            self.client.post(URL_CMS_PAGE_ADD, page_data)
-            page = Page.objects.get(title_set__slug=page_data['slug'], publisher_is_draft=True)
-            response = self.client.get(URL_CMS_PAGE_CHANGE % page.id)
-            self.assertEqual(response.status_code, 200)
-            page_data['meta_description'] = 'I am a duck'
-            response = self.client.post(URL_CMS_PAGE_CHANGE % page.id, page_data)
-            self.assertRedirects(response, URL_CMS_PAGE)
-            page = Page.objects.get(title_set__slug=page_data["slug"], publisher_is_draft=True)
-            self.assertEqual(page.get_meta_description(), 'I am a duck')
-
-    def test_meta_description_from_template_tags(self):
-        from django import template
-
-        superuser = self.get_superuser()
-        with self.login_user_context(superuser):
-            page_data = self.get_new_page_data()
-            page_data["title"] = "Hello"
-            page_data["meta_description"] = "I am a page"
-            self.client.post(URL_CMS_PAGE_ADD, page_data)
-            page = Page.objects.get(title_set__slug=page_data['slug'], publisher_is_draft=True)
-            self.client.post(URL_CMS_PAGE_CHANGE % page.id, page_data)
-            t = template.Template(
-                "{% load cms_tags %}{% page_attribute title %} {% page_attribute meta_description %}")
-            req = HttpRequest()
-            page.save()
-            page.publish('en')
-            req.current_page = page
-            req.GET = {}
-            self.assertEqual(t.render(template.Context({"request": req})), "Hello I am a page")
-
-    def test_page_obj_change_data_from_template_tags(self):
-        from django import template
-
-        superuser = self.get_superuser()
-        with self.login_user_context(superuser):
-            page_data = self.get_new_page_data()
-            change_user = str(superuser)
-            # some databases don't store microseconds, so move the start flag
-            # back by 1 second
-            before_change = tz_now()+datetime.timedelta(seconds=-1)
-            self.client.post(URL_CMS_PAGE_ADD, page_data)
-            page = Page.objects.get(
-                title_set__slug=page_data['slug'],
-                publisher_is_draft=True
-            )
-            self.client.post(URL_CMS_PAGE_CHANGE % page.id, page_data)
-            t = template.Template(
-                "{% load cms_tags %}{% page_attribute changed_by %} changed "
-                "on {% page_attribute changed_date as page_change %}"
-                "{{ page_change|date:'Y-m-d\TH:i:s' }}"
-            )
-            req = HttpRequest()
-            page.save()
-            page.publish('en')
-            after_change = tz_now()
-            req.current_page = page
-            req.GET = {}
-
-            actual_result = t.render(template.Context({"request": req}))
-            desired_result = "{0} changed on {1}".format(
-                change_user,
-                actual_result[-19:]
-            )
-            save_time = datetime.datetime.strptime(
-                actual_result[-19:],
-                "%Y-%m-%dT%H:%M:%S"
-            )
-
-            self.assertEqual(actual_result, desired_result)
-            # direct time comparisons are flaky, so we just check if the
-            # page's changed_date is within the time range taken by this test
-            self.assertLessEqual(before_change, save_time)
-            self.assertLessEqual(save_time, after_change)
-
-    def test_copy_page(self):
-        """
-        Test that a page can be copied via the admin
-        """
-        _create_page = partial(
-            create_page,
-            language="en",
-            template="nav_playground.html",
-            published=True,
-        )
-
-        # The tree path comparisons done in this test
-        # are critical to ensuring tree integrity.
-        # Do NOT alter these paths, if tests fail
-        # then something has broken the tree!.
-
-        home = _create_page("home")
-        child_1 = _create_page("Child 1", parent=home)
-        _create_page("Child 2", parent=home)
-
-        child_1_1 = _create_page("Child 1 1", parent=child_1, reverse_id="hello")
-        _create_page("Child 1 1", parent=child_1_1)
-        _create_page("Child 1 1", parent=child_1_1)
-
-        expected_tree = [
-            # Home
-            '0001',
-            # Home -> Child 1
-            '00010001',
-            # Home -> Child 1 -> Child 1 1
-            '000100010001',
-            # Home -> Child 1 -> Child 1 1 -> Child 1 1 1
-            '0001000100010001',
-            # Home -> Child 1 -> Child 1 1 -> Child 1 1 2
-            '0001000100010002',
-            # Home -> Child 2
-            '00010002',
-        ]
-
-        db_tree = (
-            home
-            .reload()
-            .get_descendants(True)
-            .order_by('path')
-            .values_list('path', flat=True)
-        )
-
-        self.assertListEqual(expected_tree, list(db_tree))
-
-        superuser = self.get_superuser()
-
-        # Copy the home page and insert it under Child 1 1 1
-        # to the left of Child 1 1 2.
-        with self.login_user_context(superuser):
-            page_data = {
-                'id': home.pk,
-                'target': child_1_1.pk,
-                'position': 1,
-                'copy_permissions': 'on',
-            }
-            self.client.post(URL_CMS_PAGE_COPY % home.pk, page_data)
-
-        expected_tree = [
-            # Home
-            '0001',
-            # Home -> Child 1
-            '00010001',
-            # Home -> Child 1 -> Child 1 1
-            '000100010001',
-            # Home -> Child 1 -> Child 1 1 -> Child 1 1 1
-            '0001000100010001',
-            # Home -> Child 1 -> Child 1 1 -> Home
-            '0001000100010002',
-            # Home -> Child 1 -> Child 1 1 -> Home -> Child 1
-            '00010001000100020001',
-            # Home -> Child 1 -> Child 1 1 -> Home -> Child 1 -> Child 1 1
-            '000100010001000200010001',
-            # Home -> Child 1 -> Child 1 1 -> Home -> Child 1 -> Child 1 1 -> Child 1 1 1
-            '0001000100010002000100010001',
-            # Home -> Child 1 -> Child 1 1 -> Home -> Child 1 -> Child 1 1 -> Child 1 1 2
-            '0001000100010002000100010002',
-            # Home -> Child 1 -> Child 1 1 -> Home -> Child 2
-            '00010001000100020002',
-            # Home -> Child 1 -> Child 1 1 -> Child 1 1 2
-            '0001000100010003',
-            # Home -> Child 2
-            '00010002',
-        ]
-
-        db_tree = (
-            home
-            .reload()
-            .get_descendants(True)
-            .order_by('path')
-            .values_list('path', flat=True)
-        )
-
-        self.assertListEqual(expected_tree, list(db_tree))
-
     def test_copy_page_method(self):
         """
         Test that a page can be copied via the admin
@@ -694,34 +329,6 @@ class PagesTestCase(CMSTestCase):
         self.assertEqual(Page.objects.filter(site_id=site.pk, depth=1).count(), 2)
         self.assertEqual(Page.objects.filter(site_id=site.pk).count(), 6)
 
-    def test_copy_self_page(self):
-        """
-        Test that a page can be copied via the admin
-        """
-        page_a = create_page("page_a", "nav_playground.html", "en")
-        page_b = create_page("page_b", "nav_playground.html", "en", parent=page_a)
-        page_c = create_page("page_c", "nav_playground.html", "en", parent=page_b)
-        with self.login_user_context(self.get_superuser()):
-            self.copy_page(page_b, page_b)
-        self.assertEqual(Page.objects.drafts().count(), 5)
-        self.assertEqual(Page.objects.filter(parent=page_b).count(), 2)
-        page_d = Page.objects.filter(parent=page_b)[0]
-        page_e = Page.objects.get(parent=page_d)
-        self.assertEqual(page_d.path, '000100010001')
-        self.assertEqual(page_e.path, '0001000100010001')
-        page_e.delete()
-        page_d.delete()
-        with self.login_user_context(self.get_superuser()):
-            self.copy_page(page_b, page_c)
-        self.assertEqual(Page.objects.filter(parent=page_c).count(), 1)
-        self.assertEqual(Page.objects.filter(parent=page_b).count(), 1)
-        Page.objects.filter(parent=page_c).delete()
-        self.assertEqual(Page.objects.all().count(), 3)
-        page_b = page_b.reload()
-        page_c = page_c.reload()
-        with self.login_user_context(self.get_superuser()):
-            self.copy_page(page_b, page_c, position=0)
-
     def test_public_exceptions(self):
         page_a = create_page("page_a", "nav_playground.html", "en", published=True)
         page_b = create_page("page_b", "nav_playground.html", "en")
@@ -733,221 +340,6 @@ class PagesTestCase(CMSTestCase):
 
         self.assertTrue(page.get_draft_object().publisher_is_draft)
         self.assertRaises(PublicVersionNeeded, page_b.revert, 'en')
-
-    def test_get_admin_tree_title(self):
-        page = create_page("page_a", "nav_playground.html", "en", published=True)
-        self.assertEqual(page.get_admin_tree_title(), 'page_a')
-        page.title_cache = {}
-        self.assertEqual("Empty", force_text(page.get_admin_tree_title()))
-        languages = {
-            1: [
-                {
-                    'code': 'en',
-                    'name': 'English',
-                    'fallbacks': ['fr', 'de'],
-                    'public': True,
-                    'fallbacks':['fr']
-                },
-                {
-                    'code': 'fr',
-                    'name': 'French',
-                    'public': True,
-                    'fallbacks':['en']
-                },
-        ]}
-        with self.settings(CMS_LANGUAGES=languages):
-            with force_language('fr'):
-                page.title_cache = {'en': Title(slug='test', page_title="test2", title="test2")}
-                self.assertEqual('test2', force_text(page.get_admin_tree_title()))
-                page.title_cache = {'en': Title(slug='test', page_title="test2")}
-                self.assertEqual('test2', force_text(page.get_admin_tree_title()))
-                page.title_cache = {'en': Title(slug='test', menu_title="test2")}
-                self.assertEqual('test2', force_text(page.get_admin_tree_title()))
-                page.title_cache = {'en': Title(slug='test2')}
-                self.assertEqual('test2', force_text(page.get_admin_tree_title()))
-                page.title_cache = {'en': Title(slug='test2'), 'fr': EmptyTitle('fr')}
-                self.assertEqual('test2', force_text(page.get_admin_tree_title()))
-
-    def test_language_change(self):
-        superuser = self.get_superuser()
-        with self.login_user_context(superuser):
-            page_data = self.get_new_page_data()
-            self.client.post(URL_CMS_PAGE_ADD, page_data)
-            pk = Page.objects.all()[0].pk
-            response = self.client.get(URL_CMS_PAGE_CHANGE % pk, {"language": "en"})
-            self.assertEqual(response.status_code, 200)
-            response = self.client.get(URL_CMS_PAGE_CHANGE % pk, {"language": "de"})
-            self.assertEqual(response.status_code, 200)
-
-    def test_move_page(self):
-        superuser = self.get_superuser()
-        with self.login_user_context(superuser):
-            page_home = self.get_new_page_data()
-            self.client.post(URL_CMS_PAGE_ADD, page_home)
-            page_data1 = self.get_new_page_data()
-            self.client.post(URL_CMS_PAGE_ADD, page_data1)
-            page_data2 = self.get_new_page_data()
-            self.client.post(URL_CMS_PAGE_ADD, page_data2)
-            page_data3 = self.get_new_page_data()
-            self.client.post(URL_CMS_PAGE_ADD, page_data3)
-            home = Page.objects.all()[0]
-            page1 = Page.objects.all()[2]
-            page2 = Page.objects.all()[3]
-            page3 = Page.objects.all()[4]
-
-            # move pages
-            response = self.client.post(URL_CMS_PAGE_MOVE % page3.pk,
-                                        {"target": page2.pk, "position": "last-child"})
-            self.assertEqual(response.status_code, 200)
-
-            page3 = Page.objects.get(pk=page3.pk)
-            response = self.client.post(URL_CMS_PAGE_MOVE % page2.pk,
-                                        {"target": page1.pk, "position": "last-child"})
-            self.assertEqual(response.status_code, 200)
-            # check page2 path and url
-            page2 = Page.objects.get(pk=page2.pk)
-            self.assertEqual(page2.get_path(), page_data1['slug'] + "/" + page_data2['slug'])
-            self.assertEqual(page2.get_absolute_url(),
-                             self.get_pages_root() + page_data1['slug'] + "/" + page_data2['slug'] + "/")
-            # check page3 path and url
-            page3 = Page.objects.get(pk=page3.pk)
-            self.assertEqual(page3.get_path(), page_data1['slug'] + "/" + page_data2['slug'] + "/" + page_data3['slug'])
-            self.assertEqual(page3.get_absolute_url(),
-                             self.get_pages_root() + page_data1['slug'] + "/" + page_data2['slug'] + "/" + page_data3[
-                                 'slug'] + "/")
-
-            # publish page 1 (becomes home)
-            home.delete()
-            page1.publish('en')
-            public_page1 = page1.publisher_public
-            self.assertEqual(page1.get_path(), '')
-            self.assertEqual(public_page1.get_path(), '')
-            # check that page2 and page3 url have changed
-            page2 = Page.objects.get(pk=page2.pk)
-            page2.publish('en')
-            public_page2 = page2.publisher_public
-            self.assertEqual(public_page2.get_absolute_url(), self.get_pages_root() + page_data2['slug'] + "/")
-            page3 = Page.objects.get(pk=page3.pk)
-            page3.publish('en')
-            public_page3 = page3.publisher_public
-            self.assertEqual(public_page3.get_absolute_url(),
-                             self.get_pages_root() + page_data2['slug'] + "/" + page_data3['slug'] + "/")
-            # set page2 as root and check path of 1 and 3
-            response = self.client.post(URL_CMS_PAGE_MOVE % page2.pk,
-                                        {"position": "0"})
-            self.assertEqual(response.status_code, 200)
-            page1 = Page.objects.get(pk=page1.pk)
-            self.assertEqual(page1.get_path(), page_data1['slug'])
-            page2 = Page.objects.get(pk=page2.pk)
-            # Check that page2 is now at the root of the tree
-            self.assertTrue(page2.is_home)
-            self.assertEqual(page2.get_path(), '')
-            page3 = Page.objects.get(pk=page3.pk)
-            self.assertEqual(page3.get_path(), page_data3['slug'])
-
-    def test_move_page_integrity(self):
-        superuser = self.get_superuser()
-        with self.login_user_context(superuser):
-            page_home = self.get_new_page_data()
-            self.client.post(URL_CMS_PAGE_ADD, page_home)
-
-            # Create parent page
-            page_root = create_page("Parent", 'col_three.html', "en")
-            page_root.publish('en')
-
-            # Create child pages
-            page_child_1 = create_page(
-                "Child 1",
-                template=constants.TEMPLATE_INHERITANCE_MAGIC,
-                language="en",
-                parent=page_root,
-            )
-            page_child_1.publish('en')
-
-            page_child_2 = create_page(
-                "Child 2",
-                template=constants.TEMPLATE_INHERITANCE_MAGIC,
-                language="en",
-                parent=page_root,
-            )
-            page_child_2.publish('en')
-
-            # Create two root pages that ware meant as child pages
-            page_child_3 = create_page("Child 3", 'col_three.html', "en")
-            page_child_4 = create_page("Child 4", 'col_three.html', "en", published=True)
-
-            # Correct our mistake.
-            # Move page_child_3 to be child of parent page
-            data = {
-                "id": page_child_3.pk,
-                "target": page_root.pk,
-                "position": "0",
-            }
-            response = self.client.post(
-                URL_CMS_PAGE_MOVE % page_child_3.pk,
-                data,
-            )
-            self.assertEqual(response.status_code, 200)
-
-            # Un-publish page_child_4
-            page_child_4.unpublish('en')
-
-            # Move page_child_4 to be child of parent page
-            data = {
-                "id": page_child_4.pk,
-                "target": page_root.pk,
-                "position": "0",
-            }
-            response = self.client.post(
-                URL_CMS_PAGE_MOVE % page_child_4.pk,
-                data,
-            )
-            self.assertEqual(response.status_code, 200)
-
-            page_root = page_root.reload()
-            page_child_4 = page_child_4.reload()
-
-            # Ensure move worked
-            self.assertEqual(page_root.get_descendants().count(), 4)
-
-            # Ensure page_child_3 is still unpublished
-            self.assertEqual(
-                page_child_3.get_publisher_state("en"),
-                PUBLISHER_STATE_DIRTY
-            )
-            self.assertEqual(page_child_3.is_published("en"), False)
-
-            # Ensure page_child_4 is still unpublished
-            self.assertEqual(
-                page_child_4.get_publisher_state("en"),
-                PUBLISHER_STATE_DIRTY
-            )
-            self.assertEqual(page_child_4.is_published("en"), False)
-
-            # And it's public page is still has the published state
-            # but is marked as unpublished
-            self.assertEqual(
-                page_child_4.publisher_public.get_publisher_state("en"),
-                PUBLISHER_STATE_DEFAULT
-            )
-            self.assertEqual(
-                page_child_4.publisher_public.is_published("en"),
-                False,
-            )
-
-            # Ensure child one is still published
-            self.assertEqual(
-                page_child_1.get_publisher_state("en"),
-                PUBLISHER_STATE_DEFAULT
-            )
-            self.assertEqual(page_child_1.is_published("en"), True)
-
-            # Ensure child two is still published
-            self.assertEqual(
-                page_child_2.get_publisher_state("en"),
-                PUBLISHER_STATE_DEFAULT
-            )
-            self.assertEqual(page_child_2.is_published("en"), True)
 
     def test_move_page_inherit(self):
         parent = create_page("Parent", 'col_three.html', "en")
@@ -1017,29 +409,6 @@ class PagesTestCase(CMSTestCase):
         sitemap = CMSSitemap()
         actual_last_modification_time = sitemap.lastmod(title)
         self.assertEqual(actual_last_modification_time.date(), now.date())
-
-    def test_edit_page_other_site_and_language(self):
-        """
-        Test that a page can edited via the admin when your current site is
-        different from the site you are editing and the language isn't available
-        for the current site.
-        """
-        self.assertEqual(Site.objects.all().count(), 1)
-        site = Site.objects.create(domain='otherlang', name='otherlang', pk=2)
-        # Change site for this session
-        page_data = self.get_new_page_data()
-        page_data['site'] = site.pk
-        page_data['title'] = 'changed title'
-        self.assertEqual(site.pk, 2)
-        TESTLANG = get_cms_setting('LANGUAGES')[site.pk][0]['code']
-        page_data['language'] = TESTLANG
-        superuser = self.get_superuser()
-        with self.login_user_context(superuser):
-            response = self.client.post(URL_CMS_PAGE_ADD, page_data)
-            self.assertRedirects(response, URL_CMS_PAGE)
-            page = Page.objects.get(title_set__slug=page_data['slug'], publisher_is_draft=True)
-            with LanguageOverride(TESTLANG):
-                self.assertEqual(page.get_title(), 'changed title')
 
     def test_templates(self):
         """
@@ -1114,38 +483,6 @@ class PagesTestCase(CMSTestCase):
         self.assertEqual(Placeholder.objects.count(), 0)
         self.assertEqual(Page.objects.count(), 0)
 
-    def test_get_page_from_request_on_non_cms_admin(self):
-        request = self.get_request(
-            admin_reverse('sampleapp_category_change', args=(1,))
-        )
-        page = get_page_from_request(request)
-        self.assertEqual(page, None)
-
-    def test_get_page_from_request_on_cms_admin(self):
-        page = create_page("page", "nav_playground.html", "en")
-        request = self.get_request(
-            admin_reverse('cms_page_change', args=(page.pk,))
-        )
-        found_page = get_page_from_request(request)
-        self.assertTrue(found_page)
-        self.assertEqual(found_page.pk, page.pk)
-
-    def test_get_page_from_request_on_cms_admin_nopage(self):
-        request = self.get_request(
-            admin_reverse('cms_page_change', args=(1,))
-        )
-        page = get_page_from_request(request)
-        self.assertEqual(page, None)
-
-    def test_get_page_from_request_cached(self):
-        mock_page = 'hello world'
-        request = self.get_request(
-            admin_reverse('sampleapp_category_change', args=(1,))
-        )
-        request._current_page_cache = mock_page
-        page = get_page_from_request(request)
-        self.assertEqual(page, mock_page)
-
     def test_get_page_from_request_nopage(self):
         request = self.get_request('/')
         page = get_page_from_request(request)
@@ -1170,22 +507,6 @@ class PagesTestCase(CMSTestCase):
         found_page = get_page_from_request(request)
         self.assertIsNotNone(found_page)
         self.assertFalse(found_page.publisher_is_draft)
-
-    def test_get_page_from_request_on_cms_admin_with_editplugin(self):
-        page = create_page("page", "nav_playground.html", "en")
-        request = self.get_request(
-            admin_reverse('cms_page_change', args=(page.pk,)) + 'edit-plugin/42/'
-        )
-        found_page = get_page_from_request(request)
-        self.assertTrue(found_page)
-        self.assertEqual(found_page.pk, page.pk)
-
-    def test_get_page_from_request_on_cms_admin_with_editplugin_nopage(self):
-        request = self.get_request(
-            admin_reverse('cms_page_change', args=(1,)) + 'edit-plugin/42/'
-        )
-        page = get_page_from_request(request)
-        self.assertEqual(page, None)
 
     def test_ancestor_expired(self):
         yesterday = tz_now() - datetime.timedelta(days=1)
@@ -1222,82 +543,6 @@ class PagesTestCase(CMSTestCase):
                                publication_end_date=yesterday, published=True)
             resp = self.client.get(page.get_absolute_url('en'))
             self.assertEqual(resp.status_code, 404)
-
-    def test_existing_overwrite_url(self):
-        with self.settings(CMS_PERMISSION=False):
-            create_page('home', 'nav_playground.html', 'en', published=True)
-            create_page('boo', 'nav_playground.html', 'en', published=True)
-            data = {
-                'title': 'foo',
-                'overwrite_url': '/boo/',
-                'slug': 'foo',
-                'language': 'en',
-                'template': 'nav_playground.html',
-                'site': 1,
-            }
-            form = AdvancedSettingsForm(data)
-            self.assertFalse(form.is_valid())
-            self.assertTrue('overwrite_url' in form.errors)
-
-    def test_advanced_settings_form(self):
-        site = Site.objects.get_current()
-        page = create_page('Page 1', 'nav_playground.html', 'en')
-
-        # First we provide fully valid conditions to make sure
-        # the form is working.
-        page_data = {
-            'language': 'en',
-            'site': site.pk,
-            'template': 'col_two.html',
-        }
-
-        form = AdvancedSettingsForm(
-            data=page_data,
-            instance=page,
-            files=None,
-        )
-        self.assertTrue(form.is_valid())
-
-        # Now switch it up by adding german as the current language
-        # Note that german has not been created as page translation.
-        page_data['language'] = 'de'
-
-        form = AdvancedSettingsForm(
-            data=page_data,
-            instance=page,
-            files=None,
-        )
-        no_translation_error = (u"Please create the German page translation "
-                                u"before editing its advanced settings.")
-        self.assertFalse(form.is_valid())
-        self.assertIn('__all__', form.errors)
-        self.assertEqual(1, len(form.errors['__all__']))
-        # Make sure we get the correct error when the given language
-        # is not an existing page translation.
-        self.assertEqual([no_translation_error],
-                         form.errors['__all__'])
-
-        de_translation = create_title('de', title='Page 1', page=page)
-        de_translation.slug = ''
-        de_translation.save()
-
-        # First make sure the title has no slug
-        self.assertEqual(de_translation.slug, '')
-
-        form = AdvancedSettingsForm(
-            data=page_data,
-            instance=page,
-            files=None,
-        )
-        no_translation_error = (u"Please set the German slug before "
-                                u"editing its advanced settings.")
-        self.assertFalse(form.is_valid())
-        self.assertIn('__all__', form.errors)
-        self.assertEqual(1, len(form.errors['__all__']))
-        # Make sure we get the correct error when the given language
-        # is not an existing page translation.
-        self.assertEqual([no_translation_error],
-                         form.errors['__all__'])
 
     def test_page_urls(self):
         page1 = create_page('test page 1', 'nav_playground.html', 'en',
@@ -1572,128 +817,9 @@ class PagesTestCase(CMSTestCase):
             resp = self.client.get(page.get_absolute_url('en'))
             self.assertEqual(resp.get('X-Frame-Options'), 'SAMEORIGIN')
 
-class PageAdminTestBase(CMSTestCase):
-    """
-    The purpose of this class is to provide some basic functionality
-    to test methods of the Page admin.
-    """
-    placeholderconf = {'body': {
-        'limits': {
-            'global': 2,
-            'TextPlugin': 1,
-        }
-    }
-    }
-
-    def get_page(self, parent=None, site=None,
-                 language=None, template='nav_playground.html'):
-        page_data = {
-            'title': 'test page %d' % self.counter,
-            'slug': 'test-page-%d' % self.counter,
-            'language': settings.LANGUAGES[0][0] if not language else language,
-            'template': template,
-            'parent': parent if parent else None,
-            'site': site if site else Site.objects.get_current(),
-        }
-        page_data = self.get_new_page_data_dbfields()
-        return create_page(**page_data)
-
-    def get_admin(self):
-        """
-        Returns a PageAdmin instance.
-        """
-        return PageAdmin(Page, admin.site)
-
-    def get_post_request(self, data):
-        return self.get_request(post_data=data)
-
-
-class PageAdminTest(PageAdminTestBase):
-    def test_form_url_page_change(self):
-        superuser = self.get_superuser()
-        with self.login_user_context(superuser):
-            pageadmin = self.get_admin()
-            page = self.get_page()
-            form_url = admin_reverse("cms_page_change", args=(page.pk,))
-            # Middleware is needed to correctly setup the environment for the admin
-            middleware = CurrentUserMiddleware()
-            request = self.get_request()
-            middleware.process_request(request)
-            response = pageadmin.change_view(
-                request, str(page.pk),
-                form_url=form_url)
-            self.assertTrue('form_url' in response.context_data)
-            self.assertEqual(response.context_data['form_url'], form_url)
-
-    def test_global_limit_on_plugin_move(self):
-        admin = self.get_admin()
-        superuser = self.get_superuser()
-        cms_page = self.get_page()
-        source_placeholder = cms_page.placeholders.get(slot='right-column')
-        target_placeholder = cms_page.placeholders.get(slot='body')
-        data = {
-            'placeholder': source_placeholder,
-            'plugin_type': 'LinkPlugin',
-            'language': 'en',
-        }
-        plugin_1 = add_plugin(**data)
-        plugin_2 = add_plugin(**data)
-        plugin_3 = add_plugin(**data)
-        with UserLoginContext(self, superuser):
-            with self.settings(CMS_PLACEHOLDER_CONF=self.placeholderconf):
-                request = self.get_post_request(
-                    {'placeholder_id': target_placeholder.pk, 'plugin_id': plugin_1.pk, 'plugin_parent': ''})
-                response = admin.move_plugin(request) # first
-                self.assertEqual(response.status_code, 200)
-                request = self.get_post_request(
-                    {'placeholder_id': target_placeholder.pk, 'plugin_id': plugin_2.pk, 'plugin_parent': ''})
-                response = admin.move_plugin(request) # second
-                self.assertEqual(response.status_code, 200)
-                request = self.get_post_request(
-                    {'placeholder_id': target_placeholder.pk, 'plugin_id': plugin_3.pk, 'plugin_parent': ''})
-                response = admin.move_plugin(request) # third
-                self.assertEqual(response.status_code, 400)
-                self.assertEqual(response.content, b"This placeholder already has the maximum number of plugins (2).")
-
-    def test_type_limit_on_plugin_move(self):
-        admin = self.get_admin()
-        superuser = self.get_superuser()
-        cms_page = self.get_page()
-        source_placeholder = cms_page.placeholders.get(slot='right-column')
-        target_placeholder = cms_page.placeholders.get(slot='body')
-        data = {
-            'placeholder': source_placeholder,
-            'plugin_type': 'TextPlugin',
-            'language': 'en',
-        }
-        plugin_1 = add_plugin(**data)
-        plugin_2 = add_plugin(**data)
-        with UserLoginContext(self, superuser):
-            with self.settings(CMS_PLACEHOLDER_CONF=self.placeholderconf):
-                request = self.get_post_request(
-                    {'placeholder_id': target_placeholder.pk, 'plugin_id': plugin_1.pk, 'plugin_parent': ''})
-                response = admin.move_plugin(request) # first
-                self.assertEqual(response.status_code, 200)
-                request = self.get_post_request(
-                    {'placeholder_id': target_placeholder.pk, 'plugin_id': plugin_2.pk, 'plugin_parent': ''})
-                response = admin.move_plugin(request) # second
-                self.assertEqual(response.status_code, 400)
-                self.assertEqual(response.content,
-                                 b"This placeholder already has the maximum number (1) of allowed Text plugins.")
-
-
-@override_settings(ROOT_URLCONF='cms.test_utils.project.noadmin_urls')
-class NoAdminPageTests(CMSTestCase):
-
-    def test_get_page_from_request_fakeadmin_nopage(self):
-        noadmin_apps = [app for app in installed_apps() if app != 'django.contrib.admin']
-        with self.settings(INSTALLED_APPS=noadmin_apps):
-            request = self.get_request('/en/admin/')
-            page = get_page_from_request(request)
-            self.assertEqual(page, None)
-
 
 class PreviousFilteredSiblingsTests(CMSTestCase):
+
     def test_with_publisher(self):
         home = create_page('home', 'nav_playground.html', 'en', published=True)
         home.publish('en')
@@ -1718,6 +844,7 @@ class PreviousFilteredSiblingsTests(CMSTestCase):
 
 
 class PageTreeTests(CMSTestCase):
+
     def test_rename_node(self):
         home = create_page('grandpa', 'nav_playground.html', 'en', slug='home', published=True)
         home.publish('en')

--- a/cms/tests/test_page.py
+++ b/cms/tests/test_page.py
@@ -12,7 +12,7 @@ from django.core.exceptions import ValidationError
 from django.core.urlresolvers import reverse
 from django.db import transaction
 from django.db.models import signals
-from django.http import HttpRequest, HttpResponse, HttpResponseNotFound
+from django.http import HttpResponse, HttpResponseNotFound
 from django.utils.timezone import now as tz_now
 
 from cms import constants

--- a/cms/tests/test_page_admin.py
+++ b/cms/tests/test_page_admin.py
@@ -1,0 +1,1436 @@
+# -*- coding: utf-8 -*-
+import datetime
+
+from django.core.cache import cache
+from django.contrib import admin
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Permission, AnonymousUser
+from django.contrib.admin.sites import site, AdminSite
+from django.contrib.sites.models import Site
+from django.core.urlresolvers import reverse
+from django.http import HttpRequest, HttpResponse, HttpResponseNotFound
+from django.utils.http import urlencode
+from django.test.utils import override_settings
+from django.utils.encoding import force_text
+from django.utils.timezone import now as tz_now
+
+from cms import constants
+from cms.admin.forms import AdvancedSettingsForm
+from cms.admin.pageadmin import PageAdmin
+from cms.admin.permissionadmin import PagePermissionInlineAdmin
+from cms.api import assign_user_to_page, create_page, add_plugin, create_title
+from cms.constants import PUBLISHER_STATE_DEFAULT, PUBLISHER_STATE_DIRTY
+from cms.middleware.user import CurrentUserMiddleware
+from cms.models.pagemodel import Page
+from cms.models.permissionmodels import GlobalPagePermission, PagePermission
+from cms.models.pluginmodel import CMSPlugin
+from cms.models.titlemodels import EmptyTitle, Title
+from cms.test_utils.testcases import (
+    CMSTestCase, URL_CMS_PAGE_DELETE, URL_CMS_PAGE, URL_CMS_PAGE_MOVE,
+    URL_CMS_PAGE_ADVANCED_CHANGE, URL_CMS_TRANSLATION_DELETE,
+    URL_CMS_PAGE_CHANGE_LANGUAGE, URL_CMS_PAGE_CHANGE,
+    URL_CMS_PAGE_PERMISSIONS, URL_CMS_PAGE_ADD, URL_CMS_PAGE_PUBLISHED,
+)
+from cms.test_utils.util.context_managers import LanguageOverride, UserLoginContext
+from cms.utils import get_cms_setting
+from cms.utils.compat.dj import installed_apps
+from cms.utils.i18n import force_language
+from cms.utils.page_resolver import get_page_from_request
+from cms.utils.urlutils import admin_reverse
+
+from djangocms_text_ckeditor.models import Text
+
+
+class PageAdminTestBase(CMSTestCase):
+    """
+    The purpose of this class is to provide some basic functionality
+    to test methods of the Page admin.
+    """
+    placeholderconf = {'body': {
+        'limits': {
+            'global': 2,
+            'TextPlugin': 1,
+        }
+    }
+    }
+
+    def get_page(self, parent=None, site=None,
+                 language=None, template='nav_playground.html'):
+        page_data = self.get_new_page_data_dbfields()
+        return create_page(**page_data)
+
+    def get_admin(self):
+        """
+        Returns a PageAdmin instance.
+        """
+        return PageAdmin(Page, admin.site)
+
+    def get_post_request(self, data):
+        return self.get_request(post_data=data)
+
+
+class PageAdminTest(PageAdminTestBase):
+
+    def tearDown(self):
+        cache.clear()
+
+    def test_add_page(self):
+        """
+        Test that the add admin page could be displayed via the admin
+        """
+        superuser = self.get_superuser()
+        with self.login_user_context(superuser):
+            response = self.client.get(URL_CMS_PAGE_ADD)
+            self.assertEqual(response.status_code, 200)
+
+    def test_create_page_admin(self):
+        """
+        Test that a page can be created via the admin
+        """
+        page_data = self.get_new_page_data()
+
+        superuser = self.get_superuser()
+        with self.login_user_context(superuser):
+            self.assertEqual(Title.objects.all().count(), 0)
+            self.assertEqual(Page.objects.all().count(), 0)
+            # crate home and auto publish
+            response = self.client.post(URL_CMS_PAGE_ADD, page_data)
+            self.assertRedirects(response, URL_CMS_PAGE)
+            page_data = self.get_new_page_data()
+            response = self.client.post(URL_CMS_PAGE_ADD, page_data)
+            self.assertRedirects(response, URL_CMS_PAGE)
+
+            #self.assertEqual(Page.objects.all().count(), 2)
+            #self.assertEqual(Title.objects.all().count(), 2)
+
+            title = Title.objects.drafts().get(slug=page_data['slug'])
+            self.assertRaises(Title.DoesNotExist, Title.objects.public().get, slug=page_data['slug'])
+
+            page = title.page
+            page.save()
+            page.publish('en')
+            self.assertEqual(page.get_title(), page_data['title'])
+            self.assertEqual(page.get_slug(), page_data['slug'])
+            self.assertEqual(page.placeholders.all().count(), 2)
+
+            # were public instances created?
+            self.assertEqual(Title.objects.all().count(), 4)
+            title = Title.objects.drafts().get(slug=page_data['slug'])
+            title = Title.objects.public().get(slug=page_data['slug'])
+
+    def test_create_tree_admin(self):
+        """
+        Test that a tree can be created via the admin
+        """
+        page_1 = self.get_new_page_data()
+
+        superuser = self.get_superuser()
+        with self.login_user_context(superuser):
+            # create home and auto publish
+            response = self.client.post(URL_CMS_PAGE_ADD, page_1)
+            self.assertRedirects(response, URL_CMS_PAGE)
+
+            title_home = Title.objects.drafts().get(slug=page_1['slug'])
+
+            page_2 = self.get_new_page_data(parent_id=title_home.page.pk)
+            page_3 = self.get_new_page_data(parent_id=title_home.page.pk)
+            page_4 = self.get_new_page_data(parent_id=title_home.page.pk)
+
+            response = self.client.post(URL_CMS_PAGE_ADD, page_2)
+            self.assertRedirects(response, URL_CMS_PAGE)
+            response = self.client.post(URL_CMS_PAGE_ADD, page_3)
+            self.assertRedirects(response, URL_CMS_PAGE)
+
+            title_left = Title.objects.drafts().get(slug=page_2['slug'])
+
+            response = self.client.post(URL_CMS_PAGE_ADD + '?target=%s&amp;position=right' % title_left.page.pk, page_4)
+            self.assertRedirects(response, URL_CMS_PAGE)
+
+    def test_slug_collision(self):
+        """
+        Test a slug collision
+        """
+        page_data = self.get_new_page_data()
+        # create first page
+        superuser = self.get_superuser()
+        with self.login_user_context(superuser):
+            response = self.client.post(URL_CMS_PAGE_ADD, page_data)
+            self.assertRedirects(response, URL_CMS_PAGE)
+
+            response = self.client.post(URL_CMS_PAGE_ADD, page_data)
+
+            self.assertEqual(response.status_code, 200)
+            self.assertTrue(response.request['PATH_INFO'].endswith(URL_CMS_PAGE_ADD))
+            self.assertContains(response, '<ul class="errorlist"><li>Another page with this slug already exists</li></ul>')
+
+    def test_child_slug_collision(self):
+        """
+        Test a slug collision
+        """
+        root = create_page("home", 'nav_playground.html', "en", published=True)
+        page = create_page("page", 'nav_playground.html', "en")
+        subPage = create_page("subpage", 'nav_playground.html', "en", parent=page)
+        create_page("child-page", 'nav_playground.html', "en", parent=root)
+        superuser = self.get_superuser()
+        with self.login_user_context(superuser):
+
+            response = self.client.get(URL_CMS_PAGE_ADD+"?target=%s&position=right&site=1" % subPage.pk)
+            self.assertContains(response, 'value="%s"' % page.pk)
+
+            # slug collision between two child pages of the same node
+            page_data = self.get_new_page_data(page.pk)
+            page_data['slug'] = 'subpage'
+            response = self.client.post(URL_CMS_PAGE_ADD, page_data)
+
+            self.assertEqual(response.status_code, 200)
+            self.assertTrue(response.request['PATH_INFO'].endswith(URL_CMS_PAGE_ADD))
+            self.assertContains(response, '<ul class="errorlist"><li>Another page with this slug already exists</li></ul>')
+
+            # slug collision between page with no parent and a child page of root
+            page_data = self.get_new_page_data()
+            page_data['slug'] = 'child-page'
+            response = self.client.post(URL_CMS_PAGE_ADD, page_data)
+
+            self.assertEqual(response.status_code, 200)
+            self.assertTrue(response.request['PATH_INFO'].endswith(URL_CMS_PAGE_ADD))
+            self.assertContains(response, '<ul class="errorlist"><li>Another page with this slug already exists</li></ul>')
+
+            # slug collision between two top-level pages
+            page_data = self.get_new_page_data()
+            page_data['slug'] = 'page'
+            response = self.client.post(URL_CMS_PAGE_ADD, page_data)
+
+            self.assertEqual(response.status_code, 200)
+            self.assertTrue(response.request['PATH_INFO'].endswith(URL_CMS_PAGE_ADD))
+            self.assertContains(response, '<ul class="errorlist"><li>Another page with this slug already exists</li></ul>')
+
+    def test_edit_page(self):
+        """
+        Test that a page can edited via the admin
+        """
+        superuser = self.get_superuser()
+        with self.login_user_context(superuser):
+            page_data = self.get_new_page_data()
+            response = self.client.post(URL_CMS_PAGE_ADD, page_data)
+            page = Page.objects.get(title_set__slug=page_data['slug'], publisher_is_draft=True)
+            response = self.client.get(URL_CMS_PAGE_CHANGE % page.id)
+            self.assertEqual(response.status_code, 200)
+            page_data['title'] = 'changed title'
+            response = self.client.post(URL_CMS_PAGE_CHANGE % page.id, page_data)
+            self.assertRedirects(response, URL_CMS_PAGE)
+            self.assertEqual(page.get_title(), 'changed title')
+
+    def test_moderator_edit_page_redirect(self):
+        """
+        Test that a page can be edited multiple times with moderator
+        """
+        create_page("home", "nav_playground.html", "en", published=True)
+        superuser = self.get_superuser()
+        with self.login_user_context(superuser):
+            page_data = self.get_new_page_data()
+            response = self.client.post(URL_CMS_PAGE_ADD, page_data)
+            self.assertEqual(response.status_code, 302)
+            page = Page.objects.get(title_set__slug=page_data['slug'])
+            response = self.client.get(URL_CMS_PAGE_CHANGE % page.id)
+            self.assertEqual(response.status_code, 200)
+            page_data['overwrite_url'] = '/hello/'
+            page_data['has_url_overwrite'] = True
+            response = self.client.post(URL_CMS_PAGE_ADVANCED_CHANGE % page.id, page_data)
+            self.assertRedirects(response, URL_CMS_PAGE)
+            self.assertEqual(page.get_absolute_url(), '/en/hello/')
+            Title.objects.all()[0]
+            page = page.reload()
+            page.publish('en')
+            page_data['title'] = 'new title'
+            response = self.client.post(URL_CMS_PAGE_CHANGE % page.id, page_data)
+            page = Page.objects.get(title_set__slug=page_data['slug'], publisher_is_draft=True)
+            self.assertRedirects(response, URL_CMS_PAGE)
+            self.assertEqual(page.get_title(), 'new title')
+
+    def test_meta_description_fields_from_admin(self):
+        """
+        Test that description and keywords tags can be set via the admin
+        """
+        superuser = self.get_superuser()
+        with self.login_user_context(superuser):
+            page_data = self.get_new_page_data()
+            page_data["meta_description"] = "I am a page"
+            self.client.post(URL_CMS_PAGE_ADD, page_data)
+            page = Page.objects.get(title_set__slug=page_data['slug'], publisher_is_draft=True)
+            response = self.client.get(URL_CMS_PAGE_CHANGE % page.id)
+            self.assertEqual(response.status_code, 200)
+            page_data['meta_description'] = 'I am a duck'
+            response = self.client.post(URL_CMS_PAGE_CHANGE % page.id, page_data)
+            self.assertRedirects(response, URL_CMS_PAGE)
+            page = Page.objects.get(title_set__slug=page_data["slug"], publisher_is_draft=True)
+            self.assertEqual(page.get_meta_description(), 'I am a duck')
+
+    def test_meta_description_from_template_tags(self):
+        from django import template
+
+        superuser = self.get_superuser()
+        with self.login_user_context(superuser):
+            page_data = self.get_new_page_data()
+            page_data["title"] = "Hello"
+            page_data["meta_description"] = "I am a page"
+            self.client.post(URL_CMS_PAGE_ADD, page_data)
+            page = Page.objects.get(title_set__slug=page_data['slug'], publisher_is_draft=True)
+            self.client.post(URL_CMS_PAGE_CHANGE % page.id, page_data)
+            t = template.Template(
+                "{% load cms_tags %}{% page_attribute title %} {% page_attribute meta_description %}")
+            req = HttpRequest()
+            page.save()
+            page.publish('en')
+            req.current_page = page
+            req.GET = {}
+            self.assertEqual(t.render(template.Context({"request": req})), "Hello I am a page")
+
+    def test_page_obj_change_data_from_template_tags(self):
+        from django import template
+
+        superuser = self.get_superuser()
+        with self.login_user_context(superuser):
+            page_data = self.get_new_page_data()
+            change_user = str(superuser)
+            # some databases don't store microseconds, so move the start flag
+            # back by 1 second
+            before_change = tz_now()+datetime.timedelta(seconds=-1)
+            self.client.post(URL_CMS_PAGE_ADD, page_data)
+            page = Page.objects.get(
+                title_set__slug=page_data['slug'],
+                publisher_is_draft=True
+            )
+            self.client.post(URL_CMS_PAGE_CHANGE % page.id, page_data)
+            t = template.Template(
+                "{% load cms_tags %}{% page_attribute changed_by %} changed "
+                "on {% page_attribute changed_date as page_change %}"
+                "{{ page_change|date:'Y-m-d\TH:i:s' }}"
+            )
+            req = HttpRequest()
+            page.save()
+            page.publish('en')
+            after_change = tz_now()
+            req.current_page = page
+            req.GET = {}
+
+            actual_result = t.render(template.Context({"request": req}))
+            desired_result = "{0} changed on {1}".format(
+                change_user,
+                actual_result[-19:]
+            )
+            save_time = datetime.datetime.strptime(
+                actual_result[-19:],
+                "%Y-%m-%dT%H:%M:%S"
+            )
+
+            self.assertEqual(actual_result, desired_result)
+            # direct time comparisons are flaky, so we just check if the
+            # page's changed_date is within the time range taken by this test
+            self.assertLessEqual(before_change, save_time)
+            self.assertLessEqual(save_time, after_change)
+
+    def test_copy_page(self):
+        """
+        Test that a page can be copied via the admin
+        """
+        page_a = create_page("page_a", "nav_playground.html", "en", published=True)
+        page_a_a = create_page("page_a_a", "nav_playground.html", "en",
+                               parent=page_a, published=True, reverse_id="hello")
+        create_page("page_a_a_a", "nav_playground.html", "en", parent=page_a_a, published=True)
+
+        page_b = create_page("page_b", "nav_playground.html", "en", published=True)
+        page_b_a = create_page("page_b_b", "nav_playground.html", "en",
+                               parent=page_b, published=True)
+
+        count = Page.objects.drafts().count()
+
+        superuser = self.get_superuser()
+        with self.login_user_context(superuser):
+            self.copy_page(page_a, page_b_a)
+
+        self.assertEqual(Page.objects.drafts().count() - count, 3)
+
+    def test_copy_self_page(self):
+        """
+        Test that a page can be copied via the admin
+        """
+        page_a = create_page("page_a", "nav_playground.html", "en")
+        page_b = create_page("page_b", "nav_playground.html", "en", parent=page_a)
+        page_c = create_page("page_c", "nav_playground.html", "en", parent=page_b)
+        with self.login_user_context(self.get_superuser()):
+            self.copy_page(page_b, page_b)
+        self.assertEqual(Page.objects.drafts().count(), 5)
+        self.assertEqual(Page.objects.filter(parent=page_b).count(), 2)
+        page_d = Page.objects.filter(parent=page_b)[0]
+        page_e = Page.objects.get(parent=page_d)
+        self.assertEqual(page_d.path, '000100010001')
+        self.assertEqual(page_e.path, '0001000100010001')
+        page_e.delete()
+        page_d.delete()
+        with self.login_user_context(self.get_superuser()):
+            self.copy_page(page_b, page_c)
+        self.assertEqual(Page.objects.filter(parent=page_c).count(), 1)
+        self.assertEqual(Page.objects.filter(parent=page_b).count(), 1)
+        Page.objects.filter(parent=page_c).delete()
+        self.assertEqual(Page.objects.all().count(), 3)
+        page_b = page_b.reload()
+        page_c = page_c.reload()
+        with self.login_user_context(self.get_superuser()):
+            self.copy_page(page_b, page_c, position=0)
+
+    def test_get_admin_tree_title(self):
+        page = create_page("page_a", "nav_playground.html", "en", published=True)
+        self.assertEqual(page.get_admin_tree_title(), 'page_a')
+        page.title_cache = {}
+        self.assertEqual("Empty", force_text(page.get_admin_tree_title()))
+        languages = {
+            1: [
+                {
+                    'code': 'en',
+                    'name': 'English',
+                    'fallbacks': ['fr', 'de'],
+                    'public': True,
+                    'fallbacks':['fr']
+                },
+                {
+                    'code': 'fr',
+                    'name': 'French',
+                    'public': True,
+                    'fallbacks':['en']
+                },
+        ]}
+        with self.settings(CMS_LANGUAGES=languages):
+            with force_language('fr'):
+                page.title_cache = {'en': Title(slug='test', page_title="test2", title="test2")}
+                self.assertEqual('test2', force_text(page.get_admin_tree_title()))
+                page.title_cache = {'en': Title(slug='test', page_title="test2")}
+                self.assertEqual('test2', force_text(page.get_admin_tree_title()))
+                page.title_cache = {'en': Title(slug='test', menu_title="test2")}
+                self.assertEqual('test2', force_text(page.get_admin_tree_title()))
+                page.title_cache = {'en': Title(slug='test2')}
+                self.assertEqual('test2', force_text(page.get_admin_tree_title()))
+                page.title_cache = {'en': Title(slug='test2'), 'fr': EmptyTitle('fr')}
+                self.assertEqual('test2', force_text(page.get_admin_tree_title()))
+
+    def test_language_change(self):
+        superuser = self.get_superuser()
+        with self.login_user_context(superuser):
+            page_data = self.get_new_page_data()
+            self.client.post(URL_CMS_PAGE_ADD, page_data)
+            pk = Page.objects.all()[0].pk
+            response = self.client.get(URL_CMS_PAGE_CHANGE % pk, {"language": "en"})
+            self.assertEqual(response.status_code, 200)
+            response = self.client.get(URL_CMS_PAGE_CHANGE % pk, {"language": "de"})
+            self.assertEqual(response.status_code, 200)
+
+    def test_move_page(self):
+        superuser = self.get_superuser()
+        with self.login_user_context(superuser):
+            page_home = self.get_new_page_data()
+            self.client.post(URL_CMS_PAGE_ADD, page_home)
+            page_data1 = self.get_new_page_data()
+            self.client.post(URL_CMS_PAGE_ADD, page_data1)
+            page_data2 = self.get_new_page_data()
+            self.client.post(URL_CMS_PAGE_ADD, page_data2)
+            page_data3 = self.get_new_page_data()
+            self.client.post(URL_CMS_PAGE_ADD, page_data3)
+            home = Page.objects.all()[0]
+            page1 = Page.objects.all()[2]
+            page2 = Page.objects.all()[3]
+            page3 = Page.objects.all()[4]
+
+            # move pages
+            response = self.client.post(URL_CMS_PAGE_MOVE % page3.pk,
+                                        {"target": page2.pk, "position": "last-child"})
+            self.assertEqual(response.status_code, 200)
+
+            page3 = Page.objects.get(pk=page3.pk)
+            response = self.client.post(URL_CMS_PAGE_MOVE % page2.pk,
+                                        {"target": page1.pk, "position": "last-child"})
+            self.assertEqual(response.status_code, 200)
+            # check page2 path and url
+            page2 = Page.objects.get(pk=page2.pk)
+            self.assertEqual(page2.get_path(), page_data1['slug'] + "/" + page_data2['slug'])
+            self.assertEqual(page2.get_absolute_url(),
+                             self.get_pages_root() + page_data1['slug'] + "/" + page_data2['slug'] + "/")
+            # check page3 path and url
+            page3 = Page.objects.get(pk=page3.pk)
+            self.assertEqual(page3.get_path(), page_data1['slug'] + "/" + page_data2['slug'] + "/" + page_data3['slug'])
+            self.assertEqual(page3.get_absolute_url(),
+                             self.get_pages_root() + page_data1['slug'] + "/" + page_data2['slug'] + "/" + page_data3[
+                                 'slug'] + "/")
+
+            # publish page 1 (becomes home)
+            home.delete()
+            page1.publish('en')
+            public_page1 = page1.publisher_public
+            self.assertEqual(page1.get_path(), '')
+            self.assertEqual(public_page1.get_path(), '')
+            # check that page2 and page3 url have changed
+            page2 = Page.objects.get(pk=page2.pk)
+            page2.publish('en')
+            public_page2 = page2.publisher_public
+            self.assertEqual(public_page2.get_absolute_url(), self.get_pages_root() + page_data2['slug'] + "/")
+            page3 = Page.objects.get(pk=page3.pk)
+            page3.publish('en')
+            public_page3 = page3.publisher_public
+            self.assertEqual(public_page3.get_absolute_url(),
+                             self.get_pages_root() + page_data2['slug'] + "/" + page_data3['slug'] + "/")
+            # set page2 as root and check path of 1 and 3
+            response = self.client.post(URL_CMS_PAGE_MOVE % page2.pk,
+                                        {"position": "0"})
+            self.assertEqual(response.status_code, 200)
+            page1 = Page.objects.get(pk=page1.pk)
+            self.assertEqual(page1.get_path(), page_data1['slug'])
+            page2 = Page.objects.get(pk=page2.pk)
+            # Check that page2 is now at the root of the tree
+            self.assertTrue(page2.is_home)
+            self.assertEqual(page2.get_path(), '')
+            page3 = Page.objects.get(pk=page3.pk)
+            self.assertEqual(page3.get_path(), page_data3['slug'])
+
+    def test_move_page_integrity(self):
+        superuser = self.get_superuser()
+        with self.login_user_context(superuser):
+            page_home = self.get_new_page_data()
+            self.client.post(URL_CMS_PAGE_ADD, page_home)
+
+            # Create parent page
+            page_root = create_page("Parent", 'col_three.html', "en")
+            page_root.publish('en')
+
+            # Create child pages
+            page_child_1 = create_page(
+                "Child 1",
+                template=constants.TEMPLATE_INHERITANCE_MAGIC,
+                language="en",
+                parent=page_root,
+            )
+            page_child_1.publish('en')
+
+            page_child_2 = create_page(
+                "Child 2",
+                template=constants.TEMPLATE_INHERITANCE_MAGIC,
+                language="en",
+                parent=page_root,
+            )
+            page_child_2.publish('en')
+
+            # Create two root pages that ware meant as child pages
+            page_child_3 = create_page("Child 3", 'col_three.html', "en")
+            page_child_4 = create_page("Child 4", 'col_three.html', "en", published=True)
+
+            # Correct our mistake.
+            # Move page_child_3 to be child of parent page
+            data = {
+                "id": page_child_3.pk,
+                "target": page_root.pk,
+                "position": "0",
+            }
+            response = self.client.post(
+                URL_CMS_PAGE_MOVE % page_child_3.pk,
+                data,
+            )
+            self.assertEqual(response.status_code, 200)
+
+            # Un-publish page_child_4
+            page_child_4.unpublish('en')
+
+            # Move page_child_4 to be child of parent page
+            data = {
+                "id": page_child_4.pk,
+                "target": page_root.pk,
+                "position": "0",
+            }
+            response = self.client.post(
+                URL_CMS_PAGE_MOVE % page_child_4.pk,
+                data,
+            )
+            self.assertEqual(response.status_code, 200)
+
+            page_root = page_root.reload()
+            page_child_4 = page_child_4.reload()
+
+            # Ensure move worked
+            self.assertEqual(page_root.get_descendants().count(), 4)
+
+            # Ensure page_child_3 is still unpublished
+            self.assertEqual(
+                page_child_3.get_publisher_state("en"),
+                PUBLISHER_STATE_DIRTY
+            )
+            self.assertEqual(page_child_3.is_published("en"), False)
+
+            # Ensure page_child_4 is still unpublished
+            self.assertEqual(
+                page_child_4.get_publisher_state("en"),
+                PUBLISHER_STATE_DIRTY
+            )
+            self.assertEqual(page_child_4.is_published("en"), False)
+
+            # And it's public page is still has the published state
+            # but is marked as unpublished
+            self.assertEqual(
+                page_child_4.publisher_public.get_publisher_state("en"),
+                PUBLISHER_STATE_DEFAULT
+            )
+            self.assertEqual(
+                page_child_4.publisher_public.is_published("en"),
+                False,
+            )
+
+            # Ensure child one is still published
+            self.assertEqual(
+                page_child_1.get_publisher_state("en"),
+                PUBLISHER_STATE_DEFAULT
+            )
+            self.assertEqual(page_child_1.is_published("en"), True)
+
+            # Ensure child two is still published
+            self.assertEqual(
+                page_child_2.get_publisher_state("en"),
+                PUBLISHER_STATE_DEFAULT
+            )
+            self.assertEqual(page_child_2.is_published("en"), True)
+
+    def test_edit_page_other_site_and_language(self):
+        """
+        Test that a page can edited via the admin when your current site is
+        different from the site you are editing and the language isn't available
+        for the current site.
+        """
+        self.assertEqual(Site.objects.all().count(), 1)
+        site = Site.objects.create(domain='otherlang', name='otherlang', pk=2)
+        # Change site for this session
+        page_data = self.get_new_page_data()
+        page_data['site'] = site.pk
+        page_data['title'] = 'changed title'
+        self.assertEqual(site.pk, 2)
+        TESTLANG = get_cms_setting('LANGUAGES')[site.pk][0]['code']
+        page_data['language'] = TESTLANG
+        superuser = self.get_superuser()
+        with self.login_user_context(superuser):
+            response = self.client.post(URL_CMS_PAGE_ADD, page_data)
+            self.assertRedirects(response, URL_CMS_PAGE)
+            page = Page.objects.get(title_set__slug=page_data['slug'], publisher_is_draft=True)
+            with LanguageOverride(TESTLANG):
+                self.assertEqual(page.get_title(), 'changed title')
+
+    def test_get_page_from_request_on_non_cms_admin(self):
+        request = self.get_request(
+            admin_reverse('sampleapp_category_change', args=(1,))
+        )
+        page = get_page_from_request(request)
+        self.assertEqual(page, None)
+
+    def test_get_page_from_request_on_cms_admin(self):
+        page = create_page("page", "nav_playground.html", "en")
+        request = self.get_request(
+            admin_reverse('cms_page_change', args=(page.pk,))
+        )
+        found_page = get_page_from_request(request)
+        self.assertTrue(found_page)
+        self.assertEqual(found_page.pk, page.pk)
+
+    def test_get_page_from_request_on_cms_admin_nopage(self):
+        request = self.get_request(
+            admin_reverse('cms_page_change', args=(1,))
+        )
+        page = get_page_from_request(request)
+        self.assertEqual(page, None)
+
+    def test_get_page_from_request_cached(self):
+        mock_page = 'hello world'
+        request = self.get_request(
+            admin_reverse('sampleapp_category_change', args=(1,))
+        )
+        request._current_page_cache = mock_page
+        page = get_page_from_request(request)
+        self.assertEqual(page, mock_page)
+
+    def test_get_page_from_request_on_cms_admin_with_editplugin(self):
+        page = create_page("page", "nav_playground.html", "en")
+        request = self.get_request(
+            admin_reverse('cms_page_change', args=(page.pk,)) + 'edit-plugin/42/'
+        )
+        found_page = get_page_from_request(request)
+        self.assertTrue(found_page)
+        self.assertEqual(found_page.pk, page.pk)
+
+    def test_get_page_from_request_on_cms_admin_with_editplugin_nopage(self):
+        request = self.get_request(
+            admin_reverse('cms_page_change', args=(1,)) + 'edit-plugin/42/'
+        )
+        page = get_page_from_request(request)
+        self.assertEqual(page, None)
+
+    def test_existing_overwrite_url(self):
+        with self.settings(CMS_PERMISSION=False):
+            create_page('home', 'nav_playground.html', 'en', published=True)
+            create_page('boo', 'nav_playground.html', 'en', published=True)
+            data = {
+                'title': 'foo',
+                'overwrite_url': '/boo/',
+                'slug': 'foo',
+                'language': 'en',
+                'template': 'nav_playground.html',
+                'site': 1,
+            }
+            form = AdvancedSettingsForm(data)
+            self.assertFalse(form.is_valid())
+            self.assertTrue('overwrite_url' in form.errors)
+
+    def test_advanced_settings_form(self):
+        site = Site.objects.get_current()
+        page = create_page('Page 1', 'nav_playground.html', 'en')
+
+        # First we provide fully valid conditions to make sure
+        # the form is working.
+        page_data = {
+            'language': 'en',
+            'site': site.pk,
+            'template': 'col_two.html',
+        }
+
+        form = AdvancedSettingsForm(
+            data=page_data,
+            instance=page,
+            files=None,
+        )
+        self.assertTrue(form.is_valid())
+
+        # Now switch it up by adding german as the current language
+        # Note that german has not been created as page translation.
+        page_data['language'] = 'de'
+
+        form = AdvancedSettingsForm(
+            data=page_data,
+            instance=page,
+            files=None,
+        )
+        no_translation_error = (u"Please create the German page translation "
+                                u"before editing its advanced settings.")
+        self.assertFalse(form.is_valid())
+        self.assertIn('__all__', form.errors)
+        self.assertEqual(1, len(form.errors['__all__']))
+        # Make sure we get the correct error when the given language
+        # is not an existing page translation.
+        self.assertEqual([no_translation_error],
+                         form.errors['__all__'])
+
+        de_translation = create_title('de', title='Page 1', page=page)
+        de_translation.slug = ''
+        de_translation.save()
+
+        # First make sure the title has no slug
+        self.assertEqual(de_translation.slug, '')
+
+        form = AdvancedSettingsForm(
+            data=page_data,
+            instance=page,
+            files=None,
+        )
+        no_translation_error = (u"Please set the German slug before "
+                                u"editing its advanced settings.")
+        self.assertFalse(form.is_valid())
+        self.assertIn('__all__', form.errors)
+        self.assertEqual(1, len(form.errors['__all__']))
+        # Make sure we get the correct error when the given language
+        # is not an existing page translation.
+        self.assertEqual([no_translation_error],
+                         form.errors['__all__'])
+
+    def test_form_url_page_change(self):
+        superuser = self.get_superuser()
+        with self.login_user_context(superuser):
+            pageadmin = self.get_admin()
+            page = self.get_page()
+            form_url = admin_reverse("cms_page_change", args=(page.pk,))
+            # Middleware is needed to correctly setup the environment for the admin
+            middleware = CurrentUserMiddleware()
+            request = self.get_request()
+            middleware.process_request(request)
+            response = pageadmin.change_view(
+                request, str(page.pk),
+                form_url=form_url)
+            self.assertTrue('form_url' in response.context_data)
+            self.assertEqual(response.context_data['form_url'], form_url)
+
+    def test_global_limit_on_plugin_move(self):
+        admin = self.get_admin()
+        superuser = self.get_superuser()
+        cms_page = self.get_page()
+        source_placeholder = cms_page.placeholders.get(slot='right-column')
+        target_placeholder = cms_page.placeholders.get(slot='body')
+        data = {
+            'placeholder': source_placeholder,
+            'plugin_type': 'LinkPlugin',
+            'language': 'en',
+        }
+        plugin_1 = add_plugin(**data)
+        plugin_2 = add_plugin(**data)
+        plugin_3 = add_plugin(**data)
+        with UserLoginContext(self, superuser):
+            with self.settings(CMS_PLACEHOLDER_CONF=self.placeholderconf):
+                request = self.get_post_request(
+                    {'placeholder_id': target_placeholder.pk, 'plugin_id': plugin_1.pk, 'plugin_parent': ''})
+                response = admin.move_plugin(request) # first
+                self.assertEqual(response.status_code, 200)
+                request = self.get_post_request(
+                    {'placeholder_id': target_placeholder.pk, 'plugin_id': plugin_2.pk, 'plugin_parent': ''})
+                response = admin.move_plugin(request) # second
+                self.assertEqual(response.status_code, 200)
+                request = self.get_post_request(
+                    {'placeholder_id': target_placeholder.pk, 'plugin_id': plugin_3.pk, 'plugin_parent': ''})
+                response = admin.move_plugin(request) # third
+                self.assertEqual(response.status_code, 400)
+                self.assertEqual(response.content, b"This placeholder already has the maximum number of plugins (2).")
+
+    def test_type_limit_on_plugin_move(self):
+        admin = self.get_admin()
+        superuser = self.get_superuser()
+        cms_page = self.get_page()
+        source_placeholder = cms_page.placeholders.get(slot='right-column')
+        target_placeholder = cms_page.placeholders.get(slot='body')
+        data = {
+            'placeholder': source_placeholder,
+            'plugin_type': 'TextPlugin',
+            'language': 'en',
+        }
+        plugin_1 = add_plugin(**data)
+        plugin_2 = add_plugin(**data)
+        with UserLoginContext(self, superuser):
+            with self.settings(CMS_PLACEHOLDER_CONF=self.placeholderconf):
+                request = self.get_post_request(
+                    {'placeholder_id': target_placeholder.pk, 'plugin_id': plugin_1.pk, 'plugin_parent': ''})
+                response = admin.move_plugin(request) # first
+                self.assertEqual(response.status_code, 200)
+                request = self.get_post_request(
+                    {'placeholder_id': target_placeholder.pk, 'plugin_id': plugin_2.pk, 'plugin_parent': ''})
+                response = admin.move_plugin(request) # second
+                self.assertEqual(response.status_code, 400)
+                self.assertEqual(response.content,
+                                 b"This placeholder already has the maximum number (1) of allowed Text plugins.")
+
+
+@override_settings(CMS_PERMISSION=True)
+class PageAdminPermissionsOnTest(PageAdminTestBase):
+
+    def test_pages_in_admin_index(self):
+        pass
+
+    def test_pages_not_in_admin_index(self):
+        pass
+
+    def test_page_can_edit(self):
+        pass
+
+    def test_page_cant_edit(self):
+        pass
+
+    def test_get_permissions(self):
+        page = create_page('test-page', 'nav_playground.html', 'en')
+        url = admin_reverse('cms_page_get_permissions', args=(page.pk,))
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 302)
+        self.assertRedirects(response, '/en/admin/login/?next=%s' % (URL_CMS_PAGE_PERMISSIONS % page.pk))
+        admin_user = self.get_superuser()
+        with self.login_user_context(admin_user):
+            response = self.client.get(url)
+            self.assertEqual(response.status_code, 200)
+            self.assertTemplateNotUsed(response, 'admin/login.html')
+
+    def test_delete_permissions(self):
+        admin_user, staff_user = self._get_guys()
+        create_page("home", "nav_playground.html", "en",
+                           created_by=admin_user, published=True)
+        page = create_page("delete-page", "nav_playground.html", "en",
+                           created_by=admin_user, published=True)
+        body = page.placeholders.get(slot='body')
+        add_plugin(body, 'TextPlugin', 'en', body='text')
+        page.publish('en')
+
+        # CMS_PERMISSION is set to True and staff user
+        # has global permissions set.
+        with self.settings(CMS_PERMISSION=True):
+            with self.login_user_context(staff_user):
+                data = {'post': 'yes'}
+                response = self.client.post(URL_CMS_PAGE_DELETE % page.pk, data)
+
+                # assert deleting page was successful
+                self.assertRedirects(response, URL_CMS_PAGE)
+                self.assertFalse(Page.objects.filter(pk=page.pk).exists())
+
+        page = create_page("delete-page", "nav_playground.html", "en",
+                           created_by=admin_user, published=True)
+
+        # CMS_PERMISSION is set to False and user does not
+        # have permission to delete any plugins but the page
+        # has no plugins.
+        with self.settings(CMS_PERMISSION=False):
+            with self.login_user_context(staff_user):
+                data = {'post': 'yes'}
+                response = self.client.post(URL_CMS_PAGE_DELETE % page.pk, data)
+
+                # assert deleting page was successful
+                self.assertRedirects(response, URL_CMS_PAGE)
+                self.assertFalse(Page.objects.filter(pk=page.pk).exists())
+
+        page = create_page("delete-page", "nav_playground.html", "en",
+                           created_by=admin_user, published=True)
+        body = page.placeholders.get(slot='body')
+        add_plugin(body, 'TextPlugin', 'en', body='text')
+        page.publish('en')
+
+        # CMS_PERMISSION is set to False and user does not
+        # have permission to delete any plugin
+        with self.settings(CMS_PERMISSION=False):
+            with self.login_user_context(staff_user):
+                data = {'post': 'yes'}
+                response = self.client.post(URL_CMS_PAGE_DELETE % page.pk, data)
+
+                # assert deleting page was unsuccessful
+                self.assertEqual(response.status_code, 403)
+                self.assertTrue(Page.objects.filter(pk=page.pk).exists())
+
+        # Give the staff user permission to delete text plugins
+        staff_user.user_permissions.add(Permission.objects.get(codename='delete_text'))
+
+        # CMS_PERMISSION is set to False and user has
+        # permission to delete text plugins
+        with self.settings(CMS_PERMISSION=False):
+            with self.login_user_context(staff_user):
+                data = {'post': 'yes'}
+                response = self.client.post(URL_CMS_PAGE_DELETE % page.pk, data)
+
+                # assert deleting page was successful
+                self.assertRedirects(response, URL_CMS_PAGE)
+                self.assertFalse(Page.objects.filter(pk=page.pk).exists())
+
+    def test_delete_translation_permissions(self):
+        admin_user, staff_user = self._get_guys()
+        page = create_page("delete-page-translation", "nav_playground.html", "en",
+                           created_by=admin_user, published=True)
+        body = page.placeholders.get(slot='body')
+        create_title("de", "delete-page-translation-2", page, slug="delete-page-translation-2")
+        create_title("fr", "delete-page-translation-fr", page.reload(), slug="delete-page-translation-fr")
+        add_plugin(body, 'TextPlugin', 'de', body='text')
+
+        # add a link plugin but never give the user permission to delete it
+        # all our tests target the german translation.
+        # this asserts that a plugin in another language does not interfere
+        # with deleting.
+        link = add_plugin(body, 'LinkPlugin', 'en', name='link-1')
+
+        # CMS_PERMISSION is set to True and staff user
+        # has global permissions set.
+        with self.settings(CMS_PERMISSION=True):
+            with self.login_user_context(staff_user):
+                response = self.client.post(URL_CMS_TRANSLATION_DELETE % page.pk, {'language': 'de'})
+
+                # assert deleting page was successful
+                self.assertRedirects(response, URL_CMS_PAGE)
+                self.assertFalse(page.title_set.filter(language='de').exists())
+                # LinkPlugin should continue to be
+                self.assertTrue(body.cmsplugin_set.filter(pk=link.pk).exists())
+
+        # the API needs a fresh page object
+        page = page.reload()
+        create_title("de", "delete-page-translation-2", page.reload(), slug="delete-page-translation-2")
+        add_plugin(body, 'TextPlugin', 'de', body='text')
+
+        # CMS_PERMISSION is set to False and user does not
+        # have permission to delete text plugins
+        with self.settings(CMS_PERMISSION=False):
+            with self.login_user_context(staff_user):
+                response = self.client.post(URL_CMS_TRANSLATION_DELETE % page.pk, {'language': 'de'})
+
+                # assert deleting page was successful
+                self.assertEqual(response.status_code, 403)
+                self.assertTrue(page.title_set.filter(language='de').exists())
+                # LinkPlugin should continue to be
+                self.assertTrue(body.cmsplugin_set.filter(pk=link.pk).exists())
+
+        # CMS_PERMISSION is set to False and user does not
+        # have permission to delete any plugins but the translation
+        # does not contain plugins
+        with self.settings(CMS_PERMISSION=False):
+            with self.login_user_context(staff_user):
+                response = self.client.post(URL_CMS_TRANSLATION_DELETE % page.pk, {'language': 'fr'})
+
+                # assert deleting page was successful
+                self.assertRedirects(response, URL_CMS_PAGE)
+                self.assertFalse(page.title_set.filter(language='fr').exists())
+                # LinkPlugin should continue to be
+                self.assertTrue(body.cmsplugin_set.filter(pk=link.pk).exists())
+
+        # Give the staff user permission to delete text plugins
+        staff_user.user_permissions.add(Permission.objects.get(codename='delete_text'))
+
+        # CMS_PERMISSION is set to False and user has
+        # permission to delete text plugins
+        with self.settings(CMS_PERMISSION=False):
+            with self.login_user_context(staff_user):
+                response = self.client.post(URL_CMS_TRANSLATION_DELETE % page.pk, {'language': 'de'})
+
+                # assert deleting page was successful
+                self.assertRedirects(response, URL_CMS_PAGE)
+                self.assertFalse(page.title_set.filter(language='de').exists())
+                # LinkPlugin should continue to be
+                self.assertTrue(body.cmsplugin_set.filter(pk=link.pk).exists())
+
+    def test_page_permission_inline_visibility(self):
+        User = get_user_model()
+
+        fields = dict(email='user@domain.com', password='user', is_staff=True)
+
+        if get_user_model().USERNAME_FIELD != 'email':
+            fields[get_user_model().USERNAME_FIELD] = 'user'
+
+        user = User(**fields)
+        user.save()
+        self._give_page_permission_rights(user)
+        page = create_page('A', 'nav_playground.html', 'en')
+        page_permission = PagePermission.objects.create(
+            can_change_permissions=True, user=user, page=page)
+        request = self._get_change_page_request(user, page)
+        page_admin = PageAdmin(Page, AdminSite())
+        page_admin._current_page = page
+        # user has can_change_permission
+        # => must see the PagePermissionInline
+        self.assertTrue(
+            any(type(inline) is PagePermissionInlineAdmin
+                for inline in page_admin.get_inline_instances(request, page)))
+
+        page = Page.objects.get(pk=page.pk)
+        # remove can_change_permission
+        page_permission.can_change_permissions = False
+        page_permission.save()
+        request = self._get_change_page_request(user, page)
+        page_admin = PageAdmin(Page, AdminSite())
+        page_admin._current_page = page
+        # => PagePermissionInline is no longer visible
+        self.assertFalse(
+            any(type(inline) is PagePermissionInlineAdmin
+                for inline in page_admin.get_inline_instances(request, page)))
+
+    def test_permissioned_page_list(self):
+        """
+        Makes sure that a user with restricted page permissions can view
+        the page list.
+        """
+        admin_user, normal_guy = self._get_guys(use_global_permissions=False)
+
+        current_site = Site.objects.get(pk=1)
+        page = create_page("Test page", "nav_playground.html", "en",
+                           site=current_site, created_by=admin_user)
+
+        PagePermission.objects.create(page=page, user=normal_guy)
+
+        with self.login_user_context(normal_guy):
+            resp = self.client.get(URL_CMS_PAGE)
+            self.assertEqual(resp.status_code, 200)
+
+    def test_edit_title_is_allowed_for_staff_user(self):
+        """
+        We check here both the permission on a single page, and the global permissions
+        """
+        user = self._create_user('user', is_staff=True)
+        another_user = self._create_user('another_user', is_staff=True)
+
+        page = create_page('A', 'nav_playground.html', 'en')
+        admin_url = reverse("admin:cms_page_edit_title_fields", args=(
+            page.pk, 'en'
+        ))
+        page_admin = PageAdmin(Page, None)
+        page_admin._current_page = page
+
+        username = getattr(user, get_user_model().USERNAME_FIELD)
+        self.client.login(username=username, password=username)
+        response = self.client.get(admin_url)
+        self.assertEqual(response.status_code, 403)
+
+        assign_user_to_page(page, user, grant_all=True)
+        username = getattr(user, get_user_model().USERNAME_FIELD)
+        self.client.login(username=username, password=username)
+        response = self.client.get(admin_url)
+        self.assertEqual(response.status_code, HttpResponse.status_code)
+
+        self._give_cms_permissions(another_user)
+        username = getattr(another_user, get_user_model().USERNAME_FIELD)
+        self.client.login(username=username, password=username)
+        response = self.client.get(admin_url)
+        self.assertEqual(response.status_code, HttpResponse.status_code)
+
+    def test_edit_does_not_reset_apphook(self):
+        """
+        Makes sure that if a non-superuser with no rights to edit advanced page
+        fields edits a page, those advanced fields are not touched.
+        """
+        OLD_PAGE_NAME = 'Test Page'
+        NEW_PAGE_NAME = 'Test page 2'
+        REVERSE_ID = 'Test'
+        APPLICATION_URLS = 'project.sampleapp.urls'
+
+        admin_user, normal_guy = self._get_guys()
+
+        current_site = Site.objects.get(pk=1)
+
+        # The admin creates the page
+        page = create_page(OLD_PAGE_NAME, "nav_playground.html", "en",
+                           site=current_site, created_by=admin_user)
+        page.reverse_id = REVERSE_ID
+        page.save()
+        title = page.get_title_obj()
+        title.has_url_overwrite = True
+
+        title.save()
+        page.application_urls = APPLICATION_URLS
+        page.save()
+        self.assertEqual(page.get_title(), OLD_PAGE_NAME)
+        self.assertEqual(page.reverse_id, REVERSE_ID)
+        self.assertEqual(page.application_urls, APPLICATION_URLS)
+
+        # The user edits the page (change the page name for ex.)
+        page_data = {
+            'title': NEW_PAGE_NAME,
+            'slug': page.get_slug(),
+            'language': title.language,
+            'site': page.site.pk,
+            'template': page.template,
+            'pagepermission_set-TOTAL_FORMS': 0,
+            'pagepermission_set-INITIAL_FORMS': 0,
+            'pagepermission_set-MAX_NUM_FORMS': 0,
+            'pagepermission_set-2-TOTAL_FORMS': 0,
+            'pagepermission_set-2-INITIAL_FORMS': 0,
+            'pagepermission_set-2-MAX_NUM_FORMS': 0,
+        }
+
+        with self.login_user_context(normal_guy):
+            resp = self.client.post(URL_CMS_PAGE_CHANGE % page.pk, page_data,
+                                    follow=True)
+            self.assertEqual(resp.status_code, 200)
+            self.assertTemplateNotUsed(resp, 'admin/login.html')
+            page = Page.objects.get(pk=page.pk)
+            self.assertEqual(page.get_title(), NEW_PAGE_NAME)
+            self.assertEqual(page.reverse_id, REVERSE_ID)
+            self.assertEqual(page.application_urls, APPLICATION_URLS)
+            title = page.get_title_obj()
+            # The admin edits the page (change the page name for ex.)
+            page_data = {
+                'title': OLD_PAGE_NAME,
+                'slug': page.get_slug(),
+                'language': title.language,
+                'site': page.site.pk,
+                'template': page.template,
+                'reverse_id': page.reverse_id,
+            }
+
+        with self.login_user_context(admin_user):
+            resp = self.client.post(URL_CMS_PAGE_ADVANCED_CHANGE % page.pk, page_data,
+                                    follow=True)
+            self.assertEqual(resp.status_code, 200)
+            self.assertTemplateNotUsed(resp, 'admin/login.html')
+            resp = self.client.post(URL_CMS_PAGE_CHANGE % page.pk, page_data,
+                                    follow=True)
+            self.assertEqual(resp.status_code, 200)
+            self.assertTemplateNotUsed(resp, 'admin/login.html')
+            page = Page.objects.get(pk=page.pk)
+
+            self.assertEqual(page.get_title(), OLD_PAGE_NAME)
+            self.assertEqual(page.reverse_id, REVERSE_ID)
+            self.assertEqual(page.application_urls, '')
+
+    def test_edit_does_not_reset_page_adv_fields(self):
+        """
+        Makes sure that if a non-superuser with no rights to edit advanced page
+        fields edits a page, those advanced fields are not touched.
+        """
+        OLD_PAGE_NAME = 'Test Page'
+        NEW_PAGE_NAME = 'Test page 2'
+        REVERSE_ID = 'Test'
+        OVERRIDE_URL = 'my/override/url'
+
+        admin_user, normal_guy = self._get_guys()
+
+        current_site = Site.objects.get(pk=1)
+
+        # The admin creates the page
+        page = create_page(OLD_PAGE_NAME, "nav_playground.html", "en",
+                           site=current_site, created_by=admin_user)
+        page.reverse_id = REVERSE_ID
+        page.save()
+        title = page.get_title_obj()
+        title.has_url_overwrite = True
+        title.path = OVERRIDE_URL
+        title.save()
+
+        self.assertEqual(page.get_title(), OLD_PAGE_NAME)
+        self.assertEqual(page.reverse_id, REVERSE_ID)
+        self.assertEqual(title.overwrite_url, OVERRIDE_URL)
+
+        # The user edits the page (change the page name for ex.)
+        page_data = {
+            'title': NEW_PAGE_NAME,
+            'slug': page.get_slug(),
+            'language': title.language,
+            'site': page.site.pk,
+            'template': page.template,
+            'pagepermission_set-TOTAL_FORMS': 0,
+            'pagepermission_set-INITIAL_FORMS': 0,
+            'pagepermission_set-MAX_NUM_FORMS': 0,
+            'pagepermission_set-2-TOTAL_FORMS': 0,
+            'pagepermission_set-2-INITIAL_FORMS': 0,
+            'pagepermission_set-2-MAX_NUM_FORMS': 0
+        }
+        # required only if user haves can_change_permission
+        with self.login_user_context(normal_guy):
+            resp = self.client.post(URL_CMS_PAGE_CHANGE % page.pk, page_data,
+                                    follow=True)
+            self.assertEqual(resp.status_code, 200)
+            self.assertTemplateNotUsed(resp, 'admin/login.html')
+            page = Page.objects.get(pk=page.pk)
+
+            self.assertEqual(page.get_title(), NEW_PAGE_NAME)
+            self.assertEqual(page.reverse_id, REVERSE_ID)
+            title = page.get_title_obj()
+            self.assertEqual(title.overwrite_url, OVERRIDE_URL)
+
+        # The admin edits the page (change the page name for ex.)
+        page_data = {
+            'title': OLD_PAGE_NAME,
+            'slug': page.get_slug(),
+            'language': title.language,
+            'site': page.site.pk,
+            'template': page.template,
+            'reverse_id': page.reverse_id,
+            'pagepermission_set-TOTAL_FORMS': 0,  # required only if user haves can_change_permission
+            'pagepermission_set-INITIAL_FORMS': 0,
+            'pagepermission_set-MAX_NUM_FORMS': 0,
+            'pagepermission_set-2-TOTAL_FORMS': 0,
+            'pagepermission_set-2-INITIAL_FORMS': 0,
+            'pagepermission_set-2-MAX_NUM_FORMS': 0
+        }
+        with self.login_user_context(admin_user):
+            resp = self.client.post(URL_CMS_PAGE_CHANGE % page.pk, page_data,
+                                    follow=True)
+            self.assertEqual(resp.status_code, 200)
+            self.assertTemplateNotUsed(resp, 'admin/login.html')
+            page = Page.objects.get(pk=page.pk)
+
+            self.assertEqual(page.get_title(), OLD_PAGE_NAME)
+            self.assertEqual(page.reverse_id, REVERSE_ID)
+            title = page.get_title_obj()
+            self.assertEqual(title.overwrite_url, OVERRIDE_URL)
+
+
+@override_settings(CMS_PERMISSION=True)
+class PluginPermissionsOnTest(PageAdminTestBase):
+
+    def test_plugin_add_requires_permissions(self):
+        """User tries to add a plugin but has no permissions. He can add the plugin after he got the permissions"""
+        admin = self._get_admin()
+        self._give_cms_permissions(admin)
+
+        if get_user_model().USERNAME_FIELD == 'email':
+            self.client.login(username='admin@django-cms.org', password='admin')
+        else:
+            self.client.login(username='admin', password='admin')
+
+        url = admin_reverse('cms_page_add_plugin') + '?' + urlencode({
+            'plugin_type': 'TextPlugin',
+            'placeholder_id': self._placeholder.pk,
+            'plugin_language': 'en',
+
+        })
+        response = self.client.post(url, {})
+        self.assertEqual(response.status_code, 403)
+        self._give_permission(admin, Text, 'add')
+        response = self.client.post(url, {})
+        self.assertEqual(response.status_code, 302)
+
+    def test_plugin_edit_requires_permissions(self):
+        """User tries to edit a plugin but has no permissions. He can edit the plugin after he got the permissions"""
+        plugin = self._create_plugin()
+        _, normal_guy = self._get_guys()
+
+        if get_user_model().USERNAME_FIELD == 'email':
+            self.client.login(username='test@test.com', password='test@test.com')
+        else:
+            self.client.login(username='test', password='test')
+
+        url = admin_reverse('cms_page_edit_plugin', args=[plugin.id])
+        response = self.client.post(url, dict())
+        self.assertEqual(response.status_code, 403)
+        # After he got the permissions, he can edit the plugin
+        self._give_permission(normal_guy, Text, 'change')
+        response = self.client.post(url, dict())
+        self.assertEqual(response.status_code, HttpResponse.status_code)
+
+    def test_plugin_remove_requires_permissions(self):
+        """User tries to remove a plugin but has no permissions. He can remove the plugin after he got the permissions"""
+        plugin = self._create_plugin()
+        _, normal_guy = self._get_guys()
+
+        if get_user_model().USERNAME_FIELD == 'email':
+            self.client.login(username='test@test.com', password='test@test.com')
+        else:
+            self.client.login(username='test', password='test')
+
+        url = admin_reverse('cms_page_delete_plugin', args=[plugin.pk])
+        data = dict(plugin_id=plugin.id)
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, 403)
+        # After he got the permissions, he can edit the plugin
+        self._give_permission(normal_guy, Text, 'delete')
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, 302)
+
+    def test_plugin_move_requires_permissions(self):
+        """User tries to move a plugin but has no permissions. He can move the plugin after he got the permissions"""
+        plugin = self._create_plugin()
+        _, normal_guy = self._get_guys()
+
+        if get_user_model().USERNAME_FIELD == 'email':
+            self.client.login(username='test@test.com', password='test@test.com')
+        else:
+            self.client.login(username='test', password='test')
+
+        url = admin_reverse('cms_page_move_plugin')
+        data = dict(plugin_id=plugin.id,
+                    placeholder_id=self._placeholder.pk,
+                    plugin_parent='',
+        )
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, 403)
+        # After he got the permissions, he can edit the plugin
+        self._give_permission(normal_guy, Text, 'change')
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, HttpResponse.status_code)
+
+    def test_plugins_copy_requires_permissions(self):
+        """User tries to copy plugin but has no permissions. He can copy plugins after he got the permissions"""
+        plugin = self._create_plugin()
+        _, normal_guy = self._get_guys()
+
+        if get_user_model().USERNAME_FIELD == 'email':
+            self.client.login(username='test@test.com', password='test@test.com')
+        else:
+            self.client.login(username='test', password='test')
+
+        url = admin_reverse('cms_page_copy_plugins')
+        data = dict(source_plugin_id=plugin.id,
+                    source_placeholder_id=self._placeholder.pk,
+                    source_language='en',
+                    target_language='fr',
+                    target_placeholder_id=self._placeholder.pk,
+        )
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, 403)
+        # After he got the permissions, he can edit the plugin
+        self._give_permission(normal_guy, Text, 'add')
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, HttpResponse.status_code)
+
+    def test_plugins_copy_language(self):
+        """User tries to copy plugin but has no permissions. He can copy plugins after he got the permissions"""
+        self._create_plugin()
+        _, normal_guy = self._get_guys()
+
+        if get_user_model().USERNAME_FIELD != 'email':
+            self.client.login(username='test', password='test')
+        else:
+            self.client.login(username='test@test.com', password='test@test.com')
+
+        self.assertEqual(1, CMSPlugin.objects.all().count())
+        url = admin_reverse('cms_page_copy_language', args=[self._page.pk])
+        data = dict(
+            source_language='en',
+            target_language='fr',
+        )
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, 403)
+        # After he got the permissions, he can edit the plugin
+        self._give_permission(normal_guy, Text, 'add')
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, HttpResponse.status_code)
+        self.assertEqual(2, CMSPlugin.objects.all().count())
+
+    def test_plugin_add_with_permissions_redirects(self):
+        admin_user = self._get_admin()
+        self._give_cms_permissions(admin_user)
+        self._give_permission(admin_user, Text, 'add')
+
+        username = getattr(admin_user, get_user_model().USERNAME_FIELD)
+        self.client.login(username=username, password='admin')
+
+        url = admin_reverse('cms_page_add_plugin') + '?' + urlencode({
+            'plugin_type': 'TextPlugin',
+            'placeholder_id': self._placeholder.pk,
+            'plugin_language': 'en',
+        })
+        response = self.client.post(url, {})
+        self.assertEqual(response.status_code, 302)
+
+
+@override_settings(CMS_PERMISSION=True)
+class PlaceholderPermissionOnTest(PageAdminTestBase):
+    pass
+
+    def test_clear_placeholder_permissions_page(self):
+        """
+        Ensures a user without delete plugin permissions
+        cannot clear a page placeholder that contains said plugin.
+        """
+        page_en = create_page("EmptyPlaceholderTestPage (EN)", "nav_playground.html", "en")
+        ph = page_en.placeholders.get(slot="body")
+
+        # add text plugin
+        add_plugin(ph, "TextPlugin", "en", body="Hello World EN 1")
+        add_plugin(ph, "TextPlugin", "en", body="Hello World EN 2")
+
+        # add a link plugin to make sure we test diversity
+        add_plugin(ph, "LinkPlugin", "en", name='link-1')
+        add_plugin(ph, "LinkPlugin", "en", name='link-2')
+
+        # Staff user has basic page permissions but no
+        # plugin permissions.
+        staff = self._get_staff_user()
+        endpoint = '%s?language=en' % admin_reverse('cms_page_clear_placeholder', args=[ph.pk])
+
+        with self.login_user_context(staff):
+            response = self.client.post(endpoint, {'test': 0})
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(ph.get_plugins('en').count(), 4)
+
+        # Give the staff user permission to delete text plugins
+        staff.user_permissions.add(Permission.objects.get(codename='delete_text'))
+
+        with self.login_user_context(staff):
+            response = self.client.post(endpoint, {'test': 0})
+
+        # Operation results in 403 because staff user does not have
+        # permission to delete links
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(ph.get_plugins('en').count(), 4)
+
+        # Give the staff user permission to delete link plugins
+        staff.user_permissions.add(Permission.objects.get(codename='delete_link'))
+
+        with self.login_user_context(staff):
+            response = self.client.post(endpoint, {'test': 0})
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(ph.get_plugins('en').count(), 0)
+
+
+@override_settings(ROOT_URLCONF='cms.test_utils.project.noadmin_urls')
+class NoAdminPageTests(CMSTestCase):
+
+    def test_get_page_from_request_fakeadmin_nopage(self):
+        noadmin_apps = [app for app in installed_apps() if app != 'django.contrib.admin']
+        with self.settings(INSTALLED_APPS=noadmin_apps):
+            request = self.get_request('/en/admin/')
+            page = get_page_from_request(request)
+            self.assertEqual(page, None)

--- a/cms/tests/test_page_user_admin.py
+++ b/cms/tests/test_page_user_admin.py
@@ -1,0 +1,514 @@
+# -*- coding: utf-8 -*-
+from django.forms.models import model_to_dict
+from django.test.utils import override_settings
+
+from cms.api import create_page
+from cms.models.permissionmodels import PageUser
+from cms.test_utils.testcases import CMSTestCase
+from cms.utils.urlutils import admin_reverse
+
+
+class PermissionsOnTestCase(CMSTestCase):
+
+    def _user_exists(self, username=None):
+        if PageUser.USERNAME_FIELD != "email":
+            username = username or "perms-testuser"
+        else:
+            username = username or "perms-testuser@django-cms.org"
+        query = {PageUser.USERNAME_FIELD: username}
+        return PageUser.objects.filter(**query).exists()
+
+    def get_staff_page_user(self, created_by):
+        user = self._create_user("staff pageuser", is_staff=True, is_superuser=False)
+        data = model_to_dict(user, exclude=['groups', 'user_permissions'])
+        data['user_ptr'] = user
+        data['created_by'] = created_by
+        return PageUser.objects.create(**data)
+
+    def get_user_dummy_data(self, **kwargs):
+        data = {
+            'password1': 'changeme',
+            'password2': 'changeme',
+        }
+
+        if PageUser.USERNAME_FIELD != "email":
+            data[PageUser.USERNAME_FIELD] = "perms-testuser"
+        else:
+            data[PageUser.USERNAME_FIELD] = "perms-testuser@django-cms.org"
+
+        data.update(**kwargs)
+        return data
+
+    def get_user(self, created_by=None):
+        if not created_by:
+            created_by = self.get_superuser()
+
+        data = {'created_by': created_by}
+
+        if PageUser.USERNAME_FIELD != "email":
+            data[PageUser.USERNAME_FIELD] = "perms-testuser"
+        else:
+            data[PageUser.USERNAME_FIELD] = "perms-testuser@django-cms.org"
+
+        user = PageUser(**data)
+        user.set_password('changeme')
+        user.save()
+        return user
+
+    def get_page(self):
+        admin = self.get_superuser()
+        create_page(
+            "home",
+            "nav_playground.html",
+            "en",
+            created_by=admin,
+            published=True,
+        )
+        page = create_page(
+            "permissions",
+            "nav_playground.html",
+            "en",
+            created_by=admin,
+            published=True,
+        )
+        return page
+
+
+@override_settings(CMS_PERMISSION=True)
+class PermissionsOnGlobalTest(PermissionsOnTestCase):
+    """
+    Uses GlobalPermission
+    """
+
+    def test_user_in_admin_index(self):
+        endpoint = admin_reverse('app_list', args=['cms'])
+        staff_user = self.get_staff_user_with_no_permissions()
+
+        self.add_permission(staff_user, 'change_pageuser')
+        self.add_global_permission(staff_user, can_change_permissions=True)
+
+        with self.login_user_context(staff_user):
+            response = self.client.get(endpoint)
+            self.assertEqual(response.status_code, 200)
+            self.assertContains(
+                response,
+                '<a href="/en/admin/cms/pageuser/">Users (page)</a>',
+                html=True,
+            )
+
+        endpoint = self.get_admin_url(PageUser, 'changelist')
+
+        with self.login_user_context(staff_user):
+            response = self.client.get(endpoint)
+            self.assertEqual(response.status_code, 200)
+
+    def test_user_not_in_admin_index(self):
+        staff_user = self.get_staff_user_with_no_permissions()
+        endpoint = admin_reverse('app_list', args=['cms'])
+
+        self.add_permission(staff_user, 'change_pageuser')
+        self.add_global_permission(staff_user, can_change_permissions=False)
+
+        with self.login_user_context(staff_user):
+            response = self.client.get(endpoint)
+            self.assertEqual(response.status_code, 404)
+
+        endpoint = self.get_admin_url(PageUser, 'changelist')
+
+        with self.login_user_context(staff_user):
+            response = self.client.get(endpoint)
+            self.assertEqual(response.status_code, 403)
+
+    def test_user_can_add(self):
+        endpoint = self.get_admin_url(PageUser, 'add')
+        staff_user = self.get_staff_user_with_no_permissions()
+        data = self.get_user_dummy_data()
+        data['_addanother'] = '1'
+
+        self.add_permission(staff_user, 'add_pageuser')
+        self.add_permission(staff_user, 'change_pageuser')
+        self.add_global_permission(staff_user, can_change_permissions=True)
+
+        with self.login_user_context(staff_user):
+            response = self.client.post(endpoint, data)
+            self.assertRedirects(response, endpoint)
+            self.assertTrue(self._user_exists())
+
+    def test_user_cant_add(self):
+        endpoint = self.get_admin_url(PageUser, 'add')
+        staff_user = self.get_staff_user_with_no_permissions()
+        data = self.get_user_dummy_data()
+
+        self.add_permission(staff_user, 'add_pageuser')
+        self.add_permission(staff_user, 'change_pageuser')
+        self.add_global_permission(staff_user, can_change_permissions=False)
+
+        with self.login_user_context(staff_user):
+            response = self.client.post(endpoint, data)
+            self.assertEqual(response.status_code, 403)
+            self.assertFalse(self._user_exists())
+
+    def test_user_can_change(self):
+        user = self.get_user()
+        endpoint = self.get_admin_url(PageUser, 'change', user.pk)
+        staff_user = self.get_staff_user_with_no_permissions()
+        data = model_to_dict(user, exclude=['date_joined'])
+        data['_continue'] = '1'
+        data['date_joined_0'] = '2016-06-21'
+        data['date_joined_1'] = '15:00:00'
+
+        self.add_permission(staff_user, 'change_pageuser')
+        self.add_global_permission(staff_user, can_change_permissions=True)
+
+        if user.USERNAME_FIELD != "email":
+            username = "perms-testuser2"
+        else:
+            username = "perms-testuser+2@django-cms.org"
+
+        data[user.USERNAME_FIELD] = username
+
+        with self.login_user_context(staff_user):
+            response = self.client.post(endpoint, data)
+            self.assertRedirects(response, endpoint)
+            self.assertTrue(self._user_exists(username))
+
+    def test_user_cant_change(self):
+        user = self.get_user()
+        endpoint = self.get_admin_url(PageUser, 'change', user.pk)
+        staff_user = self.get_staff_user_with_no_permissions()
+        data = model_to_dict(user, exclude=['date_joined'])
+        data['_continue'] = '1'
+        data['date_joined_0'] = '2016-06-21'
+        data['date_joined_1'] = '15:00:00'
+
+        self.add_permission(staff_user, 'change_pageuser')
+        self.add_global_permission(staff_user, can_change_permissions=False)
+
+        if user.USERNAME_FIELD != "email":
+            username = "perms-testuser2"
+        else:
+            username = "perms-testuser+2@django-cms.org"
+
+        data[user.USERNAME_FIELD] = username
+
+        with self.login_user_context(staff_user):
+            response = self.client.post(endpoint, data)
+            self.assertEqual(response.status_code, 403)
+            self.assertFalse(self._user_exists(username))
+
+    def test_user_can_delete(self):
+        user = self.get_user()
+        endpoint = self.get_admin_url(PageUser, 'delete', user.pk)
+        redirect_to = admin_reverse('index')
+        staff_user = self.get_staff_user_with_no_permissions()
+        data = {'post': 'yes'}
+
+        self.add_permission(staff_user, 'delete_user')
+        self.add_permission(staff_user, 'delete_pageuser')
+        self.add_global_permission(staff_user, can_change_permissions=True)
+
+        with self.login_user_context(staff_user):
+            response = self.client.post(endpoint, data)
+            self.assertRedirects(response, redirect_to)
+            self.assertFalse(self._user_exists())
+
+    def test_user_cant_delete(self):
+        user = self.get_user()
+        endpoint = self.get_admin_url(PageUser, 'delete', user.pk)
+        staff_user = self.get_staff_user_with_no_permissions()
+        data = {'post': 'yes'}
+
+        self.add_permission(staff_user, 'delete_user')
+        self.add_permission(staff_user, 'delete_pageuser')
+        self.add_global_permission(staff_user, can_change_permissions=False)
+
+        with self.login_user_context(staff_user):
+            response = self.client.post(endpoint, data)
+            self.assertEqual(response.status_code, 403)
+            self.assertTrue(self._user_exists())
+
+
+@override_settings(CMS_PERMISSION=True)
+class PermissionsOnPageTest(PermissionsOnTestCase):
+    """
+    Uses PagePermission
+    """
+
+    def setUp(self):
+        self._permissions_page = self.get_page()
+
+    def test_user_in_admin_index(self):
+        endpoint = admin_reverse('app_list', args=['cms'])
+        staff_user = self.get_staff_user_with_no_permissions()
+
+        self.add_permission(staff_user, 'change_pageuser')
+        self.add_page_permission(
+            staff_user,
+            self._permissions_page,
+            can_change_permissions=True,
+        )
+
+        with self.login_user_context(staff_user):
+            response = self.client.get(endpoint)
+            self.assertEqual(response.status_code, 200)
+            self.assertContains(
+                response,
+                '<a href="/en/admin/cms/pageuser/">Users (page)</a>',
+                html=True,
+            )
+
+        endpoint = self.get_admin_url(PageUser, 'changelist')
+
+        with self.login_user_context(staff_user):
+            response = self.client.get(endpoint)
+            self.assertEqual(response.status_code, 200)
+
+    def test_user_not_in_admin_index(self):
+        staff_user = self.get_staff_user_with_no_permissions()
+        endpoint = admin_reverse('app_list', args=['cms'])
+
+        self.add_permission(staff_user, 'change_pageuser')
+        self.add_page_permission(
+            staff_user,
+            self._permissions_page,
+            can_change_permissions=False,
+        )
+
+        with self.login_user_context(staff_user):
+            response = self.client.get(endpoint)
+            self.assertEqual(response.status_code, 200)
+            self.assertNotContains(
+                response,
+                '<a href="/en/admin/cms/pageuser/">Users (page)</a>',
+                html=True,
+            )
+
+        endpoint = self.get_admin_url(PageUser, 'changelist')
+
+        with self.login_user_context(staff_user):
+            response = self.client.get(endpoint)
+            self.assertEqual(response.status_code, 403)
+
+    def test_user_can_add(self):
+        endpoint = self.get_admin_url(PageUser, 'add')
+        staff_user = self.get_staff_user_with_no_permissions()
+        data = self.get_user_dummy_data()
+        data['_addanother'] = '1'
+
+        self.add_permission(staff_user, 'add_pageuser')
+        self.add_permission(staff_user, 'change_pageuser')
+        self.add_page_permission(
+            staff_user,
+            self._permissions_page,
+            can_change_permissions=True,
+        )
+
+        with self.login_user_context(staff_user):
+            response = self.client.post(endpoint, data)
+            self.assertRedirects(response, endpoint)
+            self.assertTrue(self._user_exists())
+
+    def test_user_cant_add(self):
+        endpoint = self.get_admin_url(PageUser, 'add')
+        staff_user = self.get_staff_user_with_no_permissions()
+        data = self.get_user_dummy_data()
+
+        self.add_permission(staff_user, 'add_pageuser')
+        self.add_permission(staff_user, 'change_pageuser')
+        self.add_page_permission(
+            staff_user,
+            self._permissions_page,
+            can_change_permissions=False,
+        )
+
+        with self.login_user_context(staff_user):
+            response = self.client.post(endpoint, data)
+            self.assertEqual(response.status_code, 403)
+            self.assertFalse(self._user_exists())
+
+    def test_user_can_change_subordinate(self):
+        staff_user = self.get_staff_user_with_no_permissions()
+        user = self.get_user(created_by=staff_user)
+        endpoint = self.get_admin_url(PageUser, 'change', user.pk)
+        data = model_to_dict(user, exclude=['date_joined'])
+        data['_continue'] = '1'
+        data['date_joined_0'] = '2016-06-21'
+        data['date_joined_1'] = '15:00:00'
+
+        self.add_permission(staff_user, 'change_pageuser')
+        self.add_global_permission(staff_user, can_change_permissions=True)
+
+        if user.USERNAME_FIELD != "email":
+            username = "perms-testuser2"
+        else:
+            username = "perms-testuser+2@django-cms.org"
+
+        data[user.USERNAME_FIELD] = username
+
+        with self.login_user_context(staff_user):
+            response = self.client.post(endpoint, data)
+            self.assertRedirects(response, endpoint)
+            self.assertTrue(self._user_exists(username))
+
+    def test_user_cant_change_subordinate(self):
+        staff_user = self.get_staff_user_with_no_permissions()
+        user = self.get_user(created_by=staff_user)
+        endpoint = self.get_admin_url(PageUser, 'change', user.pk)
+        data = model_to_dict(user, exclude=['date_joined'])
+        data['_continue'] = '1'
+        data['date_joined_0'] = '2016-06-21'
+        data['date_joined_1'] = '15:00:00'
+
+        self.add_permission(staff_user, 'change_pageuser')
+        self.add_global_permission(staff_user, can_change_permissions=False)
+
+        if user.USERNAME_FIELD != "email":
+            username = "perms-testuser2"
+        else:
+            username = "perms-testuser+2@django-cms.org"
+
+        data[user.USERNAME_FIELD] = username
+
+        with self.login_user_context(staff_user):
+            response = self.client.post(endpoint, data)
+            self.assertEqual(response.status_code, 403)
+            self.assertFalse(self._user_exists(username))
+
+    def test_user_cant_change_self(self):
+        staff_user = self.get_staff_user_with_no_permissions()
+        endpoint = self.get_admin_url(PageUser, 'change', staff_user.pk)
+
+        data = model_to_dict(staff_user, exclude=['date_joined'])
+        data['_continue'] = '1'
+        data['date_joined_0'] = '2016-06-21'
+        data['date_joined_1'] = '15:00:00'
+
+        self.add_permission(staff_user, 'change_pageuser')
+        self.add_global_permission(staff_user, can_change_permissions=True)
+
+        if staff_user.USERNAME_FIELD != "email":
+            username = "perms-testuser2"
+        else:
+            username = "perms-testuser+2@django-cms.org"
+
+        data[staff_user.USERNAME_FIELD] = username
+
+        with self.login_user_context(staff_user):
+            response = self.client.post(endpoint, data)
+            self.assertEqual(response.status_code, 404)
+            self.assertFalse(self._user_exists(username))
+
+    def test_user_cant_change_superior(self):
+        staff_user = self.get_staff_user_with_no_permissions()
+        superior = self.get_superuser()
+        endpoint = self.get_admin_url(PageUser, 'change', superior.pk)
+
+        data = model_to_dict(superior, exclude=['date_joined'])
+        data['_continue'] = '1'
+        data['date_joined_0'] = '2016-06-21'
+        data['date_joined_1'] = '15:00:00'
+
+        self.add_permission(staff_user, 'change_pageuser')
+        self.add_global_permission(staff_user, can_change_permissions=True)
+
+        if superior.USERNAME_FIELD != "email":
+            username = "perms-testuser2"
+        else:
+            username = "perms-testuser+2@django-cms.org"
+
+        data[superior.USERNAME_FIELD] = username
+
+        with self.login_user_context(staff_user):
+            response = self.client.post(endpoint, data)
+            self.assertEqual(response.status_code, 404)
+            self.assertFalse(self._user_exists(username))
+
+    def test_user_can_delete_subordinate(self):
+        staff_user = self.get_staff_user_with_no_permissions()
+        user = self.get_user(created_by=staff_user)
+        endpoint = self.get_admin_url(PageUser, 'delete', user.pk)
+        redirect_to = admin_reverse('index')
+        data = {'post': 'yes'}
+
+        self.add_permission(staff_user, 'delete_user')
+        self.add_permission(staff_user, 'delete_pageuser')
+        self.add_page_permission(
+            staff_user,
+            self._permissions_page,
+            can_change_permissions=True,
+        )
+
+        with self.login_user_context(staff_user):
+            response = self.client.post(endpoint, data)
+            self.assertRedirects(response, redirect_to)
+            self.assertFalse(self._user_exists())
+
+    def test_user_cant_delete_subordinate(self):
+        staff_user = self.get_staff_user_with_no_permissions()
+        user = self.get_user(created_by=staff_user)
+        endpoint = self.get_admin_url(PageUser, 'delete', user.pk)
+        data = {'post': 'yes'}
+
+        self.add_permission(staff_user, 'delete_user')
+        self.add_permission(staff_user, 'delete_pageuser')
+        self.add_page_permission(
+            staff_user,
+            self._permissions_page,
+            can_change_permissions=False,
+        )
+
+        with self.login_user_context(staff_user):
+            response = self.client.post(endpoint, data)
+            self.assertEqual(response.status_code, 403)
+            self.assertTrue(self._user_exists())
+
+    def test_user_cant_delete_self(self):
+        admin = self.get_superuser()
+        staff_user = self.get_staff_page_user(created_by=admin)
+        endpoint = self.get_admin_url(PageUser, 'delete', staff_user.pk)
+        data = {'post': 'yes'}
+
+        self.add_permission(staff_user, 'delete_user')
+        self.add_permission(staff_user, 'delete_pageuser')
+        self.add_page_permission(
+            staff_user,
+            self._permissions_page,
+            can_change_permissions=True,
+        )
+
+        with self.login_user_context(staff_user):
+            username = getattr(staff_user, staff_user.USERNAME_FIELD)
+            response = self.client.post(endpoint, data)
+            # The response is a 404 instead of a 403
+            # because the queryset is limited to objects
+            # that the user has permissions for.
+            # This queryset is used to fetch the object
+            # from the request, resulting in a 404.
+            self.assertEqual(response.status_code, 404)
+            self.assertTrue(self._user_exists(username))
+
+    def test_user_cant_delete_superior(self):
+        admin = self.get_superuser()
+        superior = self.get_staff_page_user(created_by=admin)
+        endpoint = self.get_admin_url(PageUser, 'delete', superior.pk)
+        staff_user = self.get_staff_user_with_no_permissions()
+        data = {'post': 'yes'}
+
+        self.add_permission(staff_user, 'delete_user')
+        self.add_permission(staff_user, 'delete_pageuser')
+        self.add_page_permission(
+            staff_user,
+            self._permissions_page,
+            can_change_permissions=True,
+        )
+
+        with self.login_user_context(staff_user):
+            username = getattr(superior, superior.USERNAME_FIELD)
+            response = self.client.post(endpoint, data)
+            # The response is a 404 instead of a 403
+            # because the queryset is limited to objects
+            # that the user has permissions for.
+            # This queryset is used to fetch the object
+            # from the request, resulting in a 404.
+            self.assertEqual(response.status_code, 404)
+            self.assertTrue(self._user_exists(username))

--- a/cms/tests/test_page_user_admin.py
+++ b/cms/tests/test_page_user_admin.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from django.contrib.auth import get_permission_codename, get_user_model
 from django.forms.models import model_to_dict
 from django.test.utils import override_settings
 
@@ -30,6 +31,9 @@ class PermissionsOnTestCase(CMSTestCase):
 
         data.update(**kwargs)
         return data
+
+    def _get_delete_perm(self):
+        return get_permission_codename('delete', get_user_model()._meta)
 
 
 @override_settings(CMS_PERMISSION=True)
@@ -165,7 +169,7 @@ class PermissionsOnGlobalTest(PermissionsOnTestCase):
         staff_user = self.get_staff_user_with_no_permissions()
         data = {'post': 'yes'}
 
-        self.add_permission(staff_user, 'delete_user')
+        self.add_permission(staff_user, self._get_delete_perm())
         self.add_permission(staff_user, 'delete_pageuser')
         self.add_global_permission(staff_user, can_change_permissions=True)
 
@@ -180,7 +184,7 @@ class PermissionsOnGlobalTest(PermissionsOnTestCase):
         staff_user = self.get_staff_user_with_no_permissions()
         data = {'post': 'yes'}
 
-        self.add_permission(staff_user, 'delete_user')
+        self.add_permission(staff_user, self._get_delete_perm())
         self.add_permission(staff_user, 'delete_pageuser')
         self.add_global_permission(staff_user, can_change_permissions=False)
 
@@ -443,7 +447,7 @@ class PermissionsOnPageTest(PermissionsOnTestCase):
         redirect_to = admin_reverse('index')
         data = {'post': 'yes'}
 
-        self.add_permission(staff_user, 'delete_user')
+        self.add_permission(staff_user, self._get_delete_perm())
         self.add_permission(staff_user, 'delete_pageuser')
         self.add_page_permission(
             staff_user,
@@ -466,7 +470,7 @@ class PermissionsOnPageTest(PermissionsOnTestCase):
         endpoint = self.get_admin_url(PageUser, 'delete', subordinate.pk)
         data = {'post': 'yes'}
 
-        self.add_permission(staff_user, 'delete_user')
+        self.add_permission(staff_user, self._get_delete_perm())
         self.add_permission(staff_user, 'delete_pageuser')
         self.add_page_permission(
             staff_user,
@@ -489,7 +493,7 @@ class PermissionsOnPageTest(PermissionsOnTestCase):
         endpoint = self.get_admin_url(PageUser, 'delete', staff_user.pk)
         data = {'post': 'yes'}
 
-        self.add_permission(staff_user, 'delete_user')
+        self.add_permission(staff_user, self._get_delete_perm())
         self.add_permission(staff_user, 'delete_pageuser')
         self.add_page_permission(
             staff_user,
@@ -520,7 +524,7 @@ class PermissionsOnPageTest(PermissionsOnTestCase):
 
         data = {'post': 'yes'}
 
-        self.add_permission(staff_user, 'delete_user')
+        self.add_permission(staff_user, self._get_delete_perm())
         self.add_permission(staff_user, 'delete_pageuser')
         self.add_page_permission(
             staff_user,

--- a/cms/tests/test_page_user_admin.py
+++ b/cms/tests/test_page_user_admin.py
@@ -17,22 +17,7 @@ class PermissionsOnTestCase(CMSTestCase):
         query = {PageUser.USERNAME_FIELD: username}
         return PageUser.objects.filter(**query).exists()
 
-    def get_staff_page_user(self, created_by=None):
-        if not created_by:
-            created_by = self.get_superuser()
-
-        if PageUser.USERNAME_FIELD != "email":
-            username = "perms-testuser"
-        else:
-            username = "perms-testuser@django-cms.org"
-
-        user = self._create_user(username, is_staff=True, is_superuser=False)
-        data = model_to_dict(user, exclude=['groups', 'user_permissions'])
-        data['user_ptr'] = user
-        data['created_by'] = created_by
-        return PageUser.objects.create(**data)
-
-    def get_user_dummy_data(self, **kwargs):
+    def _get_user_data(self, **kwargs):
         data = {
             'password1': 'changeme',
             'password2': 'changeme',
@@ -50,7 +35,9 @@ class PermissionsOnTestCase(CMSTestCase):
 @override_settings(CMS_PERMISSION=True)
 class PermissionsOnGlobalTest(PermissionsOnTestCase):
     """
-    Uses GlobalPermission
+    Tests all user interactions with the page user admin
+    while permissions are set to True and user has
+    global permissions.
     """
 
     def test_user_in_admin_index(self):
@@ -95,7 +82,7 @@ class PermissionsOnGlobalTest(PermissionsOnTestCase):
     def test_user_can_add_user(self):
         endpoint = self.get_admin_url(PageUser, 'add')
         staff_user = self.get_staff_user_with_no_permissions()
-        data = self.get_user_dummy_data()
+        data = self._get_user_data()
         data['_addanother'] = '1'
 
         self.add_permission(staff_user, 'add_pageuser')
@@ -110,7 +97,7 @@ class PermissionsOnGlobalTest(PermissionsOnTestCase):
     def test_user_cant_add_user(self):
         endpoint = self.get_admin_url(PageUser, 'add')
         staff_user = self.get_staff_user_with_no_permissions()
-        data = self.get_user_dummy_data()
+        data = self._get_user_data()
 
         self.add_permission(staff_user, 'add_pageuser')
         self.add_permission(staff_user, 'change_pageuser')
@@ -206,7 +193,9 @@ class PermissionsOnGlobalTest(PermissionsOnTestCase):
 @override_settings(CMS_PERMISSION=True)
 class PermissionsOnPageTest(PermissionsOnTestCase):
     """
-    Uses PagePermission
+    Tests all user interactions with the page user admin
+    while permissions are set to True and user has
+    page permissions.
     """
 
     def setUp(self):
@@ -242,6 +231,7 @@ class PermissionsOnPageTest(PermissionsOnTestCase):
         staff_user = self.get_staff_user_with_no_permissions()
         endpoint = admin_reverse('app_list', args=['cms'])
 
+        self.add_permission(staff_user, 'change_page')
         self.add_permission(staff_user, 'change_pageuser')
         self.add_page_permission(
             staff_user,
@@ -271,7 +261,7 @@ class PermissionsOnPageTest(PermissionsOnTestCase):
         """
         endpoint = self.get_admin_url(PageUser, 'add')
         staff_user = self.get_staff_user_with_no_permissions()
-        data = self.get_user_dummy_data()
+        data = self._get_user_data()
         data['_addanother'] = '1'
 
         self.add_permission(staff_user, 'add_pageuser')
@@ -294,7 +284,7 @@ class PermissionsOnPageTest(PermissionsOnTestCase):
         """
         endpoint = self.get_admin_url(PageUser, 'add')
         staff_user = self.get_staff_user_with_no_permissions()
-        data = self.get_user_dummy_data()
+        data = self._get_user_data()
 
         self.add_permission(staff_user, 'add_pageuser')
         self.add_permission(staff_user, 'change_pageuser')

--- a/cms/tests/test_page_user_group_admin.py
+++ b/cms/tests/test_page_user_group_admin.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from django.forms.models import model_to_dict
 from django.test.utils import override_settings
 
 from cms.models.permissionmodels import PageUserGroup
@@ -6,8 +7,12 @@ from cms.test_utils.testcases import CMSTestCase
 from cms.utils.urlutils import admin_reverse
 
 
-@override_settings(CMS_PERMISSION=True)
-class PageUserGroupPermissionsOnTest(CMSTestCase):
+class PermissionsOnTestCase(CMSTestCase):
+
+    def _group_exists(self, name=None):
+        if not name:
+            name = 'Test group'
+        return PageUserGroup.objects.filter(name=name).exists()
 
     def get_group_dummy_data(self, **kwargs):
         data = {
@@ -19,12 +24,19 @@ class PageUserGroupPermissionsOnTest(CMSTestCase):
         data.update(**kwargs)
         return data
 
-    def get_group(self):
+    def get_group(self, created_by=None):
+        if not created_by:
+            created_by = self.get_superuser()
+
         data = {
             'name': 'Test group',
-            'created_by': self.get_superuser(),
+            'created_by': created_by,
         }
         return PageUserGroup.objects.create(**data)
+
+
+@override_settings(CMS_PERMISSION=True)
+class PermissionsOnGlobalTest(PermissionsOnTestCase):
 
     def test_group_in_admin_index(self):
         endpoint = admin_reverse('app_list', args=['cms'])
@@ -65,7 +77,7 @@ class PageUserGroupPermissionsOnTest(CMSTestCase):
             response = self.client.get(endpoint)
             self.assertEqual(response.status_code, 403)
 
-    def test_group_can_add(self):
+    def test_user_can_add_group(self):
         endpoint = self.get_admin_url(PageUserGroup, 'add')
         redirect_to = admin_reverse('index')
         staff_user = self.get_staff_user_with_no_permissions()
@@ -77,9 +89,9 @@ class PageUserGroupPermissionsOnTest(CMSTestCase):
         with self.login_user_context(staff_user):
             response = self.client.post(endpoint, data)
             self.assertRedirects(response, redirect_to)
-            self.assertTrue(PageUserGroup.objects.filter(name='Test group').exists())
+            self.assertTrue(self._group_exists())
 
-    def test_group_cant_add(self):
+    def test_user_cant_add_group(self):
         endpoint = self.get_admin_url(PageUserGroup, 'add')
         staff_user = self.get_staff_user_with_no_permissions()
         data = self.get_group_dummy_data()
@@ -90,9 +102,9 @@ class PageUserGroupPermissionsOnTest(CMSTestCase):
         with self.login_user_context(staff_user):
             response = self.client.post(endpoint, data)
             self.assertEqual(response.status_code, 403)
-            self.assertFalse(PageUserGroup.objects.filter(name='Test group').exists())
+            self.assertFalse(self._group_exists())
 
-    def test_group_can_change(self):
+    def test_user_can_change_group(self):
         group = self.get_group()
         endpoint = self.get_admin_url(PageUserGroup, 'change', group.pk)
         redirect_to = self.get_admin_url(PageUserGroup, 'changelist')
@@ -105,9 +117,9 @@ class PageUserGroupPermissionsOnTest(CMSTestCase):
         with self.login_user_context(staff_user):
             response = self.client.post(endpoint, data)
             self.assertRedirects(response, redirect_to)
-            self.assertTrue(PageUserGroup.objects.filter(name='New test group').exists())
+            self.assertTrue(self._group_exists('New test group'))
 
-    def test_group_cant_change(self):
+    def test_user_cant_change_group(self):
         group = self.get_group()
         endpoint = self.get_admin_url(PageUserGroup, 'change', group.pk)
         staff_user = self.get_staff_user_with_no_permissions()
@@ -119,9 +131,9 @@ class PageUserGroupPermissionsOnTest(CMSTestCase):
         with self.login_user_context(staff_user):
             response = self.client.post(endpoint, data)
             self.assertEqual(response.status_code, 403)
-            self.assertTrue(PageUserGroup.objects.filter(name='Test group').exists())
+            self.assertTrue(self._group_exists())
 
-    def test_group_can_delete(self):
+    def test_user_can_delete_group(self):
         group = self.get_group()
         endpoint = self.get_admin_url(PageUserGroup, 'delete', group.pk)
         redirect_to = admin_reverse('index')
@@ -135,9 +147,9 @@ class PageUserGroupPermissionsOnTest(CMSTestCase):
         with self.login_user_context(staff_user):
             response = self.client.post(endpoint, data)
             self.assertRedirects(response, redirect_to)
-            self.assertFalse(PageUserGroup.objects.filter(name='Test group').exists())
+            self.assertFalse(self._group_exists())
 
-    def test_group_cant_delete(self):
+    def test_user_cant_delete_group(self):
         group = self.get_group()
         endpoint = self.get_admin_url(PageUserGroup, 'delete', group.pk)
         staff_user = self.get_staff_user_with_no_permissions()
@@ -150,4 +162,315 @@ class PageUserGroupPermissionsOnTest(CMSTestCase):
         with self.login_user_context(staff_user):
             response = self.client.post(endpoint, data)
             self.assertEqual(response.status_code, 403)
-            self.assertTrue(PageUserGroup.objects.filter(name='Test group').exists())
+            self.assertTrue(self._group_exists())
+
+
+@override_settings(CMS_PERMISSION=True)
+class PermissionsOnPageTest(PermissionsOnTestCase):
+    """
+    Uses PagePermission
+    """
+
+    def setUp(self):
+        self._permissions_page = self.get_permissions_test_page()
+
+    def test_group_in_admin_index(self):
+        endpoint = admin_reverse('app_list', args=['cms'])
+        staff_user = self.get_staff_user_with_no_permissions()
+
+        self.add_permission(staff_user, 'change_pageusergroup')
+        self.add_page_permission(
+            staff_user,
+            self._permissions_page,
+            can_change_permissions=True,
+        )
+
+        with self.login_user_context(staff_user):
+            response = self.client.get(endpoint)
+            self.assertEqual(response.status_code, 200)
+            self.assertContains(
+                response,
+                '<a href="/en/admin/cms/pageusergroup/">User groups (page)</a>',
+                html=True,
+            )
+
+        endpoint = self.get_admin_url(PageUserGroup, 'changelist')
+
+        with self.login_user_context(staff_user):
+            response = self.client.get(endpoint)
+            self.assertEqual(response.status_code, 200)
+
+    def test_group_not_in_admin_index(self):
+        endpoint = admin_reverse('app_list', args=['cms'])
+        staff_user = self.get_staff_user_with_no_permissions()
+
+        self.add_permission(staff_user, 'change_pageusergroup')
+        self.add_page_permission(
+            staff_user,
+            self._permissions_page,
+            can_change_permissions=False,
+        )
+
+        with self.login_user_context(staff_user):
+            response = self.client.get(endpoint)
+            self.assertEqual(response.status_code, 200)
+            self.assertNotContains(
+                response,
+                '<a href="/en/admin/cms/pageusergroup/">User groups (page)</a>',
+                html=True,
+            )
+
+        endpoint = self.get_admin_url(PageUserGroup, 'changelist')
+
+        with self.login_user_context(staff_user):
+            response = self.client.get(endpoint)
+            self.assertEqual(response.status_code, 403)
+
+    def test_user_can_add_group(self):
+        """
+        User can add new groups if can_change_permissions
+        is set to True.
+        """
+        endpoint = self.get_admin_url(PageUserGroup, 'add')
+        redirect_to = admin_reverse('index')
+        staff_user = self.get_staff_user_with_no_permissions()
+        data = self.get_group_dummy_data()
+
+        self.add_permission(staff_user, 'add_pageusergroup')
+        self.add_page_permission(
+            staff_user,
+            self._permissions_page,
+            can_change_permissions=True,
+        )
+
+        with self.login_user_context(staff_user):
+            response = self.client.post(endpoint, data)
+            self.assertRedirects(response, redirect_to)
+            self.assertTrue(self._group_exists())
+
+    def test_user_cant_add_group(self):
+        """
+        User can't add new groups if can_change_permissions
+        is set to False.
+        """
+        endpoint = self.get_admin_url(PageUserGroup, 'add')
+        staff_user = self.get_staff_user_with_no_permissions()
+        data = self.get_group_dummy_data()
+
+        self.add_permission(staff_user, 'add_pageusergroup')
+        self.add_page_permission(
+            staff_user,
+            self._permissions_page,
+            can_change_permissions=False,
+        )
+
+        with self.login_user_context(staff_user):
+            response = self.client.post(endpoint, data)
+            self.assertEqual(response.status_code, 403)
+            self.assertFalse(self._group_exists())
+
+    def test_user_can_change_subordinate_group(self):
+        """
+        User can change groups he created if can_change_permissions
+        is set to True.
+        """
+        staff_user = self.get_staff_user_with_no_permissions()
+        group = self.get_group(created_by=staff_user)
+        endpoint = self.get_admin_url(PageUserGroup, 'change', group.pk)
+        data = model_to_dict(group)
+        data['_continue'] = '1'
+        data['name'] = 'New test group'
+
+        self.add_permission(staff_user, 'change_pageusergroup')
+        self.add_page_permission(
+            staff_user,
+            self._permissions_page,
+            can_change_permissions=True,
+        )
+
+        with self.login_user_context(staff_user):
+            response = self.client.post(endpoint, data)
+            self.assertRedirects(response, endpoint)
+            self.assertTrue(self._group_exists('New test group'))
+
+    def test_user_cant_change_subordinate_group(self):
+        """
+        User cant change groups he created if can_change_permissions
+        is set to False.
+        """
+        staff_user = self.get_staff_user_with_no_permissions()
+        group = self.get_group(created_by=staff_user)
+        endpoint = self.get_admin_url(PageUserGroup, 'change', group.pk)
+
+        data = model_to_dict(group)
+        data['_continue'] = '1'
+        data['name'] = 'New test group'
+
+        self.add_permission(staff_user, 'change_pageusergroup')
+        self.add_page_permission(
+            staff_user,
+            self._permissions_page,
+            can_change_permissions=False,
+        )
+
+        with self.login_user_context(staff_user):
+            response = self.client.post(endpoint, data)
+            self.assertEqual(response.status_code, 403)
+            self.assertFalse(self._group_exists('New test group'))
+
+    def test_user_cant_change_own_group(self):
+        """
+        User cant change a group he's a part of,
+        even with can_change_permissions set to True.
+        """
+        group = self.get_group()
+        staff_user = self.get_staff_user_with_no_permissions()
+        staff_user.groups.add(group)
+        endpoint = self.get_admin_url(PageUserGroup, 'change', group.pk)
+
+        data = model_to_dict(group)
+        data['_continue'] = '1'
+        data['name'] = 'New test group'
+
+        self.add_permission(staff_user, 'change_pageusergroup')
+        self.add_page_permission(
+            staff_user,
+            self._permissions_page,
+            can_change_permissions=True,
+        )
+
+        with self.login_user_context(staff_user):
+            response = self.client.post(endpoint, data)
+            self.assertEqual(response.status_code, 404)
+            self.assertFalse(self._group_exists('New test group'))
+
+    def test_user_cant_change_others_group(self):
+        """
+        User cant change a group created by another user,
+        even with can_change_permissions set to True.
+        """
+        admin = self.get_superuser()
+        group = self.get_group(created_by=admin)
+        staff_user = self.get_staff_user_with_no_permissions()
+        endpoint = self.get_admin_url(PageUserGroup, 'change', group.pk)
+
+        data = model_to_dict(group)
+        data['_continue'] = '1'
+        data['name'] = 'New test group'
+
+        self.add_permission(staff_user, 'change_pageusergroup')
+        self.add_page_permission(
+            staff_user,
+            self._permissions_page,
+            can_change_permissions=True,
+        )
+
+        with self.login_user_context(staff_user):
+            response = self.client.post(endpoint, data)
+            self.assertEqual(response.status_code, 404)
+            self.assertFalse(self._group_exists('New test group'))
+
+    def test_user_can_delete_subordinate_group(self):
+        """
+        User can delete groups he created if can_change_permissions
+        is set to True.
+        """
+        staff_user = self.get_staff_user_with_no_permissions()
+        group = self.get_group(created_by=staff_user)
+        endpoint = self.get_admin_url(PageUserGroup, 'delete', group.pk)
+        redirect_to = admin_reverse('index')
+        data = {'post': 'yes'}
+
+        self.add_permission(staff_user, 'delete_group')
+        self.add_permission(staff_user, 'delete_pageusergroup')
+        self.add_page_permission(
+            staff_user,
+            self._permissions_page,
+            can_change_permissions=True,
+        )
+
+        with self.login_user_context(staff_user):
+            response = self.client.post(endpoint, data)
+            self.assertRedirects(response, redirect_to)
+            self.assertFalse(self._group_exists())
+
+    def test_user_cant_delete_subordinate_group(self):
+        """
+        User cant delete groups he created if can_change_permissions
+        is set to False.
+        """
+        staff_user = self.get_staff_user_with_no_permissions()
+        group = self.get_group(created_by=staff_user)
+        endpoint = self.get_admin_url(PageUserGroup, 'delete', group.pk)
+        data = {'post': 'yes'}
+
+        self.add_permission(staff_user, 'delete_group')
+        self.add_permission(staff_user, 'delete_pageusergroup')
+        self.add_page_permission(
+            staff_user,
+            self._permissions_page,
+            can_change_permissions=False,
+        )
+
+        with self.login_user_context(staff_user):
+            response = self.client.post(endpoint, data)
+            self.assertEqual(response.status_code, 403)
+            self.assertTrue(self._group_exists())
+
+    def test_user_cant_delete_own_group(self):
+        """
+        User cant delete a group he's a part of,
+        even with can_change_permissions set to True.
+        """
+        group = self.get_group()
+        staff_user = self.get_staff_user_with_no_permissions()
+        staff_user.groups.add(group)
+        endpoint = self.get_admin_url(PageUserGroup, 'delete', group.pk)
+        data = {'post': 'yes'}
+
+        self.add_permission(staff_user, 'delete_group')
+        self.add_permission(staff_user, 'delete_pageusergroup')
+        self.add_page_permission(
+            staff_user,
+            self._permissions_page,
+            can_change_permissions=True,
+        )
+
+        with self.login_user_context(staff_user):
+            response = self.client.post(endpoint, data)
+            # The response is a 404 instead of a 403
+            # because the queryset is limited to objects
+            # that the user has permissions for.
+            # This queryset is used to fetch the object
+            # from the request, resulting in a 404.
+            self.assertEqual(response.status_code, 404)
+            self.assertTrue(self._group_exists())
+
+    def test_user_cant_delete_others_group(self):
+        """
+        User cant delete a group created by another user,
+        even with can_change_permissions set to True.
+        """
+        admin = self.get_superuser()
+        group = self.get_group(created_by=admin)
+        staff_user = self.get_staff_user_with_no_permissions()
+        endpoint = self.get_admin_url(PageUserGroup, 'delete', group.pk)
+        data = {'post': 'yes'}
+
+        self.add_permission(staff_user, 'delete_group')
+        self.add_permission(staff_user, 'delete_pageusergroup')
+        self.add_page_permission(
+            staff_user,
+            self._permissions_page,
+            can_change_permissions=True,
+        )
+
+        with self.login_user_context(staff_user):
+            response = self.client.post(endpoint, data)
+            # The response is a 404 instead of a 403
+            # because the queryset is limited to objects
+            # that the user has permissions for.
+            # This queryset is used to fetch the object
+            # from the request, resulting in a 404.
+            self.assertEqual(response.status_code, 404)
+            self.assertTrue(self._group_exists())

--- a/cms/tests/test_page_user_group_admin.py
+++ b/cms/tests/test_page_user_group_admin.py
@@ -14,7 +14,7 @@ class PermissionsOnTestCase(CMSTestCase):
             name = 'Test group'
         return PageUserGroup.objects.filter(name=name).exists()
 
-    def get_group_dummy_data(self, **kwargs):
+    def _get_group_data(self, **kwargs):
         data = {
             'name': 'Test group',
             'can_add_page': 'on',
@@ -24,7 +24,7 @@ class PermissionsOnTestCase(CMSTestCase):
         data.update(**kwargs)
         return data
 
-    def get_group(self, created_by=None):
+    def _get_group(self, created_by=None):
         if not created_by:
             created_by = self.get_superuser()
 
@@ -81,7 +81,7 @@ class PermissionsOnGlobalTest(PermissionsOnTestCase):
         endpoint = self.get_admin_url(PageUserGroup, 'add')
         redirect_to = admin_reverse('index')
         staff_user = self.get_staff_user_with_no_permissions()
-        data = self.get_group_dummy_data()
+        data = self._get_group_data()
 
         self.add_permission(staff_user, 'add_pageusergroup')
         self.add_global_permission(staff_user, can_change_permissions=True)
@@ -94,7 +94,7 @@ class PermissionsOnGlobalTest(PermissionsOnTestCase):
     def test_user_cant_add_group(self):
         endpoint = self.get_admin_url(PageUserGroup, 'add')
         staff_user = self.get_staff_user_with_no_permissions()
-        data = self.get_group_dummy_data()
+        data = self._get_group_data()
 
         self.add_permission(staff_user, 'add_pageusergroup')
         self.add_global_permission(staff_user, can_change_permissions=False)
@@ -105,11 +105,11 @@ class PermissionsOnGlobalTest(PermissionsOnTestCase):
             self.assertFalse(self._group_exists())
 
     def test_user_can_change_group(self):
-        group = self.get_group()
+        group = self._get_group()
         endpoint = self.get_admin_url(PageUserGroup, 'change', group.pk)
         redirect_to = self.get_admin_url(PageUserGroup, 'changelist')
         staff_user = self.get_staff_user_with_no_permissions()
-        data = self.get_group_dummy_data(name='New test group')
+        data = self._get_group_data(name='New test group')
 
         self.add_permission(staff_user, 'change_pageusergroup')
         self.add_global_permission(staff_user, can_change_permissions=True)
@@ -120,10 +120,10 @@ class PermissionsOnGlobalTest(PermissionsOnTestCase):
             self.assertTrue(self._group_exists('New test group'))
 
     def test_user_cant_change_group(self):
-        group = self.get_group()
+        group = self._get_group()
         endpoint = self.get_admin_url(PageUserGroup, 'change', group.pk)
         staff_user = self.get_staff_user_with_no_permissions()
-        data = self.get_group_dummy_data(name='New test group')
+        data = self._get_group_data(name='New test group')
 
         self.add_permission(staff_user, 'change_pageusergroup')
         self.add_global_permission(staff_user, can_change_permissions=False)
@@ -134,7 +134,7 @@ class PermissionsOnGlobalTest(PermissionsOnTestCase):
             self.assertTrue(self._group_exists())
 
     def test_user_can_delete_group(self):
-        group = self.get_group()
+        group = self._get_group()
         endpoint = self.get_admin_url(PageUserGroup, 'delete', group.pk)
         redirect_to = admin_reverse('index')
         staff_user = self.get_staff_user_with_no_permissions()
@@ -150,7 +150,7 @@ class PermissionsOnGlobalTest(PermissionsOnTestCase):
             self.assertFalse(self._group_exists())
 
     def test_user_cant_delete_group(self):
-        group = self.get_group()
+        group = self._get_group()
         endpoint = self.get_admin_url(PageUserGroup, 'delete', group.pk)
         staff_user = self.get_staff_user_with_no_permissions()
         data = {'post': 'yes'}
@@ -204,6 +204,7 @@ class PermissionsOnPageTest(PermissionsOnTestCase):
         endpoint = admin_reverse('app_list', args=['cms'])
         staff_user = self.get_staff_user_with_no_permissions()
 
+        self.add_permission(staff_user, 'change_page')
         self.add_permission(staff_user, 'change_pageusergroup')
         self.add_page_permission(
             staff_user,
@@ -234,7 +235,7 @@ class PermissionsOnPageTest(PermissionsOnTestCase):
         endpoint = self.get_admin_url(PageUserGroup, 'add')
         redirect_to = admin_reverse('index')
         staff_user = self.get_staff_user_with_no_permissions()
-        data = self.get_group_dummy_data()
+        data = self._get_group_data()
 
         self.add_permission(staff_user, 'add_pageusergroup')
         self.add_page_permission(
@@ -255,7 +256,7 @@ class PermissionsOnPageTest(PermissionsOnTestCase):
         """
         endpoint = self.get_admin_url(PageUserGroup, 'add')
         staff_user = self.get_staff_user_with_no_permissions()
-        data = self.get_group_dummy_data()
+        data = self._get_group_data()
 
         self.add_permission(staff_user, 'add_pageusergroup')
         self.add_page_permission(
@@ -275,7 +276,7 @@ class PermissionsOnPageTest(PermissionsOnTestCase):
         is set to True.
         """
         staff_user = self.get_staff_user_with_no_permissions()
-        group = self.get_group(created_by=staff_user)
+        group = self._get_group(created_by=staff_user)
         endpoint = self.get_admin_url(PageUserGroup, 'change', group.pk)
         data = model_to_dict(group)
         data['_continue'] = '1'
@@ -299,7 +300,7 @@ class PermissionsOnPageTest(PermissionsOnTestCase):
         is set to False.
         """
         staff_user = self.get_staff_user_with_no_permissions()
-        group = self.get_group(created_by=staff_user)
+        group = self._get_group(created_by=staff_user)
         endpoint = self.get_admin_url(PageUserGroup, 'change', group.pk)
 
         data = model_to_dict(group)
@@ -323,7 +324,7 @@ class PermissionsOnPageTest(PermissionsOnTestCase):
         User cant change a group he's a part of,
         even with can_change_permissions set to True.
         """
-        group = self.get_group()
+        group = self._get_group()
         staff_user = self.get_staff_user_with_no_permissions()
         staff_user.groups.add(group)
         endpoint = self.get_admin_url(PageUserGroup, 'change', group.pk)
@@ -350,7 +351,7 @@ class PermissionsOnPageTest(PermissionsOnTestCase):
         even with can_change_permissions set to True.
         """
         admin = self.get_superuser()
-        group = self.get_group(created_by=admin)
+        group = self._get_group(created_by=admin)
         staff_user = self.get_staff_user_with_no_permissions()
         endpoint = self.get_admin_url(PageUserGroup, 'change', group.pk)
 
@@ -376,7 +377,7 @@ class PermissionsOnPageTest(PermissionsOnTestCase):
         is set to True.
         """
         staff_user = self.get_staff_user_with_no_permissions()
-        group = self.get_group(created_by=staff_user)
+        group = self._get_group(created_by=staff_user)
         endpoint = self.get_admin_url(PageUserGroup, 'delete', group.pk)
         redirect_to = admin_reverse('index')
         data = {'post': 'yes'}
@@ -400,7 +401,7 @@ class PermissionsOnPageTest(PermissionsOnTestCase):
         is set to False.
         """
         staff_user = self.get_staff_user_with_no_permissions()
-        group = self.get_group(created_by=staff_user)
+        group = self._get_group(created_by=staff_user)
         endpoint = self.get_admin_url(PageUserGroup, 'delete', group.pk)
         data = {'post': 'yes'}
 
@@ -422,7 +423,7 @@ class PermissionsOnPageTest(PermissionsOnTestCase):
         User cant delete a group he's a part of,
         even with can_change_permissions set to True.
         """
-        group = self.get_group()
+        group = self._get_group()
         staff_user = self.get_staff_user_with_no_permissions()
         staff_user.groups.add(group)
         endpoint = self.get_admin_url(PageUserGroup, 'delete', group.pk)
@@ -452,7 +453,7 @@ class PermissionsOnPageTest(PermissionsOnTestCase):
         even with can_change_permissions set to True.
         """
         admin = self.get_superuser()
-        group = self.get_group(created_by=admin)
+        group = self._get_group(created_by=admin)
         staff_user = self.get_staff_user_with_no_permissions()
         endpoint = self.get_admin_url(PageUserGroup, 'delete', group.pk)
         data = {'post': 'yes'}

--- a/cms/tests/test_page_user_group_admin.py
+++ b/cms/tests/test_page_user_group_admin.py
@@ -1,0 +1,153 @@
+# -*- coding: utf-8 -*-
+from django.test.utils import override_settings
+
+from cms.models.permissionmodels import PageUserGroup
+from cms.test_utils.testcases import CMSTestCase
+from cms.utils.urlutils import admin_reverse
+
+
+@override_settings(CMS_PERMISSION=True)
+class PageUserGroupPermissionsOnTest(CMSTestCase):
+
+    def get_group_dummy_data(self, **kwargs):
+        data = {
+            'name': 'Test group',
+            'can_add_page': 'on',
+            'can_change_page': 'on',
+            'can_delete_page': 'on',
+        }
+        data.update(**kwargs)
+        return data
+
+    def get_group(self):
+        data = {
+            'name': 'Test group',
+            'created_by': self.get_superuser(),
+        }
+        return PageUserGroup.objects.create(**data)
+
+    def test_group_in_admin_index(self):
+        endpoint = admin_reverse('app_list', args=['cms'])
+        staff_user = self.get_staff_user_with_no_permissions()
+
+        self.add_permission(staff_user, 'change_pageusergroup')
+        self.add_global_permission(staff_user, can_change_permissions=True)
+
+        with self.login_user_context(staff_user):
+            response = self.client.get(endpoint)
+            self.assertEqual(response.status_code, 200)
+            self.assertContains(
+                response,
+                '<a href="/en/admin/cms/pageusergroup/">User groups (page)</a>',
+                html=True,
+            )
+
+        endpoint = self.get_admin_url(PageUserGroup, 'changelist')
+
+        with self.login_user_context(staff_user):
+            response = self.client.get(endpoint)
+            self.assertEqual(response.status_code, 200)
+
+    def test_group_not_in_admin_index(self):
+        endpoint = admin_reverse('app_list', args=['cms'])
+        staff_user = self.get_staff_user_with_no_permissions()
+
+        self.add_permission(staff_user, 'change_pageusergroup')
+        self.add_global_permission(staff_user, can_change_permissions=False)
+
+        with self.login_user_context(staff_user):
+            response = self.client.get(endpoint)
+            self.assertEqual(response.status_code, 404)
+
+        endpoint = self.get_admin_url(PageUserGroup, 'changelist')
+
+        with self.login_user_context(staff_user):
+            response = self.client.get(endpoint)
+            self.assertEqual(response.status_code, 403)
+
+    def test_group_can_add(self):
+        endpoint = self.get_admin_url(PageUserGroup, 'add')
+        redirect_to = admin_reverse('index')
+        staff_user = self.get_staff_user_with_no_permissions()
+        data = self.get_group_dummy_data()
+
+        self.add_permission(staff_user, 'add_pageusergroup')
+        self.add_global_permission(staff_user, can_change_permissions=True)
+
+        with self.login_user_context(staff_user):
+            response = self.client.post(endpoint, data)
+            self.assertRedirects(response, redirect_to)
+            self.assertTrue(PageUserGroup.objects.filter(name='Test group').exists())
+
+    def test_group_cant_add(self):
+        endpoint = self.get_admin_url(PageUserGroup, 'add')
+        staff_user = self.get_staff_user_with_no_permissions()
+        data = self.get_group_dummy_data()
+
+        self.add_permission(staff_user, 'add_pageusergroup')
+        self.add_global_permission(staff_user, can_change_permissions=False)
+
+        with self.login_user_context(staff_user):
+            response = self.client.post(endpoint, data)
+            self.assertEqual(response.status_code, 403)
+            self.assertFalse(PageUserGroup.objects.filter(name='Test group').exists())
+
+    def test_group_can_change(self):
+        group = self.get_group()
+        endpoint = self.get_admin_url(PageUserGroup, 'change', group.pk)
+        redirect_to = self.get_admin_url(PageUserGroup, 'changelist')
+        staff_user = self.get_staff_user_with_no_permissions()
+        data = self.get_group_dummy_data(name='New test group')
+
+        self.add_permission(staff_user, 'change_pageusergroup')
+        self.add_global_permission(staff_user, can_change_permissions=True)
+
+        with self.login_user_context(staff_user):
+            response = self.client.post(endpoint, data)
+            self.assertRedirects(response, redirect_to)
+            self.assertTrue(PageUserGroup.objects.filter(name='New test group').exists())
+
+    def test_group_cant_change(self):
+        group = self.get_group()
+        endpoint = self.get_admin_url(PageUserGroup, 'change', group.pk)
+        staff_user = self.get_staff_user_with_no_permissions()
+        data = self.get_group_dummy_data(name='New test group')
+
+        self.add_permission(staff_user, 'change_pageusergroup')
+        self.add_global_permission(staff_user, can_change_permissions=False)
+
+        with self.login_user_context(staff_user):
+            response = self.client.post(endpoint, data)
+            self.assertEqual(response.status_code, 403)
+            self.assertTrue(PageUserGroup.objects.filter(name='Test group').exists())
+
+    def test_group_can_delete(self):
+        group = self.get_group()
+        endpoint = self.get_admin_url(PageUserGroup, 'delete', group.pk)
+        redirect_to = admin_reverse('index')
+        staff_user = self.get_staff_user_with_no_permissions()
+        data = {'post': 'yes'}
+
+        self.add_permission(staff_user, 'delete_group')
+        self.add_permission(staff_user, 'delete_pageusergroup')
+        self.add_global_permission(staff_user, can_change_permissions=True)
+
+        with self.login_user_context(staff_user):
+            response = self.client.post(endpoint, data)
+            self.assertRedirects(response, redirect_to)
+            self.assertFalse(PageUserGroup.objects.filter(name='Test group').exists())
+
+    def test_group_cant_delete(self):
+        group = self.get_group()
+        endpoint = self.get_admin_url(PageUserGroup, 'delete', group.pk)
+        staff_user = self.get_staff_user_with_no_permissions()
+        data = {'post': 'yes'}
+
+        self.add_permission(staff_user, 'delete_group')
+        self.add_permission(staff_user, 'delete_pageusergroup')
+        self.add_global_permission(staff_user, can_change_permissions=False)
+
+        with self.login_user_context(staff_user):
+            response = self.client.post(endpoint, data)
+            self.assertEqual(response.status_code, 403)
+            self.assertTrue(PageUserGroup.objects.filter(name='Test group').exists())

--- a/cms/tests/test_placeholder.py
+++ b/cms/tests/test_placeholder.py
@@ -227,10 +227,10 @@ class PlaceholderTestCase(CMSTestCase, UnittestCompatMixin):
         placeholder = Placeholder.objects.create(slot="test")
         output = self.render_template_obj(template, {'placeholder': placeholder}, request)
         self.assertEqual(output, "")
-        self.assertEqual(placeholder.cmsplugin_set.count(), 0)
+        self.assertEqual(placeholder.get_plugins().count(), 0)
 
         add_plugin(placeholder, "TextPlugin", settings.LANGUAGES[0][0], body="test")
-        self.assertEqual(placeholder.cmsplugin_set.count(), 1)
+        self.assertEqual(placeholder.get_plugins().count(), 1)
         placeholder = self.reload(placeholder)
         output = self.render_template_obj(template, {'placeholder': placeholder}, request)
         self.assertEqual(output, "test")
@@ -778,8 +778,8 @@ class PlaceholderActionTests(FakemlngFixtures, CMSTestCase):
         actions = MLNGPlaceholderActions()
         fr = Translations.objects.get(language_code='fr')
         de = Translations.objects.get(language_code='de')
-        self.assertEqual(fr.placeholder.cmsplugin_set.count(), 1)
-        self.assertEqual(de.placeholder.cmsplugin_set.count(), 0)
+        self.assertEqual(fr.placeholder.get_plugins().count(), 1)
+        self.assertEqual(de.placeholder.get_plugins().count(), 0)
 
         new_plugins = actions.copy(de.placeholder, 'fr', 'placeholder', Translations, 'de')
         self.assertEqual(len(new_plugins), 1)
@@ -787,15 +787,15 @@ class PlaceholderActionTests(FakemlngFixtures, CMSTestCase):
         de = self.reload(de)
         fr = self.reload(fr)
 
-        self.assertEqual(fr.placeholder.cmsplugin_set.count(), 1)
-        self.assertEqual(de.placeholder.cmsplugin_set.count(), 1)
+        self.assertEqual(fr.placeholder.get_plugins().count(), 1)
+        self.assertEqual(de.placeholder.get_plugins().count(), 1)
 
     def test_mlng_placeholder_actions_empty_copy(self):
         actions = MLNGPlaceholderActions()
         fr = Translations.objects.get(language_code='fr')
         de = Translations.objects.get(language_code='de')
-        self.assertEqual(fr.placeholder.cmsplugin_set.count(), 1)
-        self.assertEqual(de.placeholder.cmsplugin_set.count(), 0)
+        self.assertEqual(fr.placeholder.get_plugins().count(), 1)
+        self.assertEqual(de.placeholder.get_plugins().count(), 0)
 
         new_plugins = actions.copy(fr.placeholder, 'de', 'placeholder', Translations, 'fr')
         self.assertEqual(len(new_plugins), 0)
@@ -803,8 +803,8 @@ class PlaceholderActionTests(FakemlngFixtures, CMSTestCase):
         de = self.reload(de)
         fr = self.reload(fr)
 
-        self.assertEqual(fr.placeholder.cmsplugin_set.count(), 1)
-        self.assertEqual(de.placeholder.cmsplugin_set.count(), 0)
+        self.assertEqual(fr.placeholder.get_plugins().count(), 1)
+        self.assertEqual(de.placeholder.get_plugins().count(), 0)
 
     def test_mlng_placeholder_actions_no_placeholder(self):
         actions = MLNGPlaceholderActions()
@@ -812,7 +812,7 @@ class PlaceholderActionTests(FakemlngFixtures, CMSTestCase):
         de = Translations.objects.get(language_code='de')
         nl = Translations.objects.get(language_code='nl')
         self.assertEqual(nl.placeholder, None)
-        self.assertEqual(de.placeholder.cmsplugin_set.count(), 0)
+        self.assertEqual(de.placeholder.get_plugins().count(), 0)
 
         okay = actions.copy(de.placeholder, 'nl', 'placeholder', Translations, 'de')
         self.assertEqual(okay, False)

--- a/cms/tests/test_placeholder_app_admin.py
+++ b/cms/tests/test_placeholder_app_admin.py
@@ -1,0 +1,918 @@
+# -*- coding: utf-8 -*-
+from django.forms.models import model_to_dict
+from django.test.utils import override_settings
+
+from cms.api import add_plugin
+from cms.models import CMSPlugin, Placeholder, UserSettings
+from cms.test_utils.project.placeholderapp.exceptions import PlaceholderHookException
+from cms.test_utils.project.placeholderapp.models import Example1, CharPksExample
+from cms.test_utils.testcases import CMSTestCase
+
+
+class AppAdminTestCase(CMSTestCase):
+
+    def setUp(self):
+        self._obj = self._get_example_obj()
+
+    def _add_plugin_to_placeholder(self, placeholder,
+                                   plugin_type='LinkPlugin', language='en'):
+        plugin_data = {
+            'StylePlugin': {'tag_type': 'div'},
+            'LinkPlugin': {'name': 'A Link', 'url': 'https://www.django-cms.org'},
+            'PlaceholderPlugin': {'name': 'Content'},
+        }
+        plugin = add_plugin(
+            placeholder,
+            plugin_type,
+            language,
+            **plugin_data[plugin_type]
+        )
+        return plugin
+
+    def _get_add_plugin_uri(self, plugin_type='LinkPlugin', language='en'):
+        uri = self.get_add_plugin_uri(
+            placeholder=self._obj.placeholder,
+            plugin_type=plugin_type,
+            language=language,
+        )
+        return uri
+
+    def _get_example_obj(self):
+        obj = Example1.objects.create(
+            char_1='one',
+            char_2='two',
+            char_3='tree',
+            char_4='four'
+        )
+        return obj
+
+
+class AppAdminTest(AppAdminTestCase):
+    placeholderconf = {'placeholder': {
+        'limits': {
+            'global': 2,
+            'StylePlugin': 1,
+        }
+    }
+    }
+
+    def test_global_limit_on_plugin_add(self):
+        """
+        Ensures placeholder global plugin limit is respected
+        when adding plugins to the placeholder.
+        """
+        superuser = self.get_superuser()
+        endpoint = self._get_add_plugin_uri()
+
+        with self.login_user_context(superuser):
+            with override_settings(CMS_PLACEHOLDER_CONF=self.placeholderconf):
+                data = {'name': 'A Link', 'url': 'https://www.django-cms.org'}
+                response = self.client.post(endpoint, data)  # first
+                self.assertEqual(response.status_code, 200)
+                response = self.client.post(endpoint, data)  # second
+                self.assertEqual(response.status_code, 200)
+                response = self.client.post(endpoint, data)  # third
+                self.assertEqual(response.status_code, 400)
+                self.assertEqual(
+                    response.content,
+                    b"This placeholder already has the maximum number of plugins (2).",
+                )
+
+    def test_global_limit_on_plugin_move(self):
+        """
+        Ensures placeholder global plugin limit is respected
+        when moving plugins to the placeholder.
+        """
+        superuser = self.get_superuser()
+        source_placeholder = self._obj.placeholder
+        target_placeholder = self._get_example_obj().placeholder
+        endpoint = self.get_admin_url(Example1, 'move_plugin')
+
+        plugin_1 = self._add_plugin_to_placeholder(source_placeholder)
+        plugin_2 = self._add_plugin_to_placeholder(source_placeholder)
+        plugin_3 = self._add_plugin_to_placeholder(source_placeholder)
+
+        with self.login_user_context(superuser):
+            with self.settings(CMS_PLACEHOLDER_CONF=self.placeholderconf):
+                data = {
+                    'plugin_id': plugin_1.pk,
+                    'placeholder_id': target_placeholder.pk,
+                    'plugin_parent': '',
+                }
+                response = self.client.post(endpoint, data)  # first
+                self.assertEqual(response.status_code, 200)
+                data = {
+                    'plugin_id': plugin_2.pk,
+                    'placeholder_id': target_placeholder.pk,
+                    'plugin_parent': '',
+                }
+                response = self.client.post(endpoint, data)  # second
+                self.assertEqual(response.status_code, 200)
+                data = {
+                    'plugin_id': plugin_3.pk,
+                    'placeholder_id': target_placeholder.pk,
+                    'plugin_parent': '',
+                }
+                response = self.client.post(endpoint, data)  # third
+                self.assertEqual(response.status_code, 400)
+                self.assertEqual(
+                    response.content,
+                    b"This placeholder already has the maximum number of plugins (2)."
+                )
+
+    def test_no_global_limit_check_same_placeholder_move(self):
+        """
+        Ensures no global limit exception is raised
+        when moving plugins inside of a placeholder.
+        """
+        superuser = self.get_superuser()
+        source_placeholder = self._obj.placeholder
+        target_placeholder = source_placeholder
+        endpoint = self.get_admin_url(Example1, 'move_plugin')
+
+        plugin_1 = self._add_plugin_to_placeholder(source_placeholder)
+        plugin_2 = self._add_plugin_to_placeholder(source_placeholder)
+
+        with self.login_user_context(superuser):
+            with self.settings(CMS_PLACEHOLDER_CONF=self.placeholderconf):
+                data = {
+                    'plugin_id': plugin_1.pk,
+                    'placeholder_id': target_placeholder.pk,
+                    'plugin_parent': '',
+                    'plugin_order': 1,
+                }
+                response = self.client.post(endpoint, data)  # first
+                self.assertEqual(response.status_code, 200)
+                data = {
+                    'plugin_id': plugin_2.pk,
+                    'placeholder_id': target_placeholder.pk,
+                    'plugin_parent': '',
+                    'plugin_order': 1,
+                }
+                response = self.client.post(endpoint, data)  # second
+                self.assertEqual(response.status_code, 200)
+
+    def test_type_limit_on_plugin_add(self):
+        """
+        Ensures placeholder plugin type limit is respected
+        when adding plugins to the placeholder.
+        """
+        superuser = self.get_superuser()
+        endpoint = self._get_add_plugin_uri('StylePlugin')
+
+        with self.login_user_context(superuser):
+            with self.settings(CMS_PLACEHOLDER_CONF=self.placeholderconf):
+                data = {'tag_type': 'div'}
+                response = self.client.post(endpoint, data)  # first
+                self.assertEqual(response.status_code, 200)
+                response = self.client.post(endpoint, data)  # second
+                self.assertEqual(response.status_code, 400)
+                self.assertEqual(
+                    response.content,
+                    b"This placeholder already has the "
+                    b"maximum number (1) of allowed Style plugins."
+                )
+
+    def test_type_limit_on_plugin_move(self):
+        """
+        Ensures placeholder plugin type limit is respected
+        when moving plugins to the placeholder.
+        """
+        superuser = self.get_superuser()
+        source_placeholder = self._obj.placeholder
+        target_placeholder = self._get_example_obj().placeholder
+        endpoint = self.get_admin_url(Example1, 'move_plugin')
+
+        plugin_1 = self._add_plugin_to_placeholder(source_placeholder, 'StylePlugin')
+        plugin_2 = self._add_plugin_to_placeholder(source_placeholder, 'StylePlugin')
+
+        with self.login_user_context(superuser):
+            with self.settings(CMS_PLACEHOLDER_CONF=self.placeholderconf):
+                data = {
+                    'plugin_id': plugin_1.pk,
+                    'placeholder_id': target_placeholder.pk,
+                    'plugin_parent': '',
+                }
+                response = self.client.post(endpoint, data)  # first
+                self.assertEqual(response.status_code, 200)
+                data = {
+                    'plugin_id': plugin_2.pk,
+                    'placeholder_id': target_placeholder.pk,
+                    'plugin_parent': '',
+                }
+                response = self.client.post(endpoint, data)  # second
+                self.assertEqual(response.status_code, 400)
+                self.assertEqual(response.content,
+                                 b"This placeholder already has the maximum number (1) of allowed Style plugins.")
+
+    def test_no_type_limit_check_same_placeholder_move(self):
+        """
+        Ensures no plugin type limit exception is raised
+        when moving plugins inside of a placeholder.
+        """
+        superuser = self.get_superuser()
+        source_placeholder = self._obj.placeholder
+        target_placeholder = source_placeholder
+        endpoint = self.get_admin_url(Example1, 'move_plugin')
+
+        plugin_1 = self._add_plugin_to_placeholder(source_placeholder, 'StylePlugin')
+
+        with self.login_user_context(superuser):
+            with self.settings(CMS_PLACEHOLDER_CONF=self.placeholderconf):
+                data = {
+                    'plugin_id': plugin_1.pk,
+                    'placeholder_id': target_placeholder.pk,
+                    'plugin_parent': '',
+                    'plugin_order': 1,
+                }
+                response = self.client.post(endpoint, data)  # first
+                self.assertEqual(response.status_code, 200)
+
+    def test_placeholder_post_move_hook_resolve(self):
+        """
+        Ensure moving a plugin from placeholder A
+        registered with admin A calls the move plugin hooks
+        on the target placeholder's registered admin.
+        """
+        superuser = self.get_superuser()
+        endpoint = self.get_admin_url(Example1, 'move_plugin')
+        exception = PlaceholderHookException
+        message = 'move plugin hook has been called.'
+
+        example_1 = self._obj
+        source_placeholder = example_1.placeholder
+        plugin = self._add_plugin_to_placeholder(source_placeholder)
+
+        example_2 = CharPksExample.objects.create(
+            char_1='one',
+            slug='two',
+        )
+        target_placeholder = example_2.placeholder_1
+
+        with self.login_user_context(superuser):
+            with self.assertRaisesMessage(exception, message):
+                # move plugin to placeholder_2
+                # this will cause the Example1 admin
+                # to resolve the attached model/admin of the target placeholder
+                # and call it's hook.
+                data = {
+                    'plugin_id': plugin.pk,
+                    'placeholder_id': target_placeholder.pk,
+                    'plugin_parent': '',
+                }
+                self.client.post(endpoint, data)
+
+    def test_placeholder_post_copy_hook_resolve(self):
+        """
+        Ensure copying a plugin from placeholder A
+        registered with admin A calls the copy plugin hooks
+        on the target placeholder's registered admin.
+        """
+        superuser = self.get_superuser()
+        endpoint = self.get_admin_url(Example1, 'copy_plugins')
+        exception = PlaceholderHookException
+        message = 'copy plugin hook has been called.'
+
+        example_1 = self._obj
+        source_placeholder = example_1.placeholder
+        plugin = self._add_plugin_to_placeholder(source_placeholder)
+
+        example_2 = CharPksExample.objects.create(
+            char_1='one',
+            slug='two',
+        )
+        target_placeholder = example_2.placeholder_1
+
+        with self.login_user_context(superuser):
+            with self.assertRaisesMessage(exception, message):
+                # move plugin to placeholder_2
+                # this will cause the Example1 admin
+                # to resolve the attached model/admin of the target placeholder
+                # and call it's hook.
+                data = {
+                    'source_language': plugin.language,
+                    'source_placeholder_id': source_placeholder.pk,
+                    'source_plugin_id': plugin.pk,
+                    'target_language': plugin.language,
+                    'target_placeholder_id': target_placeholder.pk,
+                }
+                self.client.post(endpoint, data)
+
+
+class AppAdminPermissionsTest(AppAdminTestCase):
+
+    def setUp(self):
+        self._obj = self._get_example_obj()
+        self._staff_user = self.get_staff_user_with_no_permissions()
+
+    def test_user_can_add_plugin(self):
+        """
+        User can add a new plugin if he has change permissions
+        on the model attached to the placeholder and he has
+        add permissions on the plugin model.
+        """
+        staff_user = self._staff_user
+        placeholder = self._obj.placeholder
+        plugins = placeholder.get_plugins('en').filter(plugin_type='LinkPlugin')
+        endpoint = self._get_add_plugin_uri()
+
+        self.add_permission(staff_user, 'change_example1')
+        self.add_permission(staff_user, 'add_link')
+
+        with self.login_user_context(staff_user):
+            data = {'name': 'A Link', 'url': 'https://www.django-cms.org'}
+            response = self.client.post(endpoint, data)
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(plugins.count(), 1)
+
+    def test_user_cant_add_plugin(self):
+        """
+        User can't add a new plugin if he does not have
+        change permissions on the model attached to the placeholder
+        and/or does not have add permissions on the plugin model.
+        """
+        staff_user = self._staff_user
+        placeholder = self._obj.placeholder
+        plugins = placeholder.get_plugins('en').filter(plugin_type='LinkPlugin')
+        endpoint = self._get_add_plugin_uri()
+
+        self.add_permission(staff_user, 'add_example1')
+        self.add_permission(staff_user, 'delete_example1')
+        self.add_permission(staff_user, 'add_link')
+
+        with self.login_user_context(staff_user):
+            data = {'name': 'A Link', 'url': 'https://www.django-cms.org'}
+            response = self.client.post(endpoint, data)
+            self.assertEqual(response.status_code, 403)
+            self.assertEqual(plugins.count(), 0)
+
+        self.add_permission(staff_user, 'change_example1')
+        self.remove_permission(staff_user, 'add_link')
+
+        with self.login_user_context(staff_user):
+            data = {'name': 'A Link', 'url': 'https://www.django-cms.org'}
+            response = self.client.post(endpoint, data)
+            self.assertEqual(response.status_code, 403)
+            self.assertEqual(plugins.count(), 0)
+
+    def test_user_can_edit_plugin(self):
+        """
+        User can edit a plugin if he has change permissions
+        on the model attached to the placeholder and he has
+        change permissions on the plugin model.
+        """
+        staff_user = self._staff_user
+        placeholder = self._obj.placeholder
+        plugin = self._add_plugin_to_placeholder(placeholder)
+        endpoint = self.get_admin_url(Example1, 'edit_plugin', plugin.pk)
+
+        self.add_permission(staff_user, 'change_example1')
+        self.add_permission(staff_user, 'change_link')
+
+        with self.login_user_context(staff_user):
+            data = model_to_dict(plugin, fields=['name', 'url'])
+            data['name'] = 'A link 2'
+
+            response = self.client.post(endpoint, data)
+            self.assertEqual(response.status_code, 200)
+            plugin.refresh_from_db()
+            self.assertEqual(plugin.name, data['name'])
+
+    def test_user_cant_edit_plugin(self):
+        """
+        User can't edit a plugin if he does not have
+        change permissions on the model attached to the placeholder
+        and/or does not have change permissions on the plugin model.
+        """
+        staff_user = self._staff_user
+        placeholder = self._obj.placeholder
+        plugin = self._add_plugin_to_placeholder(placeholder)
+        endpoint = self.get_admin_url(Example1, 'edit_plugin', plugin.pk)
+
+        self.add_permission(staff_user, 'add_example1')
+        self.add_permission(staff_user, 'delete_example1')
+        self.add_permission(staff_user, 'change_link')
+
+        with self.login_user_context(staff_user):
+            data = model_to_dict(plugin, fields=['name', 'url'])
+            data['name'] = 'A link 2'
+
+            response = self.client.post(endpoint, data)
+            self.assertEqual(response.status_code, 403)
+            plugin.refresh_from_db()
+            self.assertNotEqual(plugin.name, data['name'])
+
+        self.add_permission(staff_user, 'change_example1')
+        self.remove_permission(staff_user, 'change_link')
+
+        with self.login_user_context(staff_user):
+            data = model_to_dict(plugin, fields=['name', 'url'])
+            data['name'] = 'A link 2'
+
+            response = self.client.post(endpoint, data)
+            self.assertEqual(response.status_code, 403)
+            plugin.refresh_from_db()
+            self.assertNotEqual(plugin.name, data['name'])
+
+    def test_user_can_delete_plugin(self):
+        """
+        User can delete a plugin if he has change permissions
+        on the model attached to the placeholder and he has
+        delete permissions on the plugin model.
+        """
+        staff_user = self._staff_user
+        placeholder = self._obj.placeholder
+        plugin = self._add_plugin_to_placeholder(placeholder)
+        endpoint = self.get_admin_url(Example1, 'delete_plugin', plugin.pk)
+
+        self.add_permission(staff_user, 'change_example1')
+        self.add_permission(staff_user, 'delete_link')
+
+        with self.login_user_context(staff_user):
+            data = {'post': True}
+
+            response = self.client.post(endpoint, data)
+            self.assertEqual(response.status_code, 302)
+            self.assertFalse(CMSPlugin.objects.filter(pk=plugin.pk).exists())
+
+    def test_user_cant_delete_plugin(self):
+        """
+        User can't delete a plugin if he does not have
+        change permissions on the model attached to the placeholder
+        and/or does not have delete permissions on the plugin model.
+        """
+        staff_user = self._staff_user
+        placeholder = self._obj.placeholder
+        plugin = self._add_plugin_to_placeholder(placeholder)
+        endpoint = self.get_admin_url(Example1, 'delete_plugin', plugin.pk)
+
+        self.add_permission(staff_user, 'add_example1')
+        self.add_permission(staff_user, 'delete_example1')
+        self.add_permission(staff_user, 'delete_link')
+
+        with self.login_user_context(staff_user):
+            data = {'post': True}
+
+            response = self.client.post(endpoint, data)
+            self.assertEqual(response.status_code, 403)
+            self.assertTrue(CMSPlugin.objects.filter(pk=plugin.pk).exists())
+
+        self.add_permission(staff_user, 'change_example1')
+        self.remove_permission(staff_user, 'delete_link')
+
+        with self.login_user_context(staff_user):
+            data = {'post': True}
+
+            response = self.client.post(endpoint, data)
+            self.assertEqual(response.status_code, 403)
+            self.assertTrue(CMSPlugin.objects.filter(pk=plugin.pk).exists())
+
+    def test_user_can_move_plugin(self):
+        """
+        User can move a plugin if he has change permissions
+        on the model attached to the placeholder and he has
+        change permissions on the plugin model.
+        """
+        staff_user = self._staff_user
+        source_placeholder = self._obj.placeholder
+        target_placeholder = self._get_example_obj().placeholder
+        plugin = self._add_plugin_to_placeholder(source_placeholder)
+        endpoint = self.get_admin_url(Example1, 'move_plugin')
+
+        data = {
+            'plugin_id': plugin.pk,
+            'placeholder_id': target_placeholder.pk,
+            'plugin_parent': '',
+        }
+
+        self.add_permission(staff_user, 'change_example1')
+        self.add_permission(staff_user, 'change_link')
+
+        with self.login_user_context(staff_user):
+            response = self.client.post(endpoint, data)
+            self.assertEqual(response.status_code, 200)
+            self.assertTrue(target_placeholder.get_plugins('en').filter(pk=plugin.pk))
+            self.assertFalse(source_placeholder.get_plugins('en').filter(pk=plugin.pk))
+
+    def test_user_cant_move_plugin(self):
+        """
+        User can't move a plugin if he does not have
+        change permissions on the model attached to the placeholder
+        and/or does not have change permissions on the plugin model.
+        """
+        staff_user = self._staff_user
+        source_placeholder = self._obj.placeholder
+        target_placeholder = self._get_example_obj().placeholder
+        plugin = self._add_plugin_to_placeholder(source_placeholder)
+        endpoint = self.get_admin_url(Example1, 'move_plugin')
+
+        data = {
+            'plugin_id': plugin.pk,
+            'placeholder_id': target_placeholder.pk,
+            'plugin_parent': '',
+        }
+
+        self.add_permission(staff_user, 'add_example1')
+        self.add_permission(staff_user, 'delete_example1')
+        self.add_permission(staff_user, 'change_link')
+
+        with self.login_user_context(staff_user):
+            response = self.client.post(endpoint, data)
+            self.assertEqual(response.status_code, 403)
+            self.assertFalse(target_placeholder.get_plugins('en').filter(pk=plugin.pk))
+            self.assertTrue(source_placeholder.get_plugins('en').filter(pk=plugin.pk))
+
+        self.add_permission(staff_user, 'change_example1')
+        self.remove_permission(staff_user, 'change_link')
+
+        with self.login_user_context(staff_user):
+            response = self.client.post(endpoint, data)
+            self.assertEqual(response.status_code, 403)
+            self.assertFalse(target_placeholder.get_plugins('en').filter(pk=plugin.pk))
+            self.assertTrue(source_placeholder.get_plugins('en').filter(pk=plugin.pk))
+
+    def test_user_can_copy_plugin(self):
+        """
+        User can copy a plugin if he has change permissions
+        on the model attached to the placeholder and he has
+        add permissions on the plugin model.
+        """
+        staff_user = self._staff_user
+        placeholder = self._obj.placeholder
+        plugin = self._add_plugin_to_placeholder(placeholder)
+        endpoint = self.get_admin_url(Example1, 'copy_plugins')
+        source_placeholder = plugin.placeholder
+        target_placeholder = self._get_example_obj().placeholder
+
+        data = {
+            'source_plugin_id': plugin.pk,
+            'source_placeholder_id': source_placeholder.pk,
+            'source_language': plugin.language,
+            'target_language': 'en',
+            'target_placeholder_id': target_placeholder.pk,
+        }
+
+        self.add_permission(staff_user, 'change_example1')
+        self.add_permission(staff_user, 'add_link')
+
+        with self.login_user_context(staff_user):
+            response = self.client.post(endpoint, data)
+            self.assertEqual(response.status_code, 200)
+            self.assertTrue(source_placeholder.get_plugins('en').filter(pk=plugin.pk).exists())
+            self.assertTrue(
+                target_placeholder
+                .get_plugins('en')
+                .filter(plugin_type=plugin.plugin_type)
+                .exists()
+            )
+
+    def test_user_cant_copy_plugin(self):
+        """
+        User can't copy a plugin if he does not have
+        change permissions on the model attached to the placeholder
+        and/or does not have add permissions on the plugin model.
+        """
+        staff_user = self._staff_user
+        placeholder = self._obj.placeholder
+        plugin = self._add_plugin_to_placeholder(placeholder)
+        endpoint = self.get_admin_url(Example1, 'copy_plugins')
+        source_placeholder = plugin.placeholder
+        target_placeholder = self._get_example_obj().placeholder
+
+        data = {
+            'source_plugin_id': plugin.pk,
+            'source_placeholder_id': source_placeholder.pk,
+            'source_language': plugin.language,
+            'target_language': 'en',
+            'target_placeholder_id': target_placeholder.pk,
+        }
+
+        self.add_permission(staff_user, 'add_example1')
+        self.add_permission(staff_user, 'delete_example1')
+        self.add_permission(staff_user, 'add_link')
+
+        with self.login_user_context(staff_user):
+            response = self.client.post(endpoint, data)
+            self.assertEqual(response.status_code, 403)
+            self.assertTrue(source_placeholder.get_plugins('en').filter(pk=plugin.pk).exists())
+            self.assertFalse(
+                target_placeholder
+                .get_plugins('en')
+                .filter(plugin_type=plugin.plugin_type)
+                .exists()
+            )
+
+        self.add_permission(staff_user, 'change_example1')
+        self.remove_permission(staff_user, 'add_link')
+
+        with self.login_user_context(staff_user):
+            response = self.client.post(endpoint, data)
+            self.assertEqual(response.status_code, 403)
+            self.assertTrue(source_placeholder.get_plugins('en').filter(pk=plugin.pk).exists())
+            self.assertFalse(
+                target_placeholder
+                .get_plugins('en')
+                .filter(plugin_type=plugin.plugin_type)
+                .exists()
+            )
+
+    def test_user_can_clear_empty_placeholder(self):
+        """
+        User can clear a placeholder if he has change permissions
+        on the model attached to the placeholder.
+        """
+        staff_user = self._staff_user
+        placeholder = self._obj.placeholder
+        endpoint = self.get_admin_url(Example1, 'clear_placeholder', placeholder.pk)
+
+        self.add_permission(staff_user, 'change_example1')
+
+        with self.login_user_context(staff_user):
+            response = self.client.post(endpoint, {'test': 0})
+            self.assertEqual(response.status_code, 302)
+
+    def test_user_cant_clear_empty_placeholder(self):
+        """
+        User can't clear a placeholder if he does not have
+        change permissions on the model attached to the placeholder.
+        """
+        staff_user = self._staff_user
+        placeholder = self._obj.placeholder
+        endpoint = self.get_admin_url(Example1, 'clear_placeholder', placeholder.pk)
+
+        with self.login_user_context(staff_user):
+            response = self.client.post(endpoint, {'test': 0})
+            self.assertEqual(response.status_code, 403)
+
+    def test_user_can_clear_non_empty_placeholder(self):
+        """
+        User can clear a placeholder with plugins if he has
+        change permissions on the model attached to the placeholder
+        and delete permissions on the plugin model.
+        """
+        staff_user = self._staff_user
+        placeholder = self._obj.placeholder
+        plugins = [
+            self._add_plugin_to_placeholder(placeholder, 'StylePlugin'),
+            self._add_plugin_to_placeholder(placeholder, 'LinkPlugin'),
+        ]
+        placeholder = plugins[0].placeholder
+        endpoint = self.get_admin_url(Example1, 'clear_placeholder', placeholder.pk)
+
+        self.add_permission(staff_user, 'delete_text')
+        self.add_permission(staff_user, 'delete_link')
+        self.add_permission(staff_user, 'change_example1')
+
+        with self.login_user_context(staff_user):
+            response = self.client.post(endpoint, {'test': 0})
+            self.assertEqual(response.status_code, 302)
+            self.assertEqual(placeholder.get_plugins('en').count(), 0)
+
+    def test_user_cant_clear_non_empty_placeholder(self):
+        """
+        User can't clear a placeholder with plugins if he does not have
+        change permissions on the model attached to the placeholder
+        and/or does not have delete permissions on the plugin model.
+        """
+        staff_user = self._staff_user
+        placeholder = self._obj.placeholder
+        plugins = [
+            self._add_plugin_to_placeholder(placeholder, 'StylePlugin'),
+            self._add_plugin_to_placeholder(placeholder, 'LinkPlugin'),
+        ]
+        placeholder = plugins[0].placeholder
+        endpoint = self.get_admin_url(Example1, 'clear_placeholder', placeholder.pk)
+
+        self.add_permission(staff_user, 'delete_text')
+        self.add_permission(staff_user, 'delete_link')
+
+        with self.login_user_context(staff_user):
+            response = self.client.post(endpoint, {'test': 0})
+            self.assertEqual(response.status_code, 403)
+            self.assertEqual(placeholder.get_plugins('en').count(), 2)
+
+    def test_user_can_copy_placeholder_to_clipboard(self):
+        """
+        User can copy a placeholder to the clipboard
+        if he has add permissions on the plugin models
+        being copied.
+        """
+        staff_user = self._staff_user
+        source_placeholder = self._obj.placeholder
+        endpoint = self.get_admin_url(Example1, 'copy_plugins')
+
+        self._add_plugin_to_placeholder(source_placeholder, 'StylePlugin')
+        self._add_plugin_to_placeholder(source_placeholder, 'LinkPlugin')
+
+        user_settings = UserSettings.objects.create(
+            language="en",
+            user=staff_user,
+            clipboard=Placeholder.objects.create(),
+        )
+
+        self.add_permission(staff_user, 'add_link')
+        self.add_permission(staff_user, 'add_style')
+
+        # This is sadly required to copy the plugins into the clipboard
+        # FIXME: https://github.com/divio/django-cms/issues/5488
+        self.add_permission(staff_user, 'change_example1')
+
+        # This are sadly required to alter the clipboard
+        # FIXME: https://github.com/divio/django-cms/issues/5488
+        self.add_permission(staff_user, 'change_usersettings')
+
+        data = {
+            'source_plugin_id': '',
+            'source_placeholder_id': source_placeholder.pk,
+            'source_language': 'en',
+            'target_language': 'en',
+            'target_placeholder_id': user_settings.clipboard.pk,
+        }
+
+        with self.login_user_context(staff_user):
+            # Copy plugins into the clipboard
+            response = self.client.post(endpoint, data)
+            self.assertEqual(response.status_code, 200)
+
+        clipboard_plugins = user_settings.clipboard.get_plugins()
+
+        # assert the clipboard has a PlaceholderPlugin
+        self.assertTrue(clipboard_plugins.filter(plugin_type='PlaceholderPlugin').exists())
+
+        # assert three new plugins have been created
+        # One for the PlaceholderPlugin and the other two
+        # are the plugins being copied.
+        self.assertEqual(len(clipboard_plugins), 1)
+
+        placeholder_plugin = clipboard_plugins[0].get_plugin_instance()[0]
+        ref_placeholder = placeholder_plugin.placeholder_ref
+
+        # assert there's only two plugins in the clipboard
+        self.assertEqual(ref_placeholder.get_plugins().count(), 2)
+
+    def test_user_cant_copy_placeholder_to_clipboard(self):
+        """
+        User cant copy a placeholder to the clipboard if he does not
+        have add permissions on the plugin models being copied.
+        """
+        staff_user = self._staff_user
+        source_placeholder = self._obj.placeholder
+        endpoint = self.get_admin_url(Example1, 'copy_plugins')
+
+        self._add_plugin_to_placeholder(source_placeholder, 'StylePlugin')
+        self._add_plugin_to_placeholder(source_placeholder, 'LinkPlugin')
+
+        user_settings = UserSettings.objects.create(
+            language="en",
+            user=staff_user,
+            clipboard=Placeholder.objects.create(),
+        )
+
+        self.add_permission(staff_user, 'change_link')
+        self.add_permission(staff_user, 'delete_link')
+        self.add_permission(staff_user, 'change_style')
+        self.add_permission(staff_user, 'delete_style')
+
+        # This is sadly required to copy the plugins
+        # FIXME: https://github.com/divio/django-cms/issues/5488
+        self.add_permission(staff_user, 'change_example1')
+
+        # This are sadly required to alter the clipboard
+        # FIXME: https://github.com/divio/django-cms/issues/5488
+        self.add_permission(staff_user, 'change_usersettings')
+
+        data = {
+            'source_plugin_id': '',
+            'source_placeholder_id': source_placeholder.pk,
+            'source_language': 'en',
+            'target_language': 'en',
+            'target_placeholder_id': user_settings.clipboard.pk,
+        }
+
+        with self.login_user_context(staff_user):
+            # Copy plugins into the clipboard
+            response = self.client.post(endpoint, data)
+
+        self.assertEqual(response.status_code, 403)
+
+        clipboard_plugins = user_settings.clipboard.get_plugins()
+
+        # assert three new plugins have been created
+        # One for the PlaceholderPlugin and the other two
+        # are the plugins being copied.
+        self.assertEqual(len(clipboard_plugins), 0)
+
+    def test_user_can_paste_from_clipboard(self):
+        """
+        User can paste plugins from the clipboard if he has
+        change permissions on the model attached to the target
+        placeholder and he has add permissions on the plugin models
+        being copied.
+        """
+        staff_user = self._staff_user
+        target_placeholder = self._obj.placeholder
+        endpoint = self.get_admin_url(Example1, 'move_plugin')
+
+        self.add_permission(staff_user, 'change_example1')
+        self.add_permission(staff_user, 'add_link')
+
+        # This is sadly required to paste from the clipboard
+        # FIXME: https://github.com/divio/django-cms/issues/5432
+        self.add_permission(staff_user, 'change_placeholderreference')
+
+        user_settings = UserSettings.objects.create(
+            language="en",
+            user=staff_user,
+            clipboard=Placeholder.objects.create(),
+        )
+
+        placeholder_plugin = self._add_plugin_to_placeholder(
+            user_settings.clipboard,
+            'PlaceholderPlugin',
+        )
+        ref_placeholder = placeholder_plugin.placeholder_ref
+
+        self._add_plugin_to_placeholder(ref_placeholder)
+        self._add_plugin_to_placeholder(ref_placeholder)
+
+        with self.login_user_context(staff_user):
+            # Paste plugins from clipboard into placeholder
+            # under the french language.
+            data = {
+                'placeholder_id': target_placeholder.pk,
+                'plugin_id': placeholder_plugin.pk,
+                'plugin_parent': '',
+                'plugin_language': 'fr',
+                'plugin_order[]': '__COPY__',
+                'move_a_copy': True,
+            }
+            response = self.client.post(endpoint, data)
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(target_placeholder.get_plugins('fr').count(), 2)
+
+    def test_user_cant_paste_from_clipboard(self):
+        """
+        User cant paste plugins from the clipboard if he does not have
+        change permissions on the model attached to the target placeholder
+        and/or does not have add permissions on the plugin models
+        being copied.
+        """
+        staff_user = self._staff_user
+        target_placeholder = self._obj.placeholder
+        endpoint = self.get_admin_url(Example1, 'move_plugin')
+
+        self.add_permission(staff_user, 'add_example1')
+        self.add_permission(staff_user, 'delete_example1')
+        self.add_permission(staff_user, 'add_link')
+
+        # This is sadly required to paste from the clipboard
+        # FIXME: https://github.com/divio/django-cms/issues/5432
+        self.add_permission(staff_user, 'change_placeholderreference')
+
+        user_settings = UserSettings.objects.create(
+            language="en",
+            user=staff_user,
+            clipboard=Placeholder.objects.create(),
+        )
+
+        placeholder_plugin = self._add_plugin_to_placeholder(
+            user_settings.clipboard,
+            'PlaceholderPlugin',
+        )
+        ref_placeholder = placeholder_plugin.placeholder_ref
+
+        self._add_plugin_to_placeholder(ref_placeholder)
+        self._add_plugin_to_placeholder(ref_placeholder)
+
+        with self.login_user_context(staff_user):
+            # Paste plugins from clipboard into placeholder
+            # under the french language.
+            data = {
+                'placeholder_id': target_placeholder.pk,
+                'plugin_id': placeholder_plugin.pk,
+                'plugin_parent': '',
+                'plugin_language': 'fr',
+                'plugin_order[]': '__COPY__',
+                'move_a_copy': True,
+            }
+            response = self.client.post(endpoint, data)
+            self.assertEqual(response.status_code, 403)
+            self.assertEqual(target_placeholder.get_plugins('fr').count(), 0)
+
+        self.add_permission(staff_user, 'change_example1')
+        self.remove_permission(staff_user, 'add_link')
+
+        with self.login_user_context(staff_user):
+            # Paste plugins from clipboard into placeholder
+            # under the french language.
+            data = {
+                'placeholder_id': target_placeholder.pk,
+                'plugin_id': placeholder_plugin.pk,
+                'plugin_parent': '',
+                'plugin_language': 'fr',
+                'plugin_order[]': '__COPY__',
+                'move_a_copy': True,
+            }
+            response = self.client.post(endpoint, data)
+            self.assertEqual(response.status_code, 403)
+            self.assertEqual(target_placeholder.get_plugins('fr').count(), 0)

--- a/cms/tests/test_plugins.py
+++ b/cms/tests/test_plugins.py
@@ -998,7 +998,7 @@ class PluginsTestCase(PluginsTestBaseCase):
         # this should not raise any errors, but just ignore the empty plugin
         out = placeholder.render(self.get_context(), width=300)
         self.assertFalse(len(out))
-        self.assertTrue(len(placeholder._plugins_cache))
+        self.assertFalse(len(placeholder._plugins_cache))
 
     def test_pickle(self):
         page = api.create_page("page", "nav_playground.html", "en")

--- a/cms/utils/permissions.py
+++ b/cms/utils/permissions.py
@@ -9,7 +9,7 @@ from django.contrib.sites.models import Site
 from django.db.models import Q
 
 from cms.exceptions import NoPermissionsException
-from cms.models import (Page, PageUser, PagePermission, GlobalPagePermission,
+from cms.models import (Page, PagePermission, GlobalPagePermission,
                         MASK_PAGE, MASK_CHILDREN, MASK_DESCENDANTS)
 from cms.utils.conf import get_cms_setting
 


### PR DESCRIPTION
This PR introduces multiple bug fixes for the permissions system, as well as small cleanups and a complete overhaul of permission related tests.

As the title suggests, this is not a finished product but it's the "core" of the cleanup, future efforts will be based on this.

High level overview:

* Moved plugin add request validation logic to placeholder admin.
  This is because plugins should have no logic aside from the builtin admin logic
   to validate and allow an add request. Placeholders on the other hand provide a way
   to extend these checks in third party apps.
* Moved all (I hope) admin related tests from `test_placeholder`, `test_admin` and `test_page`
  into the more specific `test_page_admin` module.
* Created a `test_page_user_admin` module for tests that interact with the `PageUser` admin
* Created a `test_page_user_group_admin` module for tests that interact with the `PageUserGroup`
  admin.
* Created a `test_placeholder_app_admin` module for tests that interact with the `PlaceholderAdminMixin` class.
* Refactored page & placeholder tests to account for permissions.
* Removed logic to display unsaved (ghost) plugins in structure board.

Most of the additions/changes are tests, there's several bug fixes but usually one liners.
/cc @divio/django-cms-core 