### PR TITLE
Removed deprecated features

### DIFF
--- a/cms/apphook_pool.py
+++ b/cms/apphook_pool.py
@@ -28,11 +28,6 @@ class ApphookPool(object):
         if app is None:
             return lambda app: self.register(app, discovering_apps)
 
-        if app.__module__.split('.')[-1] == 'cms_app':
-            warnings.warn('cms_app.py filename is deprecated, '
-                          'and it will be removed in version 3.4; '
-                          'please rename it to cms_apps.py', DeprecationWarning)
-
         if self.apphooks and not discovering_apps:
             return app
 
@@ -64,8 +59,6 @@ class ApphookPool(object):
                     pass
 
         else:
-            # FIXME: Remove in 3.4
-            load('cms_app')
             load('cms_apps')
 
         self.discovered = True

--- a/cms/models/pluginmodel.py
+++ b/cms/models/pluginmodel.py
@@ -562,58 +562,18 @@ class CMSPlugin(six.with_metaclass(PluginModelBase, MP_Node)):
         return data
 
     def get_add_url(self):
-        if self.add_url:
-            warnings.warn(
-                'The add_url property is deprecated, '
-                'and it will be removed in version 3.4; '
-                'please use the get_add_url method instead.',
-                DeprecationWarning
-            )
-            return self.add_url
         return self.placeholder.get_add_url()
 
     def get_edit_url(self):
-        if self.edit_url:
-            warnings.warn(
-                'The edit_url property is deprecated, '
-                'and it will be removed in version 3.4; '
-                'please use the get_edit_url method instead.',
-                DeprecationWarning
-            )
-            return self.edit_url
         return self.placeholder.get_edit_url(self.pk)
 
     def get_delete_url(self):
-        if self.delete_url:
-            warnings.warn(
-                'The delete_url property is deprecated, '
-                'and it will be removed in version 3.4; '
-                'please use the get_delete_url method instead.',
-                DeprecationWarning
-            )
-            return self.delete_url
         return self.placeholder.get_delete_url(self.pk)
 
     def get_move_url(self):
-        if self.move_url:
-            warnings.warn(
-                'The move_url property is deprecated, '
-                'and it will be removed in version 3.4; '
-                'please use the get_move_url method instead.',
-                DeprecationWarning
-            )
-            return self.move_url
         return self.placeholder.get_move_url()
 
     def get_copy_url(self):
-        if self.copy_url:
-            warnings.warn(
-                'The copy_url property is deprecated, '
-                'and it will be removed in version 3.4; '
-                'please use the get_copy_url method instead.',
-                DeprecationWarning
-            )
-            return self.copy_url
         return self.placeholder.get_copy_url()
 
     @property

--- a/cms/plugin_base.py
+++ b/cms/plugin_base.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import json
 import re
-import warnings
 
 from django.shortcuts import render_to_response
 
@@ -15,7 +14,7 @@ from django.utils.encoding import force_text, python_2_unicode_compatible, smart
 from django.utils.translation import ugettext_lazy as _
 
 from cms.constants import PLUGIN_MOVE_ACTION, PLUGIN_COPY_ACTION
-from cms.exceptions import SubClassNeededError, Deprecated
+from cms.exceptions import SubClassNeededError
 from cms.models import CMSPlugin
 from cms.utils import get_cms_setting
 
