### PR TITLE
Adjust release notes and page extension docs to reflect permission changes

### DIFF
--- a/docs/how_to/extending_page_title.rst
+++ b/docs/how_to/extending_page_title.rst
@@ -268,6 +268,8 @@ Complete toolbar API
 
 The example above uses the :ref:`simplified_extension_toolbar`.
 
+.. _complete_toolbar_api:
+
 If you need complete control over the layout of your extension toolbar items you can still use the
 low-level API to edit the toolbar according to your needs::
 
@@ -275,7 +277,7 @@ low-level API to edit the toolbar according to your needs::
     from cms.toolbar_pool import toolbar_pool
     from cms.toolbar_base import CMSToolbar
     from cms.utils import get_cms_setting
-    from cms.utils.permissions import has_page_change_permission
+    from cms.utils.page_permissions import user_can_change_page
     from django.core.urlresolvers import reverse, NoReverseMatch
     from django.utils.translation import ugettext_lazy as _
     from .models import IconExtension
@@ -291,14 +293,7 @@ low-level API to edit the toolbar according to your needs::
                 # Nothing to do
                 return
 
-            # check global permissions if CMS_PERMISSION is active
-            if get_cms_setting('PERMISSION'):
-                has_global_current_page_change_permission = has_page_change_permission(self.request)
-            else:
-                has_global_current_page_change_permission = False
-                # check if user has page edit permission
-            can_change = self.request.current_page and self.request.current_page.has_change_permission(self.request)
-            if has_global_current_page_change_permission or can_change:
+            if user_can_change_page(user=self.request.user, page=self.page):
                 try:
                     icon_extension = IconExtension.objects.get(extended_object_id=self.page.id)
                 except IconExtension.DoesNotExist:

--- a/docs/upgrade/3.4.rst
+++ b/docs/upgrade/3.4.rst
@@ -65,6 +65,14 @@ Then run::
 Backward incompatible changes
 *****************************
 
+Apphooks & Toolbars
+===================
+
+As per our deprecation policy we've now removed the backwards compatible shim
+for ``cms_app.py`` and ``cms_toolbar.py``.
+If you have not done so already, please rename these to ``cms_apps.py`` and ``cms_toolbars.py``.
+
+
 Permissions
 ===========
 
@@ -85,6 +93,7 @@ Functions removed:
  * ``load_view_restrictions``
  * ``get_any_page_view_permissions``
 
+
 The following methods were changed to require a user parameter instead of a request:
 
  * ``Page.has_view_permission``
@@ -98,6 +107,30 @@ The following methods were changed to require a user parameter instead of a requ
  * ``Page.has_move_page_permission``
 
 These are also deprecated in favor of their counterparts in ``cms.utils.page_permissions``.
+
+To keep consistency with both django CMS permissions and Django permissions,
+we've modified the vanilla permissions system (``CMS_PERMISSIONS = False``)
+to require users to have certain Django permissions to perform an action.
+
+Here's an overview:
+
+============ ==================================
+Action       Permission required
+============ ==================================
+Add Page     Can Add Page & Can Change Page
+Change Page  Can Change Page
+Delete Page  Can Change Page & Can Delete Page
+Move Page    Can Change Page
+Publish Page Can Change Page & Can Publish Page
+============ ==================================
+
+This change will only affect non-superuser staff members.
+
+.. warning::
+
+    If you have a custom ``Page`` extension with a configured toolbar,
+    please see the updated :ref:`example <complete_toolbar_api>`.
+    It uses the new permission internals.
 
 
 Manual plugin rendering


### PR DESCRIPTION
Thanks to @timgraham for pointing this out :)

Update 1
@evildmp I've added the warning at the bottom.

Update 2
Added the apphook and toolbar notes
Added the permission dependency changes note

![cms-5662-release-notes-3](https://cloud.githubusercontent.com/assets/994951/18388929/96d72a42-7671-11e6-92b4-731601908289.png)


