### PR TITLE
Plugin rendering refactor

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -14,6 +14,8 @@
   non-existing JavaScript dependencies.
 * Fixed a possible recursion error when using the ``Alias`` plugin.
 * Make it possible to use multi-table inheritance for Page/Title extensions.
+* Refactored plugin rendering functionality to speed up loading time in both
+  structure and content mode.
 
 
 === 3.3.2 (unreleased) ===

--- a/cms/cache/page.py
+++ b/cms/cache/page.py
@@ -11,6 +11,7 @@ from django.utils.timezone import now
 
 from cms.cache import _get_cache_version, _set_cache_version, _get_cache_key
 from cms.constants import EXPIRE_NOW, MAX_EXPIRATION_TTL
+from cms.toolbar.utils import get_toolbar_from_request
 from cms.utils import get_cms_setting
 from cms.utils.helpers import get_timezone_name
 
@@ -31,71 +32,64 @@ def set_page_cache(response):
     from django.core.cache import cache
 
     request = response._request
+    toolbar = get_toolbar_from_request(request)
+    is_authenticated = request.user.is_authenticated()
 
-    if get_cms_setting("PAGE_CACHE") and (
-            not hasattr(request, 'toolbar') or (
-                not request.toolbar.edit_mode and
-                not request.toolbar.show_toolbar and
-                not request.user.is_authenticated()
-            )):
+    if is_authenticated or toolbar._cache_disabled or not get_cms_setting("PAGE_CACHE"):
+        add_never_cache_headers(response)
+        return response
 
-        # This *must* be TZ-aware
-        timestamp = now()
+    # This *must* be TZ-aware
+    timestamp = now()
 
-        placeholders = [ph for ph, __ in getattr(request, 'placeholders', {}).values()]
+    placeholders = toolbar.content_renderer.get_rendered_placeholders()
+    # Checks if there's a plugin using the legacy "cache = False"
+    placeholder_ttl_list = []
+    vary_cache_on_set = set()
+    for ph in placeholders:
+        # get_cache_expiration() always returns:
+        #     EXPIRE_NOW <= int <= MAX_EXPIRATION_IN_SECONDS
+        ttl = ph.get_cache_expiration(request, timestamp)
+        vary_cache_on = ph.get_vary_cache_on(request)
 
-        # Checks if there's a plugin using the legacy "cache = False"
-        if all(ph.cache_placeholder for ph in placeholders):
+        placeholder_ttl_list.append(ttl)
+        if ttl and vary_cache_on:
+            # We're only interested in vary headers if they come from
+            # a cache-able placeholder.
+            vary_cache_on_set |= set(vary_cache_on)
 
-            placeholder_ttl_list = list()
-            vary_cache_on_set = set()
-            for ph in placeholders:
-                # get_cache_expiration() always returns:
-                #     EXPIRE_NOW <= int <= MAX_EXPIRATION_IN_SECONDS
-                ttl = ph.get_cache_expiration(request, timestamp)
-                vary_cache_on = ph.get_vary_cache_on(request)
+    if EXPIRE_NOW not in placeholder_ttl_list:
+        if placeholder_ttl_list:
+            min_placeholder_ttl = min(x for x in placeholder_ttl_list)
+        else:
+            # Should only happen when there are no placeholders at all
+            min_placeholder_ttl = MAX_EXPIRATION_TTL
+        ttl = min(
+            get_cms_setting('CACHE_DURATIONS')['content'],
+            min_placeholder_ttl
+        )
 
-                placeholder_ttl_list.append(ttl)
-                if ttl and vary_cache_on:
-                    # We're only interested in vary headers if they come from
-                    # a cache-able placeholder.
-                    vary_cache_on_set |= set(vary_cache_on)
+        if ttl > 0:
+            # Adds expiration, etc. to headers
+            patch_response_headers(response, cache_timeout=ttl)
+            patch_vary_headers(response, sorted(vary_cache_on_set))
 
-            if EXPIRE_NOW not in placeholder_ttl_list:
-                if placeholder_ttl_list:
-                    min_placeholder_ttl = min(x for x in placeholder_ttl_list)
-                else:
-                    # Should only happen when there are no placeholders at all
-                    min_placeholder_ttl = MAX_EXPIRATION_TTL
-                ttl = min(
-                    get_cms_setting('CACHE_DURATIONS')['content'],
-                    min_placeholder_ttl
-                )
-
-                if ttl > 0:
-                    # Adds expiration, etc. to headers
-                    patch_response_headers(response, cache_timeout=ttl)
-                    patch_vary_headers(response, sorted(vary_cache_on_set))
-
-                    version = _get_cache_version()
-                    # We also store the absolute expiration timestamp to avoid
-                    # recomputing it on cache-reads.
-                    expires_datetime = timestamp + timedelta(seconds=ttl)
-                    cache.set(
-                        _page_cache_key(request),
-                        (
-                            response.content,
-                            response._headers,
-                            expires_datetime,
-                        ),
-                        ttl,
-                        version=version
-                    )
-                    # See note in invalidate_cms_page_cache()
-                    _set_cache_version(version)
-                    return response
-
-    add_never_cache_headers(response)
+            version = _get_cache_version()
+            # We also store the absolute expiration timestamp to avoid
+            # recomputing it on cache-reads.
+            expires_datetime = timestamp + timedelta(seconds=ttl)
+            cache.set(
+                _page_cache_key(request),
+                (
+                    response.content,
+                    response._headers,
+                    expires_datetime,
+                ),
+                ttl,
+                version=version
+            )
+            # See note in invalidate_cms_page_cache()
+            _set_cache_version(version)
     return response
 
 

--- a/cms/constants.py
+++ b/cms/constants.py
@@ -35,3 +35,7 @@ SLUG_REGEXP = '[0-9A-Za-z-_.//]+'
 EXPIRE_NOW = 0
 # HTTP Specification says max caching should only be up to one year.
 MAX_EXPIRATION_TTL = 365 * 24 * 3600
+
+PLUGIN_TOOLBAR_JS = "CMS._plugins.push(['cms-plugin-%(pk)s', %(config)s]);"
+
+PLACEHOLDER_TOOLBAR_JS = "CMS._plugins.push(['cms-placeholder-%(pk)s', %(config)s]);"

--- a/cms/context_processors.py
+++ b/cms/context_processors.py
@@ -2,6 +2,7 @@
 from django.utils import lru_cache
 from django.utils.functional import lazy
 
+from cms.toolbar.utils import get_toolbar_from_request
 from cms.utils.conf import get_cms_setting
 from cms.utils import get_template_from_request
 
@@ -19,13 +20,14 @@ def cms_settings(request):
         from menus.menu_pool import menu_pool
         return menu_pool.get_renderer(request)
 
+    toolbar = get_toolbar_from_request(request)
     # Now use lazy() to avoid getting the menu renderer
     # up until the point is needed.
     # lazy() does not memoize results, is why lru_cache is needed.
     _get_menu_renderer = lazy(_get_menu_renderer, MenuRenderer)
