### PR TITLE
Allways escape text passed from django to JS

### DIFF
--- a/cms/templates/cms/toolbar/toolbar_javascript.html
+++ b/cms/templates/cms/toolbar/toolbar_javascript.html
@@ -53,9 +53,9 @@ $(document).ready(function () {
             'id': '{{ request.toolbar.clipboard.pk|unlocalize }}',
             'url': '{% if request.toolbar.clipboard.pk %}{% cms_admin_url "cms_page_clear_placeholder" request.toolbar.clipboard.pk %}{% endif %}'
         },
-        'messages': '{% if messages %}{% for message in messages %}{{ message }}{% endfor %}{% endif %}',
-        'error': '{% if request.toolbar.login_form.errors or cms_toolbar_login_error %}{% blocktrans %}<strong>Login failed.</strong> Please check your credentials and try again.{% endblocktrans %}{% endif %}',
-        'publisher': '{% if not request.current_page.publisher_is_draft and request.current_page.publisher_draft.is_dirty and user.is_authenticated %}{% trans "This page has unpublished changes." %}{% endif %}'
+        'messages': '{% filter escapejs %}{% if messages %}{% for message in messages %}{{ message }}{% endfor %}{% endif %}{% endfilter %}',
+        'error': '{% filter escapejs %}{% if request.toolbar.login_form.errors or cms_toolbar_login_error %}{% blocktrans %}<strong>Login failed.</strong> Please check your credentials and try again.{% endblocktrans %}{% endif %}{% endfilter %}',
+        'publisher': '{% filter escapejs %}{% if not request.current_page.publisher_is_draft and request.current_page.publisher_draft.is_dirty and user.is_authenticated %}{% trans "This page has unpublished changes." %}{% endif %}{% endfilter %}'
     };
     CMS.settings = CMS.API.Helpers.getSettings();
 


### PR DESCRIPTION
This will fix bug when there is a new line (or other non valid characters) in the resulted text which will lead to JavaScript error.

This is the same as CMS.config.lang values in the same file.