### PR TITLE
Fixed #5402 -- recursion error when referencing same Alias plugin

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@
   started on the disabled menu item on small screens.
 * Fixed a regression when standalone CMS Widgets wouldn't work due to
   non-existing JavaScript dependencies.
+* Fixed a possible recursion error when using the ``Alias`` plugin.
 
 
 === 3.3.1 (2016-07-13) ===

--- a/cms/cms_plugins.py
+++ b/cms/cms_plugins.py
@@ -36,6 +36,10 @@ class AliasPlugin(CMSPluginBase):
 
     def render(self, context, instance, placeholder):
         from cms.utils.plugins import downcast_plugins, build_plugin_tree
+
+        if instance.is_recursive():
+            return context
+
         request = context.get('request', None)
         context['instance'] = instance
         context['placeholder'] = placeholder

--- a/cms/models/aliaspluginmodel.py
+++ b/cms/models/aliaspluginmodel.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from django.db import models
+from django.db.models import Q
 from django.utils.encoding import force_text, python_2_unicode_compatible
 
 from cms.models import CMSPlugin, Placeholder
@@ -19,3 +20,19 @@ class AliasPluginModel(CMSPlugin):
             return "(%s) %s" % (force_text(self.plugin.get_plugin_name()), self.plugin.get_plugin_instance()[0])
         else:
             return force_text(self.alias_placeholder.get_label())
+
+    def is_recursive(self):
+        if self.plugin_id:
+            placeholder = self.plugin.placeholder_id
+        else:
+            placeholder = self.alias_placeholder_id
+
+        if not placeholder:
+            return False
+
+        plugins = AliasPluginModel.objects.filter(
+            plugin_type='AliasPlugin',
+            placeholder=placeholder,
+        )
+        plugins = plugins.filter(Q(plugin=self) | Q(alias_placeholder=self.placeholder_id))
+        return plugins.exists()


### PR DESCRIPTION
Fixed #5402

This prevents the recursion error by failing silently (not rendering the alias), thus allowing the user to remove the recursive plugin.

A better fix will be to detect this when pasting the plugin but this will come in the future when we add validation hooks for certain actions (pasting, moving, etc.)