### PR TITLE
Fixed example code for custom `render_placeholder`.

### DIFF
--- a/docs/upgrade/3.4.rst
+++ b/docs/upgrade/3.4.rst
@@ -173,8 +173,8 @@ Like a plugin, to render a placeholder programmatically, you will need a context
                      # Avoid errors if plugin require a request object
                      # when rendering.
                      context['request'] = request
-                     content = content_renderer.render_placeholder(
+                     content = renderer.render_placeholder(
                         placeholder,
                         context=context,
-                    )
-                    return content
+                     )
+                     return content


### PR DESCRIPTION
Fixed indentation so copy/paste works for end users.