### PR TITLE
Fix example in doc about ModelForm

### DIFF
--- a/docs/how_to/wizards.rst
+++ b/docs/how_to/wizards.rst
@@ -56,8 +56,9 @@ And you need a form::
     from django import forms
 
     class MyAppWizardForm(forms.ModelForm):
-        model = MyApp
-        exclude = []
+        class Meta:
+            model = MyApp
+            exclude = []
 
 
 That's it!


### PR DESCRIPTION
This fixes the bug that would cause the error:

    django.core.exceptions.ImproperlyConfigured: Please set entry 'model' attribute or use ModelForm subclass as a form