### PR TITLE
Fixed double-escaping when rendering placeholder with dashes

### DIFF
--- a/cms/tests/test_templatetags.py
+++ b/cms/tests/test_templatetags.py
@@ -302,6 +302,32 @@ class TemplatetagDatabaseTests(TwoPagesFixture, CMSTestCase):
                 start_tag = tag_format.format(plugin.pk)
                 self.assertIn(start_tag, output)
 
+    def test_render_placeholder_toolbar_js_escaping(self):
+        page = self._getfirst()
+        request = self.get_request(language='en', page=page)
+        renderer = self.get_content_renderer(request)
+        placeholder = page.placeholders.get(slot='body')
+
+        conf = {placeholder.slot: {'name': 'Content-with-dash'}}
+
+        with self.settings(CMS_PLACEHOLDER_CONF=conf):
+            content = render_placeholder_toolbar_js(
+                placeholder,
+                render_language='en',
+                content_renderer=renderer,
+            )
+
+        expected_bits = [
+            '"addPluginHelpTitle": "Add plugin to placeholder \\"Content-with-dash\\""',
+            '"name": "Content-with-dash"',
+            '"placeholder_id": "{}"'.format(placeholder.pk),
+            '"plugin_language": "en"',
+            '"page_language": "en"',
+        ]
+
+        for bit in expected_bits:
+            self.assertIn(bit, content)
+
     def test_render_placeholder_toolbar_js_with_no_plugins(self):
         page = self._getfirst()
         request = self.get_request(language='en', page=page)

--- a/cms/toolbar/utils.py
+++ b/cms/toolbar/utils.py
@@ -1,6 +1,5 @@
 import json
 
-from django.template.defaultfilters import escapejs
 from django.utils.encoding import force_text
 from django.utils.six import text_type
 from django.utils.translation import ugettext
@@ -10,7 +9,7 @@ from cms.constants import PLACEHOLDER_TOOLBAR_JS, PLUGIN_TOOLBAR_JS
 
 def get_placeholder_toolbar_js(placeholder, request_language,
                                render_language, allowed_plugins=None):
-    label = escapejs(placeholder.get_label() or '')
+    label = placeholder.get_label() or ''
     help_text = ugettext(
         'Add plugin to placeholder "%(placeholder_label)s"'
     ) % {'placeholder_label': label}
@@ -32,7 +31,7 @@ def get_placeholder_toolbar_js(placeholder, request_language,
 
 
 def get_plugin_toolbar_js(plugin, request_language, children=None, parents=None):
-    plugin_name = escapejs(plugin.get_plugin_name())
+    plugin_name = plugin.get_plugin_name()
     help_text = ugettext(
         'Add plugin to %(plugin_name)s'
     ) % {'plugin_name': plugin_name}


### PR DESCRIPTION
Using `escapejs` and `json.dumps()` will double escape certain characters.