-
     return {
         'cms_menu_renderer': _get_menu_renderer(),
+        'cms_content_renderer': toolbar.content_renderer,
         'CMS_MEDIA_URL': get_cms_setting('MEDIA_URL'),
         'CMS_TEMPLATE': lambda: get_template_from_request(request),
     }

--- a/cms/models/placeholdermodel.py
+++ b/cms/models/placeholdermodel.py
@@ -74,6 +74,10 @@ class Placeholder(models.Model):
         name = _(name)
         return name
 
+    def get_extra_context(self, template=None):
+        from cms.utils.placeholder import get_placeholder_conf
+        return get_placeholder_conf("extra_context", self.slot, template, {})
+
     def get_add_url(self):
         return self._get_url('add_plugin')
 
@@ -163,14 +167,25 @@ class Placeholder(models.Model):
         '''
         Set editable = False to disable front-end rendering for this render.
         '''
-        from cms.plugin_rendering import render_placeholder
-        if not 'request' in context:
-            return '<!-- missing request -->'
+        content_renderer = context.get('cms_content_renderer')
+
+        if not content_renderer:
+            return '<!-- missing cms_content_renderer -->'
+
         width = width or self.default_width
+
         if width:
             context['width'] = width
-        return render_placeholder(self, context, lang=lang, editable=editable,
-                                  use_cache=use_cache)
+
+        content = content_renderer.render_placeholder(
+            self,
+            context,
+            language=lang,
+            editable=editable,
+            use_cache=use_cache,
+        )
+        return content
+
 
     def _get_related_objects(self):
         fields = self._meta._get_fields(

--- a/cms/page_rendering.py
+++ b/cms/page_rendering.py
@@ -27,7 +27,6 @@ def render_page(request, page, current_language, slug):
         return _handle_no_page(request, slug)
 
     response = TemplateResponse(request, template_name, context)
-
     response.add_post_render_callback(set_page_cache)
 
     # Add headers for X Frame Options - this really should be changed upon moving to class based views

--- a/cms/plugin_base.py
+++ b/cms/plugin_base.py
@@ -8,7 +8,7 @@ from django.shortcuts import render_to_response
 from django import forms
 from django.contrib import admin
 from django.contrib import messages
-from django.core.exceptions import ImproperlyConfigured
+from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.template.defaultfilters import force_escape
 from django.utils import six
 from django.utils.encoding import force_text, python_2_unicode_compatible, smart_str
@@ -96,7 +96,6 @@ class CMSPluginBase(six.with_metaclass(CMSPluginBaseMetaclass, admin.ModelAdmin)
 
     form = None
     change_form_template = "admin/cms/page/plugin/change_form.html"
-    frontend_edit_template = 'cms/toolbar/plugin.html'
     # Should the plugin be rendered in the admin?
     admin_preview = False
 
@@ -150,11 +149,17 @@ class CMSPluginBase(six.with_metaclass(CMSPluginBaseMetaclass, admin.ModelAdmin)
             warnings.warn('CMSPlugin.render_template attribute is deprecated '
                           'and it will be removed in version 3.2; please move'
                           'template in plugin classes', DeprecationWarning)
-            return getattr(instance, 'render_template', False)
+            template = getattr(instance, 'render_template', False)
         elif hasattr(self, 'get_render_template'):
-            return self.get_render_template(context, instance, placeholder)
+            template = self.get_render_template(context, instance, placeholder)
         elif getattr(self, 'render_template', False):
-            return getattr(self, 'render_template', False)
+            template = getattr(self, 'render_template', False)
+        else:
+            template = None
+
+        if not template:
+            raise ValidationError("plugin has no render_template: %s" % self.__class__)
+        return template
 
     @classmethod
     def get_render_queryset(cls):
@@ -386,22 +391,23 @@ class CMSPluginBase(six.with_metaclass(CMSPluginBaseMetaclass, admin.ModelAdmin)
         from cms.plugin_pool import plugin_pool
         return plugin_pool.get_all_plugins()
 
-    def get_child_classes(self, slot, page):
+    @classmethod
+    def get_child_classes(cls, slot, page):
         """
         Returns a list of plugin types that can be added
         as children to this plugin.
         """
         # Placeholder overrides are highest in priority
-        child_classes = self.get_child_class_overrides(slot, page)
+        child_classes = cls.get_child_class_overrides(slot, page)
 
         if child_classes:
             return child_classes
 
         # Get all child plugin candidates
-        installed_plugins = self.get_child_plugin_candidates(slot, page)
+        installed_plugins = cls.get_child_plugin_candidates(slot, page)
 
         child_classes = []
-        plugin_type = self.__class__.__name__
+        plugin_type = cls.__name__
 
         # The following will go through each
         # child plugin candidate and check if
@@ -422,14 +428,15 @@ class CMSPluginBase(six.with_metaclass(CMSPluginBaseMetaclass, admin.ModelAdmin)
                 continue
         return child_classes
 
-    def get_parent_classes(self, slot, page):
+    @classmethod
+    def get_parent_classes(cls, slot, page):
         from cms.utils.placeholder import get_placeholder_conf
 
         template = page and page.get_template() or None
 
         # config overrides..
         ph_conf = get_placeholder_conf('parent_classes', slot, template, default={})
-        parent_classes = ph_conf.get(self.__class__.__name__, self.parent_classes)
+        parent_classes = ph_conf.get(cls.__name__, cls.parent_classes)
         return parent_classes
 
     def get_action_options(self):

--- a/cms/plugin_pool.py
+++ b/cms/plugin_pool.py
@@ -19,6 +19,7 @@ from cms.utils.compat.dj import is_installed
 
 
 class PluginPool(object):
+
     def __init__(self):
         self.plugins = {}
         self.discovered = False
@@ -235,5 +236,6 @@ class PluginPool(object):
         self.discover_plugins()
         self.set_plugin_meta()
         return [plugin.__name__ for plugin in self.plugins.values() if plugin.system]
+
 
 plugin_pool = PluginPool()

--- a/cms/plugin_rendering.py
+++ b/cms/plugin_rendering.py
@@ -1,19 +1,20 @@
 # -*- coding: utf-8 -*-
-from copy import copy
+from collections import deque
 
 from classytags.utils import flatten_context
 from django.template import Template, Context
-from django.template.loader import render_to_string
-from django.utils import six
+from django.template.loader import get_template
+from django.utils.functional import cached_property
 from django.utils.safestring import mark_safe
 
 from cms.cache.placeholder import get_placeholder_cache, set_placeholder_cache
-from cms.models.placeholdermodel import Placeholder
+from cms.exceptions import PlaceholderNotFound
 from cms.plugin_processors import (plugin_meta_context_processor, mark_safe_plugin_processor)
+from cms.toolbar.utils import get_toolbar_from_request
 from cms.utils import get_language_from_request
 from cms.utils.conf import get_cms_setting, get_site_id
 from cms.utils.django_load import iterload_objects
-from cms.utils.placeholder import get_toolbar_plugin_struct
+from cms.utils.placeholder import get_toolbar_plugin_struct, restore_sekizai_context
 
 
 DEFAULT_PLUGIN_CONTEXT_PROCESSORS = (
@@ -24,6 +25,469 @@ DEFAULT_PLUGIN_CONTEXT_PROCESSORS = (
 DEFAULT_PLUGIN_PROCESSORS = (
     mark_safe_plugin_processor,
 )
+
+
+class ContentRenderer(object):
+
+    def __init__(self, request):
+        self.request = request
+        self.request_language = get_language_from_request(self.request)
+        self._cached_templates = {}
+        self._placeholders_content_cache = {}
+        self._placeholders_by_page_cache = {}
+        self._rendered_placeholders = deque()
+        self._rendered_static_placeholders = deque()
+        self._rendered_plugins_by_placeholder = {}
+
+    @cached_property
+    def current_page(self):
+        return self.request.current_page
+
+    @cached_property
+    def toolbar(self):
+        return get_toolbar_from_request(self.request)
+
+    @cached_property
+    def plugin_pool(self):
+        import cms.plugin_pool
+        return cms.plugin_pool.plugin_pool
+
+    @cached_property
+    def registered_plugins(self):
+        return self.plugin_pool.get_all_plugins()
+
+    @cached_property
+    def placeholder_toolbar_template(self):
+        return self.get_cached_template('cms/toolbar/placeholder.html')
+
+    @cached_property
+    def drag_item_template(self):
+        return self.get_cached_template('cms/toolbar/dragitem.html')
+
+    @cached_property
+    def drag_item_menu_template(self):
+        return self.get_cached_template('cms/toolbar/dragitem_menu.html')
+
+    @cached_property
+    def dragbar_template(self):
+        return self.get_cached_template('cms/toolbar/dragbar.html')
+
+    def user_is_on_edit_mode(self):
+        return self.toolbar.edit_mode or self.toolbar.show_toolbar
+
+    def placeholder_cache_is_enabled(self):
+        if not get_cms_setting('PLACEHOLDER_CACHE'):
+            return False
+        if self.request.user.is_staff:
+            return False
+        return not self.user_is_on_edit_mode()
+
+    def get_cached_template(self, template):
+        if isinstance(template, Template):
+            return template
+
+        if not template in self._cached_templates:
+            self._cached_templates[template] = get_template(template)
+        return self._cached_templates[template]
+
+    def get_rendered_plugins_cache(self, placeholder):
+        blank = {
+            'plugins': [],
+            'plugin_parents': {},
+            'plugin_children': {},
+        }
+        return self._rendered_plugins_by_placeholder.get(placeholder.pk, blank)
+
+    def get_rendered_placeholders(self):
+        return self._rendered_placeholders
+
+    def get_rendered_static_placeholders(self):
+        return self._rendered_static_placeholders
+
+    def render_placeholder(self, placeholder, context, language=None, page=None,
+                           editable=False, use_cache=False, nodelist=None, width=None):
+        from sekizai.helpers import Watcher
+        from cms.utils.plugins import get_plugins
+
+        language = language or self.request_language
+        editable = editable and self.toolbar.edit_mode
+
+        if use_cache and not editable and placeholder.cache_placeholder:
+            use_cache = self.placeholder_cache_is_enabled()
+        else:
+            use_cache = False
+
+        if page:
+            site_id = page.site_id
+            template = page.get_template()
+        else:
+            site_id = get_site_id(None)
+            template = None
+
+        if use_cache:
+            cached_value = self._get_cached_placeholder_content(
+                placeholder=placeholder,
+                site_id=site_id,
+                language=language,
+            )
+        else:
+            cached_value = None
+
+        if cached_value is not None:
+            # User has opted to use the cache
+            # and there is something in the cache
+            restore_sekizai_context(context, cached_value['sekizai'])
+            return mark_safe(cached_value['content'])
+
+        context.push()
+
+        width = width or placeholder.default_width
+
+        if width:
+            context['width'] = width
+
+        # Add extra context as defined in settings, but do not overwrite existing context variables,
+        # since settings are general and database/template are specific
+        # TODO this should actually happen as a plugin context processor, but these currently overwrite
+        # existing context -- maybe change this order?
+        for key, value in placeholder.get_extra_context(template).items():
+            if key not in context:
+                context[key] = value
+
+        if use_cache:
+            watcher = Watcher(context)
+
+        plugins = get_plugins(
+            request=self.request,
+            placeholder=placeholder,
+            template=template,
+            lang=language,
+        )
+
+        if plugins:
+            plugin_content = self.render_plugins(
+                plugins=plugins,
+                context=context,
+                placeholder=placeholder,
+                editable=editable,
+            )
+            placeholder_content = ''.join(plugin_content)
+        elif nodelist:
+            # should be nodelist from a template
+            placeholder_content = nodelist.render(context)
+        else:
+            placeholder_content = ''
+
+        if use_cache:
+            content = {
+                'content': placeholder_content,
+                'sekizai': watcher.get_changes(),
+            }
+            set_placeholder_cache(
+                placeholder,
+                lang=language,
+                site_id=site_id,
+                content=content,
+                request=self.request,
+            )
+
+        if editable:
+            toolbar_content = self.render_editable_placeholder(
+                placeholder=placeholder,
+                context=context,
+                language=language,
+            )
+        else:
+            toolbar_content = ''
+
+        if placeholder not in self._rendered_placeholders:
+            # First time this placeholder is rendered
+            if not self.toolbar._cache_disabled:
+                # The toolbar middleware needs to know if the response
+                # is to be cached.
+                # Set the _cache_disabled flag to the value of cache_placeholder
+                # only if the flag is False (meaning cache is enabled).
+                self.toolbar._cache_disabled = not placeholder.cache_placeholder
+            self._rendered_placeholders.append(placeholder)
+
+        context.pop()
+        return mark_safe(toolbar_content + placeholder_content)
+
+    def render_page_placeholder(self, slot, context, inherit, nodelist=None):
+        current_page = self.current_page
+
+        if not current_page:
+            return
+
+        content = self._render_page_placeholder(
+            context=context,
+            slot=slot,
+            page=current_page,
+            editable=True,
+            nodelist=nodelist,
+        )
+
+        # don't display inherited plugins in edit mode, so that the user doesn't
+        # mistakenly edit/delete them. This is a fix for issue #1303. See the discussion
+        # there for possible enhancements
+        if not inherit or self.toolbar.edit_mode:
+            return content
+
+        pages = list(reversed(current_page.get_cached_ancestors()))
+
+        for page in pages:
+            # nodelist is set to None to avoid rendering the nodes inside
+            # a {% placeholder or %} block tag.
+            # When placeholder inheritance is used, we only care about placeholders
+            # with plugins.
+            inherited_content = self._render_page_placeholder(
+                context=context,
+                slot=slot,
+                page=page,
+                nodelist=None,
+                editable=False,
+            )
+
+            if inherited_content:
+                return inherited_content
+        return content
+
+    def render_static_placeholder(self, static_placeholder, context, nodelist=None):
+        user = self.request.user
+
+        if self.toolbar.edit_mode and user.has_perm('cms.edit_static_placeholder'):
+            placeholder = static_placeholder.draft
+            editable = True
+            use_cache = False
+        else:
+            placeholder = static_placeholder.public
+            editable = False
+            use_cache = True
+
+        # I really don't like these impromptu flags...
+        placeholder.is_static = True
+
+        content = self.render_placeholder(
+            placeholder,
+            context=context,
+            editable=editable,
+            use_cache=use_cache,
+            nodelist=nodelist,
+        )
+
+        if static_placeholder not in self._rendered_static_placeholders:
+            # First time this static placeholder is rendered
+            self._rendered_static_placeholders.append(static_placeholder)
+        return content
+
+    def render_plugin(self, instance, context, placeholder=None, editable=False):
+        if not placeholder:
+            placeholder = instance.placeholder
+
+        instance, plugin = instance.get_plugin_instance()
+
+        if not instance or not plugin.render_plugin:
+            return ''
+
+        context = PluginContext(context, instance, placeholder)
+        context = plugin.render(context, instance, placeholder.slot)
+
+        template = plugin._get_render_template(context, instance, placeholder)
+        template = self.get_cached_template(template)
+
+        content = template.render(context)
+
+        for processor in iterload_objects(get_cms_setting('PLUGIN_PROCESSORS')):
+            content = processor(instance, placeholder, content, context)
+
+        if editable:
+            content = self.render_editable_plugin(
+                instance,
+                context=context,
+                plugin_class=plugin,
+                placeholder=placeholder,
+                content=content,
+            )
+            placeholder_cache = self._rendered_plugins_by_placeholder[placeholder.pk]
+
+            plugins_cache = placeholder_cache.setdefault('plugins', [])
+            plugins_cache.append(instance)
+
+        for processor in DEFAULT_PLUGIN_PROCESSORS:
+            content = processor(instance, placeholder, content, context)
+        return content
+
+    def render_editable_plugin(self, instance, context, plugin_class,
+                               placeholder=None, content=''):
+        if not placeholder:
+            placeholder = instance.placeholder
+
+        # this is fine. I'm fine.
+        output = ('<template class="cms-plugin '
+                  'cms-plugin-start cms-plugin-%(pk)s"></template>%(content)s'
+                  '<template class="cms-plugin cms-plugin-end cms-plugin-%(pk)s"></template>')
+        try:
+            # Compatibility with CMS < 3.4
+            template = self.get_cached_template(plugin_class.frontend_edit_template)
+        except AttributeError:
+            content = output % {'pk': instance.pk, 'content': content}
+        else:
+            content = template.render(context)
+
+        plugin_type = instance.plugin_type
+        placeholder_cache = self._rendered_plugins_by_placeholder.setdefault(placeholder.pk, {})
+
+        parents_cache = placeholder_cache.setdefault('plugin_parents', {})
+        children_cache = placeholder_cache.setdefault('plugin_children', {})
+
+        if plugin_type not in parents_cache:
+            parent_classes = plugin_class.get_parent_classes(
+                slot=placeholder.slot,
+                page=self.current_page,
+            )
+            parents_cache[plugin_type] = parent_classes or []
+
+        if plugin_type not in children_cache:
+            child_classes = plugin_class.get_child_classes(
+                slot=placeholder.slot,
+                page=self.current_page,
+            )
+            children_cache[plugin_type] = child_classes or []
+        return content
+
+    def render_editable_placeholder(self, placeholder, context, language):
+        plugin_menu = get_toolbar_plugin_struct(
+            plugins=self.registered_plugins,
+            slot=placeholder.slot,
+            page=placeholder.page,
+        )
+        new_context = {
+            'plugin_menu': plugin_menu,
+            'placeholder': placeholder,
+            'language': language,
+        }
+
+        with context.push(new_context):
+            return self.placeholder_toolbar_template.render(context.flatten())
+
+    def render_plugins(self, plugins, context, placeholder=None, editable=False):
+        total = len(plugins)
+
+        for index, plugin in enumerate(plugins):
+            plugin._render_meta.total = total
+            plugin._render_meta.index = index
+            yield self.render_plugin(plugin, context, placeholder, editable)
+
+    def _get_cached_placeholder_content(self, placeholder, site_id, language):
+        """
+        Returns a dictionary mapping placeholder content and sekizai data.
+        Returns None if no cache is present.
+        """
+        # Placeholders can be rendered multiple times under different sites
+        # it's important to have a per-site "cache".
+        site_cache = self._placeholders_content_cache.setdefault(site_id, {})
+        # Placeholders can be rendered multiple times under different languages
+        # it's important to have a per-language "cache".
+        language_cache = site_cache.setdefault(language, {})
+
+        if placeholder.pk not in language_cache:
+            cached_value = get_placeholder_cache(
+                placeholder,
+                lang=language,
+                site_id=site_id,
+                request=self.request,
+            )
+
+            if cached_value != None:
+                # None means nothing in the cache
+                # Anything else is a valid value
+                language_cache[placeholder.pk] = cached_value
+        return language_cache.get(placeholder.pk)
+
+    def _get_page_placeholder(self, context, page, slot):
+        """
+        Returns a Placeholder instance attached to page that
+        matches the given slot.
+
+        A PlaceholderNotFound is raised if the placeholder is
+        not present on the page template.
+        """
+        placeholder_cache = self._placeholders_by_page_cache
+
+        if page.pk not in placeholder_cache:
+            # Instead of loading plugins for this one placeholder
+            # try and load them for all placeholders on the page.
+            self._preload_placeholders_for_page(page)
+
+        try:
+            placeholder = placeholder_cache[page.pk][slot]
+        except KeyError:
+            message = '"%s" placeholder not found' % slot
+            raise PlaceholderNotFound(message)
+        return placeholder
+
+    def _render_page_placeholder(self, context, slot, page, editable=True, nodelist=None):
+        """
+        Renders a placeholder attached to a page.
+        """
+        try:
+            placeholder = self._get_page_placeholder(context, page, slot)
+        except PlaceholderNotFound:
+            if nodelist:
+                return nodelist.render(context)
+            return ''
+
+        content = self.render_placeholder(
+            placeholder,
+            context=context,
+            page=page,
+            editable=editable,
+            use_cache=True,
+            nodelist=nodelist,
+        )
+        return content
+
+    def _preload_placeholders_for_page(self, page):
+        """
+        Populates the internal plugin cache of each placeholder
+        in the given page if the placeholder has not been
+        previously cached.
+        """
+        from cms.utils.plugins import assign_plugins
+
+        site_id = page.site_id
+        placeholders = page.rescan_placeholders().values()
+
+        if self.placeholder_cache_is_enabled():
+            _cached_content = self._get_cached_placeholder_content
+            # Only prefetch placeholder plugins if the placeholder
+            # has not been cached.
+            placeholders_to_fetch = [
+                placeholder for placeholder in placeholders
+                if _cached_content(placeholder, site_id, self.request_language) == None]
+        else:
+            # cache is disabled, prefetch plugins for all
+            # placeholders in the page.
+            placeholders_to_fetch = placeholders
+
+        if placeholders_to_fetch:
+            assign_plugins(
+                request=self.request,
+                placeholders=placeholders_to_fetch,
+                template=page.get_template(),
+                lang=self.request_language,
+            )
+
+        # Internal cache mapping placeholder slots
+        # to placeholder instances.
+        page_placeholder_cache = {}
+
+        for placeholder in placeholders:
+            # Save a query when the placeholder toolbar is rendered.
+            placeholder.page = page
+            page_placeholder_cache[placeholder.slot] = placeholder
+
+        self._placeholders_by_page_cache[page.pk] = page_placeholder_cache
 
 
 class PluginContext(Context):
@@ -45,208 +509,3 @@ class PluginContext(Context):
             self.update(processor(instance, placeholder, self))
         for processor in processors:
             self.update(processor(instance, placeholder, self))
-
-
-def render_plugin(context, instance, placeholder, template, processors=None, current_app=None):
-    """
-    Renders a single plugin and applies the post processors to it's rendered
-    content.
-    """
-    request = context.get('request')
-
-    if request:
-        toolbar = getattr(request, 'toolbar', None)
-
-        if current_app:
-            request.current_app = current_app
-    else:
-        toolbar = None
-
-    if toolbar and isinstance(template, six.string_types):
-        template = toolbar.get_cached_template(template)
-
-    if not processors:
-        processors = []
-    if isinstance(template, six.string_types):
-        content = render_to_string(template, flatten_context(context))
-    elif (isinstance(template, Template) or (hasattr(template, 'template') and
-          hasattr(template, 'render') and isinstance(template.template, Template))):
-        content = template.render(context)
-    else:
-        content = ''
-    for processor in iterload_objects(get_cms_setting('PLUGIN_PROCESSORS')):
-        content = processor(instance, placeholder, content, context)
-    for processor in processors:
-        content = processor(instance, placeholder, content, context)
-    for processor in DEFAULT_PLUGIN_PROCESSORS:
-        content = processor(instance, placeholder, content, context)
-    return content
-
-
-def render_plugins(plugins, context, placeholder, processors=None):
-    """
-    Renders a collection of plugins with the given context, using the appropriate processors
-    for a given placeholder name, and returns a list containing a "rendered content" string
-    for each plugin.
-
-    This is the main plugin rendering utility function, use this function rather than
-    Plugin.render_plugin().
-    """
-    out = []
-    total = len(plugins)
-    for index, plugin in enumerate(plugins):
-        plugin._render_meta.total = total
-        plugin._render_meta.index = index
-        context.push()
-        out.append(plugin.render_plugin(context, placeholder, processors=processors))
-        context.pop()
-    return out
-
-
-def render_placeholder(placeholder, context_to_copy, name_fallback="Placeholder",
-                       lang=None, default=None, editable=True, use_cache=True):
-    """
-    Renders plugins for a placeholder on the given page using shallow copies of the
-    given context, and returns a string containing the rendered output.
-
-    Set editable = False to disable front-end editing for this placeholder
-    during rendering. This is primarily used for the "as" variant of the
-    render_placeholder tag.
-    """
-    from cms.utils.placeholder import get_placeholder_conf, restore_sekizai_context
-    from cms.utils.plugins import get_plugins
-    # these are always called before all other plugin context processors
-    from sekizai.helpers import Watcher
-
-    if not placeholder:
-        return
-    context = copy(context_to_copy)
-    context.push()
-    request = context['request']
-    if not hasattr(request, 'placeholders'):
-        request.placeholders = {}
-
-    # Prepend frontedit toolbar output if applicable
-    try:
-        toolbar = getattr(request, 'toolbar', None)
-    except AttributeError:
-        toolbar = None
-
-    if (toolbar and toolbar.edit_mode and toolbar.show_toolbar and
-            placeholder.is_editable and editable):
-        from cms.middleware.toolbar import toolbar_plugin_processor
-        processors = (toolbar_plugin_processor,)
-        edit = True
-    else:
-        processors = None
-        edit = False
-
-    if edit:
-        perms = (placeholder.has_change_permission(request) or not placeholder.cache_placeholder)
-        if not perms or placeholder.slot not in request.placeholders:
-            request.placeholders[placeholder.slot] = (placeholder, perms)
-        else:
-            request.placeholders[placeholder.slot] = (
-                placeholder, perms and request.placeholders[placeholder.slot][1]
-            )
-    else:
-        request.placeholders[placeholder.slot] = (
-            placeholder, False
-        )
-    if hasattr(placeholder, 'content_cache'):
-        return mark_safe(placeholder.content_cache)
-    page = placeholder.page if placeholder else None
-    if page:
-        site_id = page.site_id
-    else:
-        site_id = get_site_id(None)
-
-    # It's kind of duplicate of the similar call in `get_plugins`, but it's required
-    # to have a valid language in this function for `get_fallback_languages` to work
-    if lang:
-        save_language = lang
-    else:
-        lang = get_language_from_request(request)
-        save_language = lang
-
-    use_cache = use_cache and not request.user.is_authenticated()
-    if get_cms_setting('PLACEHOLDER_CACHE') and use_cache:
-        if not edit and placeholder and not hasattr(placeholder, 'cache_checked'):
-            cached_value = get_placeholder_cache(placeholder, lang, site_id, request)
-            if cached_value is not None:
-                restore_sekizai_context(context, cached_value['sekizai'])
-                return mark_safe(cached_value['content'])
-    if page:
-        template = page.template
-    else:
-        template = None
-
-    plugins = [plugin for plugin in get_plugins(request, placeholder, template, lang=lang)]
-
-    # Add extra context as defined in settings, but do not overwrite existing context variables,
-    # since settings are general and database/template are specific
-    # TODO this should actually happen as a plugin context processor, but these currently overwrite
-    # existing context -- maybe change this order?
-    slot = getattr(placeholder, 'slot', None)
-    if slot:
-        for key, value in get_placeholder_conf("extra_context", slot, template, {}).items():
-            if key not in context:
-                context[key] = value
-    content = []
-    watcher = Watcher(context)
-    content.extend(render_plugins(plugins, context, placeholder, processors))
-    toolbar_content = ''
-
-    if edit and editable:
-        if not hasattr(request.toolbar, 'placeholder_list'):
-            request.toolbar.placeholder_list = []
-        if placeholder not in request.toolbar.placeholder_list:
-            request.toolbar.placeholder_list.append(placeholder)
-        toolbar_content = mark_safe(render_placeholder_toolbar(placeholder, context, name_fallback, save_language))
-    if content:
-        content = mark_safe("".join(content))
-    elif default:
-        # should be nodelist from a template
-        content = mark_safe(default.render(context_to_copy))
-    else:
-        content = ''
-    context['content'] = content
-    context['placeholder'] = toolbar_content
-    context['edit'] = edit
-    result = render_to_string("cms/toolbar/content.html", flatten_context(context))
-    changes = watcher.get_changes()
-    if use_cache and placeholder.cache_placeholder and get_cms_setting('PLACEHOLDER_CACHE'):
-        content = {'content': result, 'sekizai': changes}
-        set_placeholder_cache(placeholder, lang, site_id, content=content, request=request)
-    context.pop()
-    return result
-
-
-def render_placeholder_toolbar(placeholder, context, name_fallback, save_language):
-    from cms.plugin_pool import plugin_pool
-    request = context['request']
-    page = placeholder.page if placeholder else None
-    if not page:
-        page = getattr(request, 'current_page', None)
-    if page:
-        if name_fallback and not placeholder:
-            placeholder = Placeholder.objects.create(slot=name_fallback)
-            page.placeholders.add(placeholder)
-            placeholder.page = page
-    if placeholder:
-        slot = placeholder.slot
-    else:
-        slot = None
-    context.push()
-
-    all_plugins = plugin_pool.get_all_plugins()
-    plugin_types = [cls.__name__ for cls in plugin_pool.get_all_plugins(slot, page)]
-
-    context['allowed_plugins'] = plugin_types + plugin_pool.get_system_plugins()
-    context['plugin_menu'] = get_toolbar_plugin_struct(all_plugins, slot=slot, page=page)
-    context['placeholder'] = placeholder
-    context['language'] = save_language
-    context['page'] = page
-    toolbar = render_to_string("cms/toolbar/placeholder.html", flatten_context(context))
-    context.pop()
-    return toolbar

--- a/cms/templates/cms/toolbar/clipboard.html
+++ b/cms/templates/cms/toolbar/clipboard.html
@@ -1,17 +1,17 @@
 {% load i18n cms_admin %}
 
 {% if request.toolbar.edit_mode or request.toolbar.build_mode %}
-{% with slot="clipboard" clipboard_plugins=local_toolbar.get_clipboard_plugins|slice:":1" %}
+{% with clipboard_plugins=local_toolbar.get_clipboard_plugins|slice:":1" %}
 {% if clipboard_plugins %}
 <div class="cms-clipboard" data-title="{% trans 'Clipboard' %}">
     {% for plugin in clipboard_plugins %}
     <div class="cms-plugins">
-        {% render_plugin_toolbar_config plugin slot %}
+        {% render_plugin_toolbar_config plugin %}
     </div>
     {% endfor %}
     <div class="cms-clipboard-containers cms-dragarea cms-draggables">
         {% for plugin in clipboard_plugins %}
-            {% with clipboard="true" %}{% include request.toolbar.drag_item_template with plugin=plugin %}{% endwith %}
+            {% with clipboard="true" %}{% include cms_content_renderer.drag_item_template with plugin=plugin %}{% endwith %}
         {% endfor %}
     </div>
 </div>

--- a/cms/templates/cms/toolbar/dragitem.html
+++ b/cms/templates/cms/toolbar/dragitem.html
@@ -57,7 +57,7 @@
         {% if allow_children %} cms-draggables{% endif %}">
         {% if plugin.child_plugin_instances %}
             {% for child in plugin.child_plugin_instances %}
-                {% include request.toolbar.drag_item_template with plugin=child disabled_child=disable_child_plugins %}
+                {% include cms_content_renderer.drag_item_template with plugin=child disabled_child=disable_child_plugins %}
             {% endfor %}
         {% endif %}
     </div>

--- a/cms/templates/cms/toolbar/placeholder.html
+++ b/cms/templates/cms/toolbar/placeholder.html
@@ -1,29 +1,13 @@
 {% spaceless %}
-{% load i18n l10n sekizai_tags %}
+{% load cms_js_tags i18n l10n sekizai_tags %}
 
 <div class="cms-placeholder cms-placeholder-{{ placeholder.pk|unlocalize }}"></div>
 {% language request.toolbar.toolbar_language %}
 <script id="cms-plugin-child-classes-{{ placeholder.pk|unlocalize }}" type="text/cms-template">
-    {% include request.toolbar.drag_item_menu_template %}
-</script>
-{% endlanguage %}
-
+    {% include cms_content_renderer.drag_item_menu_template %}
+</script>{% endlanguage %}
 {% endspaceless %}{% addtoblock "js" %}
 {% language request.toolbar.toolbar_language %}
-<script>
-CMS._plugins.push(['cms-placeholder-{{ placeholder.pk|unlocalize }}', {
-    type: 'placeholder',
-    name: '{{ placeholder.get_label|escapejs }}',
-    page_language: '{{ LANGUAGE_CODE }}',
-    placeholder_id: '{{ placeholder.pk|unlocalize }}',
-    plugin_language: '{{ language }}',
-    plugin_restriction: [{% for module in allowed_plugins %}"{{ module }}"{% if not forloop.last %}, {% endif %}{% endfor %}],
-    addPluginHelpTitle: '{% trans "Add plugin to placeholder" %} "{{ placeholder.get_label|escapejs }}"',
-    urls: {
-        add_plugin: '{{ placeholder.get_add_url }}',
-        copy_plugin: '{{ placeholder.get_copy_url }}'
-    }
-}]);
-</script>
+<script>{% render_placeholder_toolbar_js placeholder language cms_content_renderer %}</script>
 {% endlanguage %}
 {% endaddtoblock %}

--- a/cms/templates/cms/toolbar/toolbar.html
+++ b/cms/templates/cms/toolbar/toolbar.html
@@ -93,14 +93,14 @@
     {# start: structure #}
     <div class="cms-structure">
         <div class="cms-structure-content" data-touch-action="pan-y">
-            {% for placeholder in request.toolbar.placeholder_list %}
+            {% for placeholder in cms_content_renderer.get_rendered_placeholders %}
             <div class="cms-dragarea cms-dragarea-{{ placeholder.pk|unlocalize }}{% if placeholder.is_static %} cms-dragarea-static{% endif %}">
-                {% include request.toolbar.dragbar_template with placeholder=placeholder language=language %}
+                {% include cms_content_renderer.dragbar_template with placeholder=placeholder language=language %}
 
                 <div class="cms-draggables cms-draggables-root">
                     <div class="cms-draggables-empty">{% trans "Drop a plugin here" %}</div>
                     {% for plugin in placeholder.get_cached_plugins %}
-                        {% include request.toolbar.drag_item_template with plugin=plugin slot=slot %}
+                        {% include cms_content_renderer.drag_item_template with plugin=plugin slot=slot %}
                     {% endfor %}
                 </div>
             </div>

--- a/cms/templatetags/cms_js_tags.py
+++ b/cms/templatetags/cms_js_tags.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 import json
+import functools
 
 from classytags.core import Tag, Options
+from cms.toolbar.utils import get_placeholder_toolbar_js, get_plugin_toolbar_js
 from cms.utils.encoder import SafeJSONEncoder
 from django import template
 from django.utils.safestring import mark_safe
@@ -23,6 +25,41 @@ def bool(value):
         return 'true'
     else:
         return 'false'
+
+
+@register.simple_tag(takes_context=False)
+def render_placeholder_toolbar_js(placeholder, render_language, content_renderer):
+    page = placeholder.page
+    slot = placeholder.slot
+    placeholder_cache = content_renderer.get_rendered_plugins_cache(placeholder)
+    rendered_plugins = placeholder_cache['plugins']
+    plugin_parents = placeholder_cache['plugin_parents']
+    plugin_children = placeholder_cache['plugin_children']
+    plugin_pool = content_renderer.plugin_pool
+    plugin_types = [cls.__name__ for cls in plugin_pool.get_all_plugins(slot, page)]
+    allowed_plugins = plugin_types + plugin_pool.get_system_plugins()
+
+    get_toolbar_js = functools.partial(
+        get_plugin_toolbar_js,
+        request_language=content_renderer.request_language,
+    )
+
+    def _render_plugin_js(plugin):
+        content = get_toolbar_js(
+            plugin,
+            children=plugin_children[plugin.plugin_type],
+            parents=plugin_parents[plugin.plugin_type],
+        )
+        return content
+
+    plugin_js_output = ''.join(_render_plugin_js(plugin) for plugin in rendered_plugins)
+    placeholder_js_output = get_placeholder_toolbar_js(
+        placeholder=placeholder,
+        request_language=content_renderer.request_language,
+        render_language=render_language,
+        allowed_plugins=allowed_plugins,
+    )
+    return mark_safe(plugin_js_output + '\n' + placeholder_js_output)
 
 
 class JavascriptString(Tag):

--- a/cms/test_utils/testcases.py
+++ b/cms/test_utils/testcases.py
@@ -22,6 +22,7 @@ from django.utils.six.moves.urllib.parse import unquote, urljoin
 from menus.menu_pool import menu_pool
 
 from cms.api import create_page
+from cms.plugin_rendering import ContentRenderer
 from cms.models import Page
 from cms.models.permissionmodels import (
     GlobalPagePermission,
@@ -382,7 +383,12 @@ class BaseCMSTestCase(object):
         context = {}
         request = self.get_request(path, page=page)
         context['request'] = request
+        context['cms_content_renderer'] = self.get_content_renderer(request=request)
         return Context(context)
+
+    def get_content_renderer(self, request=None):
+        request = request or self.get_request()
+        return ContentRenderer(request)
 
     def get_request(self, path=None, language=None, post_data=None, enforce_csrf_checks=False, page=None):
         factory = RequestFactory()

--- a/cms/tests/test_alias.py
+++ b/cms/tests/test_alias.py
@@ -4,7 +4,7 @@ from cms.cms_plugins import AliasPlugin
 from cms.models import Placeholder, AliasPluginModel
 from cms.test_utils.testcases import CMSTestCase
 from cms.utils.urlutils import admin_reverse
-from django.template import Template, Context
+from django.template import Template
 
 
 class AliasTestCase(CMSTestCase):
@@ -28,8 +28,7 @@ class AliasTestCase(CMSTestCase):
         self.assertEqual(response.status_code, 403)
         instance = AliasPluginModel.objects.all()[0]
         admin = AliasPlugin()
-        request = self.get_request("/")
-        context = Context({'request': request})
+        context = self.get_context()
         admin.render(context, instance, ph_en)
         self.assertEqual(context['content'], "I'm the first")
 
@@ -105,14 +104,8 @@ class AliasTestCase(CMSTestCase):
         page_en = api.create_page("PluginOrderPage", "col_two.html", "en",
                                   slug="page1", published=True, in_navigation=True)
         ph_en = page_en.placeholders.get(slot="col_left")
-        class FakeRequest(object):
-            current_page = page_en
-            user = self.get_superuser()
-            GET = {'language': 'en'}
-            META = {"CSRF_COOKIE_USED": True}
-        request = FakeRequest()
-        template = Template('{% load cms_tags %}{% render_extra_menu_items placeholder %}')
-        context = Context({'request': request})
+        context = self.get_context(page=page_en)
         context['placeholder'] = ph_en
+        template = Template('{% load cms_tags %}{% render_extra_menu_items placeholder %}')
         output = template.render(context)
         self.assertTrue(len(output), 200)

--- a/cms/tests/test_page.py
+++ b/cms/tests/test_page.py
@@ -22,7 +22,6 @@ from cms.models.placeholdermodel import Placeholder
 from cms.models.pluginmodel import CMSPlugin
 from cms.signals import pre_save_page, post_save_page
 from cms.sitemaps import CMSSitemap
-from cms.templatetags.cms_tags import get_placeholder_content
 from cms.test_utils.testcases import CMSTestCase
 from cms.utils import get_cms_setting
 from cms.utils.i18n import force_language
@@ -708,9 +707,15 @@ class PagesTestCase(CMSTestCase):
             # trigger the get_languages query so it doesn't get in our way
             context = self.get_context(page=page)
             context['request'].current_page.get_languages()
+
+            content_renderer = context['cms_content_renderer']
             with self.assertNumQueries(4):
                 for i, placeholder in enumerate(placeholders):
-                    content = get_placeholder_content(context, context['request'], page, placeholder.slot, False, None)
+                    content = content_renderer.render_page_placeholder(
+                        placeholder.slot,
+                        context,
+                        inherit=False,
+                    )
                     for j in range(5):
                         self.assertIn('text-%d-%d' % (i, j), content)
                         self.assertIn('link-%d-%d' % (i, j), content)

--- a/cms/tests/test_permmod.py
+++ b/cms/tests/test_permmod.py
@@ -501,7 +501,8 @@ class PermissionModeratorTests(CMSTestCase):
         with self.login_user_context(self.user_non_global):
             response = self.client.get(url)
             self.assertEqual(response.status_code, 404)
-            # non logged in user
+
+        # non logged in user
         response = self.client.get(url)
         self.assertEqual(response.status_code, 404)
 

--- a/cms/tests/test_plugins.py
+++ b/cms/tests/test_plugins.py
@@ -1362,15 +1362,16 @@ class PluginManyToManyTestCase(PluginsTestBaseCase):
         ph_en = page_en.placeholders.get(slot="body")
         api.add_plugin(ph_en, "ArticleDynamicTemplatePlugin", "en", title="a title")
         api.add_plugin(ph_en, "ArticleDynamicTemplatePlugin", "en", title="custom template")
-        request = self.get_request(path=page_en.get_absolute_url())
+        context = self.get_context(path=page_en.get_absolute_url())
+        request = context['request']
         plugins = get_plugins(request, ph_en, page_en.template)
         for plugin in plugins:
             if plugin.title == 'custom template':
                 self.assertEqual(plugin.get_plugin_class_instance().get_render_template({}, plugin, ph_en), 'articles_custom.html')
-                self.assertTrue('Articles Custom template' in plugin.render_plugin({}, ph_en))
+                self.assertTrue('Articles Custom template' in plugin.render_plugin(context, ph_en))
             else:
                 self.assertEqual(plugin.get_plugin_class_instance().get_render_template({}, plugin, ph_en), 'articles.html')
-                self.assertFalse('Articles Custom template' in plugin.render_plugin({}, ph_en))
+                self.assertFalse('Articles Custom template' in plugin.render_plugin(context, ph_en))
 
     def test_add_plugin_with_m2m(self):
         # add a new text plugin

--- a/cms/tests/test_toolbar.py
+++ b/cms/tests/test_toolbar.py
@@ -1715,14 +1715,14 @@ class EditModelTemplateTagTest(ToolbarTestBase):
 '''
         request = self.get_page_request(page, user, edit=True)
         response = detail_view(request, ex1.pk, template_string=template_text)
-        self.assertContains(
-            response,
+        expected_output = (
             '<h1>'
             '<template class="cms-plugin cms-plugin-start cms-plugin-{0}-{1}-{2}-{3} cms-render-model"></template>'
             'char_1'
             '<template class="cms-plugin cms-plugin-end cms-plugin-{0}-{1}-{2}-{3} cms-render-model"></template>'
-            '</h1>'.format(
-                'placeholderapp', 'example1', 'callable_item', ex1.pk))
+            '</h1>'
+        ).format('placeholderapp', 'example1', 'callable_item', ex1.pk)
+        self.assertContains(response, expected_output)
 
     def test_admin_url_extra_field(self):
         user = self.get_staff()

--- a/cms/toolbar/utils.py
+++ b/cms/toolbar/utils.py
@@ -1,0 +1,66 @@
+import json
+import functools
+
+from django.template.defaultfilters import escapejs
+from django.utils.six import text_type
+from django.utils.translation import ugettext
+
+from cms.constants import PLACEHOLDER_TOOLBAR_JS, PLUGIN_TOOLBAR_JS
+from cms.utils.encoder import SafeJSONEncoder
+
+
+dump_json = functools.partial(json.dumps, cls=SafeJSONEncoder)
+
+
+def get_placeholder_toolbar_js(placeholder, request_language,
+                               render_language, allowed_plugins=None):
+    label = escapejs(placeholder.get_label() or '')
+    help_text = ugettext(
+        'Add plugin to placeholder "%(placeholder_label)s"'
+    ) % {'placeholder_label': label}
+
+    data = {
+        'type': 'placeholder',
+        'name': label,
+        'page_language': request_language,
+        'placeholder_id': text_type(placeholder.pk),
+        'plugin_language': request_language,
+        'plugin_restriction': allowed_plugins or [],
+        'addPluginHelpTitle': help_text,
+        'urls': {
+            'add_plugin': placeholder.get_add_url(),
+            'copy_plugin': placeholder.get_copy_url(),
+        }
+    }
+    return PLACEHOLDER_TOOLBAR_JS % {'pk': placeholder.pk, 'config': dump_json(data)}
+
+
+def get_plugin_toolbar_js(plugin, request_language, children=None, parents=None):
+    plugin_name = escapejs(plugin.get_plugin_name())
+    help_text = ugettext(
+        'Add plugin to %(plugin_name)s'
+    ) % {'plugin_name': plugin_name}
+
+    data = {
+        'type': 'plugin',
+        'page_language': request_language,
+        'placeholder_id': text_type(plugin.placeholder_id),
+        'plugin_name': plugin_name or '',
+        'plugin_type': plugin.plugin_type,
+        'plugin_id': text_type(plugin.pk),
+        'plugin_language': plugin.language or '',
+        'plugin_parent': text_type(plugin.parent_id or ''),
+        'plugin_order': '',
+        'plugin_restriction': children or [],
+        'plugin_parent_restriction': parents or [],
+        'onClose': False,
+        'addPluginHelpTitle': help_text,
+        'urls': plugin.get_action_urls(),
+    }
+    return PLUGIN_TOOLBAR_JS % {'pk': plugin.pk, 'config': dump_json(data)}
+
+
+def get_toolbar_from_request(request):
+    from .toolbar import EmptyToolbar
+
+    return getattr(request, 'toolbar', EmptyToolbar(request))

--- a/cms/utils/apphook_reload.py
+++ b/cms/utils/apphook_reload.py
@@ -22,7 +22,10 @@ use_threadlocal = False
 def ensure_urlconf_is_up_to_date():
     global_revision = get_global_revision()
     local_revision = get_local_revision()
-    if global_revision != local_revision:
+
+    if not local_revision:
+        set_local_revision(global_revision)
+    elif global_revision != local_revision:
         if settings.DEBUG:
             print("   New revision!!!! RELOAD!\n"
                   "      {0} ({1})\n"


### PR DESCRIPTION
The goal of this refactor was to simplify the logic behind plugin/placeholder rendering with speed as the motivator.

A quick test on my machine showed that a page with 300 plugins on CMS 3.3.1 takes about 2 seconds to load, with this branch it takes about 0.4 to 0.5 seconds.

All performance gains are due to the new structuring of the Python/Django code, I was unable to optimize the SQL queries involved in rendering as they were already heavily optimized.

Here's an overview of the changes:

New utilities
	`get_toolbar_from_request`

Removed internal functions
	`cms.middleware.toolbar.toolbar_plugin_processor`
	`cms.plugin_rendering.render_plugin`
	`cms.plugin_rendering.render_plugins`
	`cms.plugin_rendering.render_placeholder`
	`cms.plugin_rendering.render_placeholder_toolbar`
	`cms.templatetags.cms_tags._get_placeholder`
	`cms.templatetags.cms_tags.get_placeholder_content`
	`cms.templatetags.cms_tags._show_placeholder_for_page`

Removed internal attributes
	`request.placeholders`
	`request.toolbar.placeholder_list`
        `plugin_base.CMSPluginBase.frontend_edit_template`

Internal modifications
	`Placeholder.render()` now requires a `cms_content_renderer` instance in the context.
	`CMSPlugin.render()` now requires a `cms_content_renderer` instance in the context.
	`RenderPlugin` now requires a `cms_content_renderer` instance in the context.
	`CMSPluginBase.get_child_classes()` is now a class method for consistency with the other methods.
	`CMSPluginBase.get_parent_classes()`  is now a class method for consistency with the other methods.
	Moved in-memory template caching from the `CMSToolbar` class to the `ContentRenderer` class.