### PR TITLE
Fixed #5684 -- Removed globally unique constraint for Apphook configs

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,7 @@
 
 * Fixed a regression when static placeholder was uneditable if it was present
   on the page multiple times
+* Removed globally unique constraint for Apphook configs.
 
 
 === 3.4.0 (2016-09-14) ===

--- a/cms/admin/forms.py
+++ b/cms/admin/forms.py
@@ -314,6 +314,7 @@ class AdvancedSettingsForm(forms.ModelForm):
     def _check_unique_namespace_instance(self, namespace):
         return Page.objects.filter(
             publisher_is_draft=True,
+            site_id=self.instance.site_id,
             application_namespace=namespace
         ).exclude(pk=self.instance.pk).exists()
 


### PR DESCRIPTION
Fix  #5684

This is the forwardport of #5458 with tests

Will backport test after this is merged