### PR TITLE
Removed unused context variables in Page change_view().

### DIFF
--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -367,10 +367,8 @@ class PageAdmin(PlaceholderAdminMixin, admin.ModelAdmin):
             context = {
                 'page': obj,
                 'CMS_PERMISSION': get_cms_setting('PERMISSION'),
-                'ADMIN_MEDIA_URL': settings.STATIC_URL,
                 'can_change': self.has_change_permission(request, obj=obj),
                 'can_change_permissions': self.has_change_permissions_permission(request, obj=obj),
-                'current_site_id': settings.SITE_ID,
             }
             context.update(extra_context or {})
             extra_context = self.update_language_tab_context(request, obj, context)


### PR DESCRIPTION
Unused after 49c8d4c2905243fb33890f526c334bd39bb350f0 and
785b31a1a0879eddb6385bfba31cf7303c060239.