### PR TITLE
Fix example code in 3.4 release notes

### DIFF
--- a/docs/upgrade/3.4.rst
+++ b/docs/upgrade/3.4.rst
@@ -173,7 +173,7 @@ Like a plugin, to render a placeholder programmatically, you will need a context
                      # Avoid errors if plugin require a request object
                      # when rendering.
                      context['request'] = request
-                     content = content_renderer.render_placeholder(
+                     content = renderer.render_placeholder(
                         placeholder,
                         context=context,
                     )


### PR DESCRIPTION
There is a small variable name mismatch (`renderer` vs `content_renderer`)