### PR TITLE
Fixed #5627 Do not set session cookie on every request when `CMS_TOOLBAR_ANONYMOUS_ON` is `False`

### DIFF
--- a/cms/middleware/toolbar.py
+++ b/cms/middleware/toolbar.py
@@ -77,8 +77,10 @@ class ToolbarMiddleware(object):
             if build in request.GET and not request.session.get('cms_build', False):
                 request.session['cms_build'] = True
         else:
-            request.session['cms_build'] = False
-            request.session['cms_edit'] = False
+            if request.session.get('cms_build'):
+                request.session['cms_build'] = False
+            if request.session.get('cms_edit'):
+                request.session['cms_edit'] = False
         if request.user.is_staff:
             try:
                 request.cms_latest_entry = LogEntry.objects.filter(

--- a/cms/tests/test_toolbar.py
+++ b/cms/tests/test_toolbar.py
@@ -364,8 +364,8 @@ class ToolbarTests(ToolbarTestBase):
         page = create_page("toolbar-page", "nav_playground.html", "en",
                            published=True)
         request = self.get_page_request(page, self.get_nonstaff(), edit=True)
-        self.assertFalse(request.session.get('cms_build', True))
-        self.assertFalse(request.session.get('cms_edit', True))
+        self.assertNotIn('cms_build', request.session)
+        self.assertNotIn('cms_edit', request.session)
 
     def test_hide_toolbar_disabled(self):
         page = create_page("toolbar-page", "nav_playground.html", "en",


### PR DESCRIPTION
I'm not sure how to test this. If someone can give me a hint I can add tests too.

If this can be backported to stable 3.3.x will be awesome