### PR TITLE
Fixed migration 0014 use of ContentType model

### DIFF
--- a/cms/migrations/0014_auto_20160404_1908.py
+++ b/cms/migrations/0014_auto_20160404_1908.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.contrib.auth.models import Permission
-from django.contrib.contenttypes.models import ContentType
 from django.db import migrations, models
 
 
 def forwards(apps, schema_editor):
+    ContentType = apps.get_model('contenttypes', 'ContentType')
+    Permission = apps.get_model('auth', 'Permission')
     page_model = apps.get_model('cms', 'Page')
     page_ctype = ContentType.objects.get_for_model(page_model)
     Permission.objects.filter(


### PR DESCRIPTION
needs to be forwardported

<details>
<summary>Failure log</summary>
```
  Applying cms.0014_auto_20160404_1908...[91mTraceback (most recent call last):
  File "manage.py", line 10, in <module>
[0m[91m    execute_from_command_line(sys.argv)
[0m[91m  File "/usr/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 354, in execute_from_command_line
[0m[91m    utility.execute()
[0m[91m  File "/usr/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 346, in execute
    [0m[91mself.fetch_command(subcommand).run_from_argv(self.argv)
  File "/usr/local/lib/python2.7/site-packages/django/core/management/base.py", line 394, in run_from_argv
[0m[91m    self.execute(*args, **cmd_options)
[0m[91m  File "/usr/local/lib/python2.7/site-packages/django/core/management/base.py", line 445, in execute
[0m[91m    output = self.handle(*args, **options)
[0m[91m  File "/usr/local/lib/python2.7/site-packages/django/core/management/commands/migrate.py", line 222, in handle
[0m[91m    executor.migrate(targets, plan, fake=fake, fake_initial=fake_initial)
[0m[91m  File "/usr/local/lib/python2.7/site-packages/django/db/migrations/executor.py", line 110, in migrate
[0m[91m    self.apply_migration(states[migration], migration, fake=fake, fake_initial=fake_initial)
[0m[91m  File "/usr/local/lib/python2.7/site-packages/django/db/migrations/executor.py", line 148, in apply_migration
    [0m[91mstate = migration.apply(state, schema_editor)
  File "/usr/local/lib/python2.7/site-packages/django/db/migrations/migration.py", line 115, in apply
[0m[91m    operation.database_forwards(self.app_label, schema_editor, old_state, project_state)
[0m[91m  File "/usr/local/lib/python2.7/site-packages/django/db/migrations/operations/special.py", line 183, in database_forwards
[0m[91m    self.code(from_state.apps, schema_editor)
[0m[91m  File "/usr/local/lib/python2.7/site-packages/cms/migrations/0014_auto_20160404_1908.py", line 14, in forwards
[0m[91m    codename='change_page', content_type=page_ctype).update(name='Can change page')
[0m[91m  File "/usr/local/lib/python2.7/site-packages/django/db/models/manager.py", line 127, in manager_method
[0m[91m    return getattr(self.get_queryset(), name)(*args, **kwargs)
[0m[91m  File "/usr/local/lib/python2.7/site-packages/django/db/models/query.py", line 679, in filter
[0m[91m    return self._filter_or_exclude(False, *args, **kwargs)
[0m[91m  File "/usr/local/lib/python2.7/site-packages/django/db/models/query.py", line 697, in _filter_or_exclude
    [0m[91mclone.query.add_q(Q(*args, **kwargs))
  File "/usr/local/lib/python2.7/site-packages/django/db/models/sql/query.py", line 1310, in add_q
[0m[91m    clause, require_inner = self._add_q(where_part, self.used_aliases)
[0m[91m  File "/usr/local/lib/python2.7/site-packages/django/db/models/sql/query.py", line 1338, in _add_q
[0m[91m    allow_joins=allow_joins, split_subq=split_subq,
[0m[91m  File "/usr/local/lib/python2.7/site-packages/django/db/models/sql/query.py", line 1179, in build_filter
    [0m[91mself.check_related_objects(field, value, opts)
  File "/usr/local/lib/python2.7/site-packages/django/db/models/sql/query.py", line 1074, in check_related_objects
[0m[91m    self.check_query_object_type(value, opts)
[0m[91m  File "/usr/local/lib/python2.7/site-packages/django/db/models/sql/query.py", line 1058, in check_query_object_type
    [0m[91m(value, opts.object_name))
ValueError[0m[91m: Cannot query "ContentType object": Must be "ContentType" instance.[0m[91m
[0mRemoving intermediate container d52ebd2f5f72
The command '/bin/sh -c python manage.py migrate' returned a non-zero code: 1
```
</details>