### PR TITLE
Improve warnings

### DIFF
--- a/cms/models/pluginmodel.py
+++ b/cms/models/pluginmodel.py
@@ -296,7 +296,7 @@ class CMSPlugin(six.with_metaclass(PluginModelBase, MP_Node)):
         warnings.warn(
             "Don't use the page attribute on CMSPlugins! CMSPlugins are not "
             "guaranteed to have a page associated with them!",
-            DontUsePageAttributeWarning)
+            DontUsePageAttributeWarning, stacklevel=2)
         return self.placeholder.page if self.placeholder_id else None
 
     def get_instance_icon_src(self):

--- a/cms/toolbar_pool.py
+++ b/cms/toolbar_pool.py
@@ -38,7 +38,8 @@ class ToolbarPool(object):
         if toolbar.__module__.split('.')[-1] == 'cms_toolbar':
             warnings.warn('cms_toolbar.py filename is deprecated, '
                           'and it will be removed in version 3.4; '
-                          'please rename it to cms_toolbars.py', DeprecationWarning)
+                          'please rename it to cms_toolbars.py',
+                          DeprecationWarning, stacklevel=2)
         if not self.force_register and get_cms_setting('TOOLBARS'):
             return toolbar
         from cms.toolbar_base import CMSToolbar

--- a/menus/menu_pool.py
+++ b/menus/menu_pool.py
@@ -314,7 +314,8 @@ class MenuPool(object):
         if menu_cls.__module__.split('.')[-1] == 'menu':
             warnings.warn('menu.py filename is deprecated, '
                           'and it will be removed in version 3.4; '
-                          'please rename it to cms_menus.py', DeprecationWarning)
+                          'please rename it to cms_menus.py',
+                          DeprecationWarning, stacklevel=2)
         from menus.base import Menu
         assert issubclass(menu_cls, Menu)
         if menu_cls.__name__ in self.menus:
@@ -332,7 +333,8 @@ class MenuPool(object):
         if source_file == 'menu.py':
             warnings.warn('menu.py filename is deprecated, '
                           'and it will be removed in version 3.4; '
-                          'please rename it to cms_menus.py', DeprecationWarning)
+                          'please rename it to cms_menus.py',
+                          DeprecationWarning, stacklevel=2)
         from menus.base import Modifier
         assert issubclass(modifier_class, Modifier)
         if modifier_class not in self.modifiers:
@@ -361,7 +363,8 @@ class MenuPool(object):
             post_cut=False, breadcrumb=False):
         warnings.warn('menu_pool.apply_modifiers is deprecated '
                       'and it will be removed in version 3.4; '
-                      'please use the menu renderer instead.', DeprecationWarning)
+                      'please use the menu renderer instead.',
+                      DeprecationWarning, stacklevel=2)
         renderer = self.get_renderer(request)
         nodes = renderer.apply_modifiers(
             nodes=nodes,
@@ -376,7 +379,8 @@ class MenuPool(object):
                   breadcrumb=False):
         warnings.warn('menu_pool.get_nodes is deprecated '
                       'and it will be removed in version 3.4; '
-                      'please use the menu renderer instead.', DeprecationWarning)
+                      'please use the menu renderer instead.',
+                      DeprecationWarning, stacklevel=2)
         renderer = self.get_renderer(request)
         nodes = renderer.get_nodes(
             namespace=namespace,


### PR DESCRIPTION
By default stacklevel argument is `1` which will print the line where the warning was raised instead of the line which is calling deprecated method/property.

If stacklevel is set to 2 then more meaningfull information is shown to the developer.

This probably need to be backported because some of the warnings will be removed in the next release.