@@ -115,7 +114,6 @@ class CMSPluginBase(six.with_metaclass(CMSPluginBaseMetaclass, admin.ModelAdmin)
     parent_classes = None
 
     disable_child_plugins = False
-    disable_child_plugin = False  # DEPRECATED: REMOVE IN CMS v3.3
 
     cache = get_cms_setting('PLUGIN_CACHE')
     system = False
@@ -145,12 +143,7 @@ class CMSPluginBase(six.with_metaclass(CMSPluginBaseMetaclass, admin.ModelAdmin)
         self._cms_initial_attributes = {}
 
     def _get_render_template(self, context, instance, placeholder):
-        if getattr(instance, 'render_template', False):
-            warnings.warn('CMSPlugin.render_template attribute is deprecated '
-                          'and it will be removed in version 3.2; please move'
-                          'template in plugin classes', DeprecationWarning)
-            template = getattr(instance, 'render_template', False)
-        elif hasattr(self, 'get_render_template'):
+        if hasattr(self, 'get_render_template'):
             template = self.get_render_template(context, instance, placeholder)
         elif getattr(self, 'render_template', False):
             template = getattr(self, 'render_template', False)
@@ -463,21 +456,6 @@ class CMSPluginBase(six.with_metaclass(CMSPluginBaseMetaclass, admin.ModelAdmin)
 
     def __str__(self):
         return self.name
-
-    # ===============
-    # Deprecated APIs
-    # ===============
-
-    @property
-    def pluginmedia(self):
-        raise Deprecated(
-            "CMSPluginBase.pluginmedia is deprecated in favor of django-sekizai"
-        )
-
-    def get_plugin_media(self, request, context, plugin):
-        raise Deprecated(
-            "CMSPluginBase.get_plugin_media is deprecated in favor of django-sekizai"
-        )
 
 
 class PluginMenuItem(object):

--- a/cms/plugin_pool.py
+++ b/cms/plugin_pool.py
@@ -52,7 +52,6 @@ class PluginPool(object):
                     or hasattr(plugin.model, 'render_template')
                     or hasattr(plugin, 'get_render_template')):
                 if (plugin.render_template is None and
-                        not hasattr(plugin.model, 'render_template') and
                         not hasattr(plugin, 'get_render_template')):
                     raise ImproperlyConfigured(
                         "CMS Plugins must define a render template, "
@@ -66,9 +65,7 @@ class PluginPool(object):
                 elif not hasattr(plugin, 'get_render_template'):
                     from django.template import loader
 
-                    template = ((hasattr(plugin.model, 'render_template') and
-                                plugin.model.render_template) or
-                                plugin.render_template)
+                    template = plugin.render_template
                     if isinstance(template, six.string_types) and template:
                         try:
                             loader.get_template(template)

--- a/cms/plugin_processors.py
+++ b/cms/plugin_processors.py
@@ -3,7 +3,6 @@ from django.utils.safestring import mark_safe
 
 def plugin_meta_context_processor(instance, placeholder, context):
     return {
-        'plugin_index': instance._render_meta.index, # deprecated template variable
         'plugin': {
             'counter': instance._render_meta.index + 1,
             'counter0': instance._render_meta.index,

--- a/cms/templatetags/cms_tags.py
+++ b/cms/templatetags/cms_tags.py
@@ -693,10 +693,7 @@ class CMSEditableObject(InclusionTag):
         # content is for non-edit template content.html
         # rendered_content is for edit template plugin.html
         # in this templatetag both hold the same content
-        if get_cms_setting('UNESCAPED_RENDER_MODEL_TAGS'):
-            extra_context['content'] = mark_safe(extra_context['content'])
-        else:
-            extra_context['content'] = extra_context['content']
+        extra_context['content'] = extra_context['content']
         extra_context['rendered_content'] = extra_context['content']
         return extra_context
 

--- a/cms/tests/test_check.py
+++ b/cms/tests/test_check.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from copy import deepcopy
-import os
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured

--- a/cms/tests/test_check.py
+++ b/cms/tests/test_check.py
@@ -53,14 +53,6 @@ class CheckTests(CheckAssertMixin, TestCase):
     def test_test_confs(self):
         self.assertCheck(True, errors=0, warnings=0)
 
-    def test_cms_moderator_deprecated(self):
-        with self.settings(CMS_MODERATOR=True):
-            self.assertCheck(True, warnings=1, errors=0)
-
-    def test_cms_flat_urls_deprecated(self):
-        with self.settings(CMS_FLAT_URLS=True):
-            self.assertCheck(True, warnings=1, errors=0)
-
     def test_no_sekizai(self):
         apps = list(settings.INSTALLED_APPS)
         apps.remove('sekizai')
@@ -84,18 +76,6 @@ class CheckTests(CheckAssertMixin, TestCase):
         with self.settings(CMS_LANGUAGES=[('en', 'English')]):
             self.assertRaises(ImproperlyConfigured, self.assertCheck, True, warnings=1, errors=0)
 
-    def test_cms_hide_untranslated_deprecated(self):
-        with self.settings(CMS_HIDE_UNTRANSLATED=True):
-            self.assertCheck(True, warnings=1, errors=0)
-
-    def test_cms_language_fallback_deprecated(self):
-        with self.settings(CMS_LANGUAGE_FALLBACK=True):
-            self.assertCheck(True, warnings=1, errors=0)
-
-    def test_cms_language_conf_deprecated(self):
-        with self.settings(CMS_LANGUAGE_CONF=True):
-            self.assertCheck(True, warnings=1, errors=0)
-
     def test_middlewares(self):
         MIDDLEWARE_CLASSES=[
             'django.middleware.cache.UpdateCacheMiddleware',
@@ -113,14 +93,6 @@ class CheckTests(CheckAssertMixin, TestCase):
         self.assertCheck(True, warnings=0, errors=0)
         with self.settings(MIDDLEWARE_CLASSES=MIDDLEWARE_CLASSES):
             self.assertCheck(False, warnings=0, errors=2)
-
-    def test_cms_site_languages_deprecated(self):
-        with self.settings(CMS_SITE_LANGUAGES=True):
-            self.assertCheck(True, warnings=1, errors=0)
-
-    def test_cms_frontend_languages_deprecated(self):
-        with self.settings(CMS_FRONTEND_LANGUAGES=True):
-            self.assertCheck(True, warnings=1, errors=0)
 
     def test_copy_relations_fk_check(self):
         """
@@ -142,20 +114,6 @@ class CheckTests(CheckAssertMixin, TestCase):
         self.assertCheck(True, warnings=1, errors=0)
         MyPageExtension.copy_relations = copy_rel
 
-    def test_placeholder_tag_deprecation(self):
-        self.assertCheck(True, warnings=0, errors=0)
-        alt_dir = os.path.join(
-            os.path.dirname(__file__),
-            '..',
-            'test_utils',
-            'project',
-            'alt_templates'
-        )
-        NEWTEMPLATES = deepcopy(settings.TEMPLATES)
-        NEWTEMPLATES[0]['DIRS'] = [alt_dir]
-        with self.settings(TEMPLATES=NEWTEMPLATES, CMS_TEMPLATES=[]):
-            self.assertCheck(True, warnings=1, errors=0)
-
     def test_non_numeric_site_id(self):
         self.assertCheck(True, warnings=0, errors=0)
         with self.settings(SITE_ID='broken'):
@@ -167,23 +125,21 @@ class CheckWithDatabaseTests(CheckAssertMixin, TestCase):
     def test_check_plugin_instances(self):
         self.assertCheck(True, warnings=0, errors=0 )
 
-        apps = ["cms", "menus", "sekizai", "cms.test_utils.project.sampleapp", "treebeard"]
-        with self.settings(INSTALLED_APPS=apps):
-            placeholder = Placeholder.objects.create(slot="test")
-            add_plugin(placeholder, TextPlugin, "en", body="en body")
-            add_plugin(placeholder, TextPlugin, "en", body="en body")
-            add_plugin(placeholder, "LinkPlugin", "en",
-                       name="A Link", url="https://www.django-cms.org")
+        placeholder = Placeholder.objects.create(slot="test")
+        add_plugin(placeholder, TextPlugin, "en", body="en body")
+        add_plugin(placeholder, TextPlugin, "en", body="en body")
+        add_plugin(placeholder, "LinkPlugin", "en",
+                   name="A Link", url="https://www.django-cms.org")
 
-            # create a CMSPlugin with an unsaved instance
-            instanceless_plugin = CMSPlugin(language="en", plugin_type="TextPlugin")
-            instanceless_plugin.save()
+        # create a CMSPlugin with an unsaved instance
+        instanceless_plugin = CMSPlugin(language="en", plugin_type="TextPlugin")
+        instanceless_plugin.save()
 
-            self.assertCheck(False, warnings=0, errors=2)
+        self.assertCheck(False, warnings=0, errors=2)
 
-            # create a bogus CMSPlugin to simulate one which used to exist but
-            # is no longer installed
-            bogus_plugin = CMSPlugin(language="en", plugin_type="BogusPlugin")
-            bogus_plugin.save()
+        # create a bogus CMSPlugin to simulate one which used to exist but
+        # is no longer installed
+        bogus_plugin = CMSPlugin(language="en", plugin_type="BogusPlugin")
+        bogus_plugin.save()
 
-            self.assertCheck(False, warnings=0, errors=3)
+        self.assertCheck(False, warnings=0, errors=3)

--- a/cms/tests/test_toolbar.py
+++ b/cms/tests/test_toolbar.py
@@ -1126,19 +1126,6 @@ class EditModelTemplateTagTest(ToolbarTestBase):
             '{4}'
             '<template class="cms-plugin cms-plugin-end cms-plugin-{0}-{1}-{2}-{3} cms-render-model"></template>'
             '</h1>'.format(
-                'placeholderapp', 'example1', 'char_1', ex1.pk, truncatewords(ex1.char_1, 2),
-                )
-            )
-
-        request = self.get_page_request(page, user, edit=True)
-        response = detail_view(request, ex1.pk, template_string=template_text)
-        self.assertContains(
-            response,
-            '<h1>'
-            '<template class="cms-plugin cms-plugin-start cms-plugin-{0}-{1}-{2}-{3} cms-render-model"></template>'
-            '{4}'
-            '<template class="cms-plugin cms-plugin-end cms-plugin-{0}-{1}-{2}-{3} cms-render-model"></template>'
-            '</h1>'.format(
                 'placeholderapp', 'example1', 'char_1', ex1.pk, truncatewords(escape(ex1.char_1), 2)))
 
         template_text = '''{% extends "base.html" %}

--- a/cms/tests/test_toolbar.py
+++ b/cms/tests/test_toolbar.py
@@ -1117,51 +1117,47 @@ class EditModelTemplateTagTest(ToolbarTestBase):
 <h1>{% render_model instance "char_1" "" "" 'truncatewords:2' %}</h1>
 {% endblock content %}
 '''
-        with self.settings(CMS_UNESCAPED_RENDER_MODEL_TAGS=True):
-            request = self.get_page_request(page, user, edit=True)
-            response = detail_view(request, ex1.pk, template_string=template_text)
-            self.assertContains(
-                response,
-                '<h1>'
-                '<template class="cms-plugin cms-plugin-start cms-plugin-{0}-{1}-{2}-{3} cms-render-model"></template>'
-                '{4}'
-                '<template class="cms-plugin cms-plugin-end cms-plugin-{0}-{1}-{2}-{3} cms-render-model"></template>'
-                '</h1>'.format(
-                    'placeholderapp', 'example1', 'char_1', ex1.pk, truncatewords(ex1.char_1, 2),
-                    )
+        request = self.get_page_request(page, user, edit=True)
+        response = detail_view(request, ex1.pk, template_string=template_text)
+        self.assertContains(
+            response,
+            '<h1>'
+            '<template class="cms-plugin cms-plugin-start cms-plugin-{0}-{1}-{2}-{3} cms-render-model"></template>'
+            '{4}'
+            '<template class="cms-plugin cms-plugin-end cms-plugin-{0}-{1}-{2}-{3} cms-render-model"></template>'
+            '</h1>'.format(
+                'placeholderapp', 'example1', 'char_1', ex1.pk, truncatewords(ex1.char_1, 2),
                 )
+            )
 
-        with self.settings(CMS_UNESCAPED_RENDER_MODEL_TAGS=False):
-            request = self.get_page_request(page, user, edit=True)
-            response = detail_view(request, ex1.pk, template_string=template_text)
-            self.assertContains(
-                response,
-                '<h1>'
-                '<template class="cms-plugin cms-plugin-start cms-plugin-{0}-{1}-{2}-{3} cms-render-model"></template>'
-                '{4}'
-                '<template class="cms-plugin cms-plugin-end cms-plugin-{0}-{1}-{2}-{3} cms-render-model"></template>'
-                '</h1>'.format(
-                    'placeholderapp', 'example1', 'char_1', ex1.pk, truncatewords(escape(ex1.char_1), 2)))
+        request = self.get_page_request(page, user, edit=True)
+        response = detail_view(request, ex1.pk, template_string=template_text)
+        self.assertContains(
+            response,
+            '<h1>'
+            '<template class="cms-plugin cms-plugin-start cms-plugin-{0}-{1}-{2}-{3} cms-render-model"></template>'
+            '{4}'
+            '<template class="cms-plugin cms-plugin-end cms-plugin-{0}-{1}-{2}-{3} cms-render-model"></template>'
+            '</h1>'.format(
+                'placeholderapp', 'example1', 'char_1', ex1.pk, truncatewords(escape(ex1.char_1), 2)))
 
-        # Test with setting=False, but use "filter" parameter to include "safe"
-        with self.settings(CMS_UNESCAPED_RENDER_MODEL_TAGS=False):
-            template_text = '''{% extends "base.html" %}
+        template_text = '''{% extends "base.html" %}
 {% load cms_tags %}
 
 {% block content %}
 <h1>{% render_model instance "char_1" "" "" "truncatewords:2|safe" %}</h1>
 {% endblock content %}
 '''
-            request = self.get_page_request(page, user, edit=True)
-            response = detail_view(request, ex1.pk, template_string=template_text)
-            self.assertContains(
-                response,
-                '<h1>'
-                '<template class="cms-plugin cms-plugin-start cms-plugin-{0}-{1}-{2}-{3} cms-render-model"></template>'
-                '{4}'
-                '<template class="cms-plugin cms-plugin-end cms-plugin-{0}-{1}-{2}-{3} cms-render-model"></template>'
-                '</h1>'.format(
-                    'placeholderapp', 'example1', 'char_1', ex1.pk, truncatewords(ex1.char_1, 2)))
+        request = self.get_page_request(page, user, edit=True)
+        response = detail_view(request, ex1.pk, template_string=template_text)
+        self.assertContains(
+            response,
+            '<h1>'
+            '<template class="cms-plugin cms-plugin-start cms-plugin-{0}-{1}-{2}-{3} cms-render-model"></template>'
+            '{4}'
+            '<template class="cms-plugin cms-plugin-end cms-plugin-{0}-{1}-{2}-{3} cms-render-model"></template>'
+            '</h1>'.format(
+                'placeholderapp', 'example1', 'char_1', ex1.pk, truncatewords(ex1.char_1, 2)))
 
     def test_setting_override(self):
         template_text = '''{% extends "base.html" %}
@@ -1178,31 +1174,16 @@ class EditModelTemplateTagTest(ToolbarTestBase):
                        char_4="char_4")
         ex1.save()
 
-        # With CMS override settings (True) (assert that the resulting output is NOT escaped)
-        with self.settings(CMS_UNESCAPED_RENDER_MODEL_TAGS=True):
-            request = self.get_page_request(page, user, edit=True)
-            response = detail_view(request, ex1.pk, template_string=template_text)
-            self.assertContains(
-                response,
-                '<h1>'
-                '<template class="cms-plugin cms-plugin-start cms-plugin-{0}-{1}-{2}-{3} cms-render-model"></template>'
-                '{4}'
-                '<template class="cms-plugin cms-plugin-end cms-plugin-{0}-{1}-{2}-{3} cms-render-model"></template>'
-                '</h1>'.format(
-                    'placeholderapp', 'example1', 'char_1', ex1.pk, truncatewords(ex1.char_1, 2)))
-
-        # With CMS override settings (False) (assert that the resulting output IS escaped)
-        with self.settings(CMS_UNESCAPED_RENDER_MODEL_TAGS=False):
-            request = self.get_page_request(page, user, edit=True)
-            response = detail_view(request, ex1.pk, template_string=template_text)
-            self.assertContains(
-                response,
-                '<h1>'
-                '<template class="cms-plugin cms-plugin-start cms-plugin-{0}-{1}-{2}-{3} cms-render-model"></template>'
-                '{4}'
-                '<template class="cms-plugin cms-plugin-end cms-plugin-{0}-{1}-{2}-{3} cms-render-model"></template>'
-                '</h1>'.format(
-                    'placeholderapp', 'example1', 'char_1', ex1.pk, truncatewords(escape(ex1.char_1), 2)))
+        request = self.get_page_request(page, user, edit=True)
+        response = detail_view(request, ex1.pk, template_string=template_text)
+        self.assertContains(
+            response,
+            '<h1>'
+            '<template class="cms-plugin cms-plugin-start cms-plugin-{0}-{1}-{2}-{3} cms-render-model"></template>'
+            '{4}'
+            '<template class="cms-plugin cms-plugin-end cms-plugin-{0}-{1}-{2}-{3} cms-render-model"></template>'
+            '</h1>'.format(
+                'placeholderapp', 'example1', 'char_1', ex1.pk, truncatewords(escape(ex1.char_1), 2)))
 
     def test_filters_date(self):
         # Ensure we have a consistent testing env...
@@ -1220,52 +1201,37 @@ class EditModelTemplateTagTest(ToolbarTestBase):
 <h1>{% render_model instance "date_field" %}</h1>
 {% endblock content %}
 '''
-            with self.settings(CMS_UNESCAPED_RENDER_MODEL_TAGS=True):
-                request = self.get_page_request(page, user, edit=True)
-                response = detail_view(request, ex1.pk, template_string=template_text)
-                self.assertContains(
-                    response,
-                    '<h1>'
-                    '<template class="cms-plugin cms-plugin-start cms-plugin-{0}-{1}-{2}-{3} cms-render-model"></template>'
-                    '{4}'
-                    '<template class="cms-plugin cms-plugin-end cms-plugin-{0}-{1}-{2}-{3} cms-render-model"></template>'
-                    '</h1>'.format(
-                        'placeholderapp', 'example1', 'date_field', ex1.pk,
-                        ex1.date_field.strftime("%Y-%m-%d")))
 
-            with self.settings(CMS_UNESCAPED_RENDER_MODEL_TAGS=False):
-                request = self.get_page_request(page, user, edit=True)
-                response = detail_view(request, ex1.pk, template_string=template_text)
-                self.assertContains(
-                    response,
-                    '<h1>'
-                    '<template class="cms-plugin cms-plugin-start cms-plugin-{0}-{1}-{2}-{3} cms-render-model"></template>'
-                    '{4}'
-                    '<template class="cms-plugin cms-plugin-end cms-plugin-{0}-{1}-{2}-{3} cms-render-model"></template>'
-                    '</h1>'.format(
-                        'placeholderapp', 'example1', 'date_field', ex1.pk,
-                        ex1.date_field.strftime("%b. %d, %Y")))
+            request = self.get_page_request(page, user, edit=True)
+            response = detail_view(request, ex1.pk, template_string=template_text)
+            self.assertContains(
+                response,
+                '<h1>'
+                '<template class="cms-plugin cms-plugin-start cms-plugin-{0}-{1}-{2}-{3} cms-render-model"></template>'
+                '{4}'
+                '<template class="cms-plugin cms-plugin-end cms-plugin-{0}-{1}-{2}-{3} cms-render-model"></template>'
+                '</h1>'.format(
+                    'placeholderapp', 'example1', 'date_field', ex1.pk,
+                    ex1.date_field.strftime("%b. %d, %Y")))
 
-            # Test with setting=False, but use "filter" parameter to add "safe"
-            with self.settings(CMS_UNESCAPED_RENDER_MODEL_TAGS=False):
-                template_text = '''{% extends "base.html" %}
+            template_text = '''{% extends "base.html" %}
 {% load cms_tags %}
 
 {% block content %}
 <h1>{% render_model instance "date_field" "" "" "safe" %}</h1>
 {% endblock content %}
 '''
-                request = self.get_page_request(page, user, edit=True)
-                response = detail_view(request, ex1.pk, template_string=template_text)
-                self.assertContains(
-                    response,
-                    '<h1>'
-                    '<template class="cms-plugin cms-plugin-start cms-plugin-{0}-{1}-{2}-{3} cms-render-model"></template>'
-                    '{4}'
-                    '<template class="cms-plugin cms-plugin-end cms-plugin-{0}-{1}-{2}-{3} cms-render-model"></template>'
-                    '</h1>'.format(
-                        'placeholderapp', 'example1', 'date_field', ex1.pk,
-                        ex1.date_field.strftime("%Y-%m-%d")))
+            request = self.get_page_request(page, user, edit=True)
+            response = detail_view(request, ex1.pk, template_string=template_text)
+            self.assertContains(
+                response,
+                '<h1>'
+                '<template class="cms-plugin cms-plugin-start cms-plugin-{0}-{1}-{2}-{3} cms-render-model"></template>'
+                '{4}'
+                '<template class="cms-plugin cms-plugin-end cms-plugin-{0}-{1}-{2}-{3} cms-render-model"></template>'
+                '</h1>'.format(
+                    'placeholderapp', 'example1', 'date_field', ex1.pk,
+                    ex1.date_field.strftime("%Y-%m-%d")))
 
             template_text = '''{% extends "base.html" %}
 {% load cms_tags %}
@@ -1299,31 +1265,23 @@ class EditModelTemplateTagTest(ToolbarTestBase):
 <h1>{% render_model instance "char_1" "" "" 'truncatewords:2' %}</h1>
 {% endblock content %}
 '''
-        with self.settings(CMS_UNESCAPED_RENDER_MODEL_TAGS=True):
-            request = self.get_page_request(page, user, edit=False)
-            response = detail_view(request, ex1.pk, template_string=template_text)
-            self.assertContains(response,
-                                '<h1>%s</h1>' % truncatewords(ex1.char_1, 2))
 
-        with self.settings(CMS_UNESCAPED_RENDER_MODEL_TAGS=False):
-            request = self.get_page_request(page, user, edit=False)
-            response = detail_view(request, ex1.pk, template_string=template_text)
-            self.assertContains(response,
-                                '<h1>%s</h1>' % truncatewords(escape(ex1.char_1), 2))
+        request = self.get_page_request(page, user, edit=False)
+        response = detail_view(request, ex1.pk, template_string=template_text)
+        self.assertContains(response,
+                            '<h1>%s</h1>' % truncatewords(escape(ex1.char_1), 2))
 
-        # Test with setting=False, but use "filter" parameter to add "safe"
-        with self.settings(CMS_UNESCAPED_RENDER_MODEL_TAGS=False):
-            template_text = '''{% extends "base.html" %}
+        template_text = '''{% extends "base.html" %}
 {% load cms_tags %}
 
 {% block content %}
 <h1>{% render_model instance "char_1" "" "" 'truncatewords:2|safe' "" "" %}</h1>
 {% endblock content %}
 '''
-            request = self.get_page_request(page, user, edit=False)
-            response = detail_view(request, ex1.pk, template_string=template_text)
-            self.assertContains(response,
-                                '<h1>%s</h1>' % truncatewords(ex1.char_1, 2))
+        request = self.get_page_request(page, user, edit=False)
+        response = detail_view(request, ex1.pk, template_string=template_text)
+        self.assertContains(response,
+                            '<h1>%s</h1>' % truncatewords(ex1.char_1, 2))
 
     def test_no_cms(self):
         user = self.get_staff()

--- a/cms/toolbar_pool.py
+++ b/cms/toolbar_pool.py
@@ -24,8 +24,6 @@ class ToolbarPool(object):
                 self.register(cls)
                 self.force_register = False
         else:
-            # FIXME: Remove in 3.4
-            load('cms_toolbar')
             load('cms_toolbars')
         self._discovered = True
 
@@ -34,11 +32,6 @@ class ToolbarPool(object):
         self._discovered = False
 
     def register(self, toolbar):
-        import warnings
-        if toolbar.__module__.split('.')[-1] == 'cms_toolbar':
-            warnings.warn('cms_toolbar.py filename is deprecated, '
-                          'and it will be removed in version 3.4; '
-                          'please rename it to cms_toolbars.py', DeprecationWarning)
         if not self.force_register and get_cms_setting('TOOLBARS'):
             return toolbar
         from cms.toolbar_base import CMSToolbar

--- a/cms/utils/conf.py
+++ b/cms/utils/conf.py
@@ -66,7 +66,6 @@ DEFAULTS = {
     'TOOLBAR_HIDE': False,
     'INTERNAL_IPS': [],
     'REQUEST_IP_RESOLVER': 'cms.utils.request_ip_resolvers.default_request_ip_resolver',
-    'UNESCAPED_RENDER_MODEL_TAGS': True,
     'PAGE_WIZARD_DEFAULT_TEMPLATE': constants.TEMPLATE_INHERITANCE_MAGIC,
     'PAGE_WIZARD_CONTENT_PLUGIN': 'TextPlugin',
     'PAGE_WIZARD_CONTENT_PLUGIN_BODY': 'body',

--- a/docs/how_to/frontend_models.rst
+++ b/docs/how_to/frontend_models.rst
@@ -20,15 +20,6 @@ hint on hover. Double-clicking opens a pop-up window containing the change form 
 
 .. warning::
 
-    By default and for consistency with previous releases, template tags used
-    by this feature mark as safe the content of the rendered
-    model attribute. This may be a security risk if used on fields which may
-    hold non-trusted content. Be aware, and use the template tags accordingly.
-    To change this behaviour, set the setting: :setting:`CMS_UNESCAPED_RENDER_MODEL_TAGS` to False.
-
-
-.. warning::
-
     This feature is only partially compatible with django-hvad: using
     ``render_model`` with hvad-translated fields (say
     ``{% render_model object 'translated_field' %}`` returns an error if the

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -1140,31 +1140,3 @@ when the "Content" field is filled in. There should be no need to change it,
 unless you **don't** use ``djangocms-text-ckeditor`` in your project **and**
 your custom plugin defined in :setting:`CMS_PAGE_WIZARD_CONTENT_PLUGIN` have a
 body field **different** than ``body``.
-
-
-..  setting:: CMS_UNESCAPED_RENDER_MODEL_TAGS
-
-CMS_UNESCAPED_RENDER_MODEL_TAGS
-===================================
-
-..  versionadded:: 3.2.4
-
-default
-    True
-
-To immediately improve the security of your project and to prepare for
-future releases of django CMS and related addons, the project
-administrator should carefully review each use of the ``render_model``
-template tags provided by django CMS. He or she is encouraged to ensure
-that all content which is rendered to a page using this template tag is
-cleansed of any potentially harmful HTML markup, CSS styles or JavaScript.
-Once the administrator or developer is satisfied that the content is
-clean, he or she can add the "safe" filter parameter to the render_model
-template tag if the content should be rendered without escaping. If there
-is no need to render the content unescaped, no further action
-is required.
-
-Once all template tags have been reviewed and adjusted where necessary,
-the administrator should set ``CMS_UNESCAPED_RENDER_MODEL_TAGS = False``
-in the project settings. At that point, the project is more secure and
-will be ready for any future upgrades.

--- a/docs/reference/templatetags.rst
+++ b/docs/reference/templatetags.rst
@@ -438,12 +438,6 @@ Example::
 render_model
 ============
 
-.. warning::
-
-    ``render_model`` marks as safe the content of the rendered model
-    attribute. This may be a security risk if used on fields which may contains
-    non-trusted content. Be aware, and use the template tag accordingly.
-
 ``render_model`` is the way to add frontend editing to any Django model.
 It both renders the content of the given attribute of the model instance and
 makes it clickable to edit the related model.
@@ -494,6 +488,20 @@ This will render to:
 * ``varname`` (optional): the template tag output can be saved as a context
   variable for later use.
 
+.. note::
+
+    By default this template tag escapes the content of the rendered
+    model attribute. This helps prevent a range of security vulnerabilities
+    stemming from HTML, Javascript, and CSS Code Injection.
+
+    To change this behavior, the project administrator should carefully review
+    each use of this template tag and ensure that all content which is rendered
+    to a page using this template tag is cleansed of any potentially harmful
+    HTML markup, CSS styles or JavaScript.
+
+    Once the administrator is satisfied that the content is
+    clean, he or she can add the "safe" filter parameter to the template tag
+    if the content should be rendered without escaping.
 
 .. warning::
 
@@ -562,6 +570,21 @@ method is available; also template tags and filters are available in the block.
 * ``varname`` (optional): the template tag output can be saved as a context
   variable for later use.
 
+.. note::
+
+    By default this template tag escapes the content of the rendered
+    model attribute. This helps prevent a range of security vulnerabilities
+    stemming from HTML, Javascript, and CSS Code Injection.
+
+    To change this behavior, the project administrator should carefully review
+    each use of this template tag and ensure that all content which is rendered
+    to a page using this template tag is cleansed of any potentially harmful
+    HTML markup, CSS styles or JavaScript.
+
+    Once the administrator is satisfied that the content is
+    clean, he or she can add the "safe" filter parameter to the template tag
+    if the content should be rendered without escaping.
+
 
 .. templatetag:: render_model_icon
 .. versionadded:: 3.0
@@ -614,6 +637,21 @@ It will render to something like:
 * ``varname`` (optional): the template tag output can be saved as a context
   variable for later use.
 
+.. note::
+
+    By default this template tag escapes the content of the rendered
+    model attribute. This helps prevent a range of security vulnerabilities
+    stemming from HTML, Javascript, and CSS Code Injection.
+
+    To change this behavior, the project administrator should carefully review
+    each use of this template tag and ensure that all content which is rendered
+    to a page using this template tag is cleansed of any potentially harmful
+    HTML markup, CSS styles or JavaScript.
+
+    Once the administrator is satisfied that the content is
+    clean, he or she can add the "safe" filter parameter to the template tag
+    if the content should be rendered without escaping.
+
 
 .. templatetag:: render_model_add
 .. versionadded:: 3.0
@@ -661,6 +699,21 @@ It will render to something like:
   the method must accept ``request`` as first parameter.
 * ``varname`` (optional): the template tag output can be saved as a context
   variable for later use.
+
+.. note::
+
+    By default this template tag escapes the content of the rendered
+    model attribute. This helps prevent a range of security vulnerabilities
+    stemming from HTML, Javascript, and CSS Code Injection.
+
+    To change this behavior, the project administrator should carefully review
+    each use of this template tag and ensure that all content which is rendered
+    to a page using this template tag is cleansed of any potentially harmful
+    HTML markup, CSS styles or JavaScript.
+
+    Once the administrator is satisfied that the content is
+    clean, he or she can add the "safe" filter parameter to the template tag
+    if the content should be rendered without escaping.
 
 .. warning::
 

--- a/docs/reference/templatetags.rst
+++ b/docs/reference/templatetags.rst
@@ -494,13 +494,6 @@ This will render to:
 * ``varname`` (optional): the template tag output can be saved as a context
   variable for later use.
 
-.. warning::
-
-    In this version of django CMS, the setting :setting:`CMS_UNESCAPED_RENDER_MODEL_TAGS`
-    has a default value of ``True`` to provide behavior consistent with
-    previous releases. However, all developers are encouraged to set this
-    value to ``False`` to help prevent a range of security vulnerabilities
-    stemming from HTML, Javascript, and CSS Code Injection.
 
 .. warning::
 
@@ -569,13 +562,6 @@ method is available; also template tags and filters are available in the block.
 * ``varname`` (optional): the template tag output can be saved as a context
   variable for later use.
 
-.. warning::
-
-    In this version of django CMS, the setting :setting:`CMS_UNESCAPED_RENDER_MODEL_TAGS`
-    has a default value of ``True`` to provide behavior consistent with
-    previous releases. However, all developers are encouraged to set this
-    value to ``False`` to help prevent a range of security vulnerabilities
-    stemming from HTML, Javascript, and CSS Code Injection.
 
 .. templatetag:: render_model_icon
 .. versionadded:: 3.0
@@ -628,13 +614,6 @@ It will render to something like:
 * ``varname`` (optional): the template tag output can be saved as a context
   variable for later use.
 
-.. warning::
-
-    In this version of django CMS, the setting :setting:`CMS_UNESCAPED_RENDER_MODEL_TAGS`
-    has a default value of ``True`` to provide behavior consistent with
-    previous releases. However, all developers are encouraged to set this
-    value to ``False`` to help prevent a range of security vulnerabilities
-    stemming from HTML, Javascript, and CSS Code Injection.
 
 .. templatetag:: render_model_add
 .. versionadded:: 3.0
@@ -682,14 +661,6 @@ It will render to something like:
   the method must accept ``request`` as first parameter.
 * ``varname`` (optional): the template tag output can be saved as a context
   variable for later use.
-
-.. warning::
-
-    In this version of django CMS, the setting :setting:`CMS_UNESCAPED_RENDER_MODEL_TAGS`
-    has a default value of ``True`` to provide behavior consistent with
-    previous releases. However, all developers are encouraged to set this
-    value to ``False`` to help prevent a range of security vulnerabilities
-    stemming from HTML, Javascript, and CSS Code Injection.
 
 .. warning::
 


### PR DESCRIPTION
**Apphooks**
`cms_app` will no longer be loaded, instead `cms_apps` is used

**Toolbar**
`cms_toolbar` will no longer be loaded, instead `cms_toolbars` is used

**Removed Settings (and behaviors)**
`CMS_UNESCAPED_RENDER_MODEL_TAGS`
`CMS_HIDE_UNTRANSLATED`
`CMS_LANGUAGE_FALLBACK`
`CMS_LANGUAGE_CONF`
`CMS_SITE_LANGUAGES`
`CMS_FRONTEND_LANGUAGES`