### PR TITLE
[WIP] untranslated placeholders

### DIFF
--- a/cms/tests/test_placeholder.py
+++ b/cms/tests/test_placeholder.py
@@ -624,6 +624,11 @@ class PlaceholderTestCase(CMSTestCase, UnittestCompatMixin):
         placeholder_de = title_de.page.placeholders.get(slot='col_left')
         add_plugin(placeholder_en, TextPlugin, 'en', body='en body')
 
+        context_en = SekizaiContext()
+        context_en['request'] = self.get_request(language="en", page=page_en)
+        context_de = SekizaiContext()
+        context_de['request'] = self.get_request(language="de", page=page_en)
+
         conf = {
             'col_left': {
                 'untranslated': True,
@@ -632,19 +637,25 @@ class PlaceholderTestCase(CMSTestCase, UnittestCompatMixin):
         }
         # configure untranslated
         with self.settings(CMS_PLACEHOLDER_CONF=conf):
-            context_en = SekizaiContext()
-            context_en['request'] = self.get_request(language="en", page=page_en)
-            context_de = SekizaiContext()
-            context_de['request'] = self.get_request(language="de", page=page_en)
-
             ## English page should have the text plugin
             content_en = _render_placeholder(placeholder_en, context_en)
             self.assertRegexpMatches(content_en, "^en body$")
-
             ## Deutsch page have text due to untranslated
             content_de = _render_placeholder(placeholder_de, context_de)
             self.assertRegexpMatches(content_de, "^en body$")
             self.assertEqual(len(content_de), 7)
+
+            del(placeholder_en._plugins_cache)
+            del(placeholder_de._plugins_cache)
+            cache.clear()
+            # add another
+            add_plugin(placeholder_en, TextPlugin, 'de', body='de body')
+
+            # both should have both
+            content_de = _render_placeholder(placeholder_de, context_de)
+            self.assertRegexpMatches(content_de, "^en bodyde body$")
+            content_en = _render_placeholder(placeholder_en, context_en)
+            self.assertRegexpMatches(content_en, "^en bodyde body$")
 
     def test_plugins_prepopulate(self):
         """ Tests prepopulate placeholder configuration """

--- a/cms/tests/test_placeholder.py
+++ b/cms/tests/test_placeholder.py
@@ -528,6 +528,7 @@ class PlaceholderTestCase(CMSTestCase, UnittestCompatMixin):
             del(placeholder_de._plugins_cache)
             cache.clear()
             content_de2 = _render_placeholder(placeholder_de, context_de2)
+            # no fallback in edit mode
             self.assertFalse("en body" in content_de2)
             # remove the cached plugins instances
             del(placeholder_de._plugins_cache)
@@ -614,6 +615,36 @@ class PlaceholderTestCase(CMSTestCase, UnittestCompatMixin):
             # remove the cached plugins instances
             del(placeholder_sidebar_en._plugins_cache)
             cache.clear()
+
+    def test_plugins_untranslated(self):
+        """ Tests untranslated placeholder configuration """
+        page_en = create_page('page_en', 'col_two.html', 'en')
+        title_de = create_title("de", "page_de", page_en)
+        placeholder_en = page_en.placeholders.get(slot='col_left')
+        placeholder_de = title_de.page.placeholders.get(slot='col_left')
+        add_plugin(placeholder_en, TextPlugin, 'en', body='en body')
+
+        conf = {
+            'col_left': {
+                'untranslated': True,
+                'language_fallback': False,
+            },
+        }
+        # configure untranslated
+        with self.settings(CMS_PLACEHOLDER_CONF=conf):
+            context_en = SekizaiContext()
+            context_en['request'] = self.get_request(language="en", page=page_en)
+            context_de = SekizaiContext()
+            context_de['request'] = self.get_request(language="de", page=page_en)
+
+            ## English page should have the text plugin
+            content_en = _render_placeholder(placeholder_en, context_en)
+            self.assertRegexpMatches(content_en, "^en body$")
+
+            ## Deutsch page have text due to untranslated
+            content_de = _render_placeholder(placeholder_de, context_de)
+            self.assertRegexpMatches(content_de, "^en body$")
+            self.assertEqual(len(content_de), 7)
 
     def test_plugins_prepopulate(self):
         """ Tests prepopulate placeholder configuration """


### PR DESCRIPTION
This is a proposal, how a "untranslated" setting could be added to the placeholder config. untranslated placeholders would just ignore the language field on plugins, and always show all plugins. Typical use cases: Header images, and other "non language specific content". I'm aware that almost the same can be achieved with language_fallbacks, but IMO it's worth it, as it makes the UI more clean for those use cases.

Differences to language fallbacks. Fallbacks need to be defined, untranslated just is untranslated. Also, fallback plugins are not shown in edit mode (so one could add a plugin, and no more fallback would be needed), wereas untranslated plugins are visible in any language, also in edit mode.

I'm sure there would be some more changes and tests needed (cms/utils/plugins.py also has get_plugins_for_page and reorder_plugins) - this is a proof of concept, to check if this feature has any chance to get into django-cms...
