### PR TITLE
Fixed #5651 -- Corectly get language from request

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -13,6 +13,7 @@
 * Fixed a bug where moving a published page under a page marked as pending publishing
   is left as published instead of being marked as pending publishing.
 * Fixed AttributeError when using ``create_page`` in management command
+* Fixed a bug in getting the language from current request which can cause error 500
 
 
 === 3.3.2 (2016-08-11) ===

--- a/cms/utils/__init__.py
+++ b/cms/utils/__init__.py
@@ -52,20 +52,20 @@ def get_language_from_request(request, current_page=None):
         language = get_language_code(language)
         if not language in get_language_list(site_id):
             language = None
-    if language is None:
+    if not language:
         language = get_language_code(getattr(request, 'LANGUAGE_CODE', None))
     if language:
         if not language in get_language_list(site_id):
             language = None
 
-    if language is None and current_page:
+    if not language and current_page:
         # in last resort, get the first language available in the page
         languages = current_page.get_languages()
 
         if len(languages) > 0:
             language = languages[0]
 
-    if language is None:
+    if not language:
         # language must be defined in CMS_LANGUAGES, so check first if there
         # is any language with LANGUAGE_CODE, otherwise try to split it and find
         # best match


### PR DESCRIPTION
In `get_language_from_request` if for some reason local variable `language` becomes empty string instead of `None` then treat is as `None` (Duck typing).

Fixes #5651

I opened this PR against release/3.3.x because #5651 is marked as bug for 3.3.x. If you prefer I can open it against develop and you can backport it then (also for 3.4), instead of forward porting.