### PR TITLE
Fixed CMS_TEMPLATES_DIR without __init__.py (#5649)

### DIFF
--- a/cms/utils/conf.py
+++ b/cms/utils/conf.py
@@ -150,7 +150,7 @@ def get_templates():
         config_path = os.path.join(tpldir, '__init__.py')
         # Try to load templates list and names from the template module
         # If module file is not present skip configuration and just dump the filenames as templates
-        if config_path:
+        if os.path.isfile(config_path):
             template_module = load_from_file(config_path)
             templates = [(os.path.join(prefix, data[0].strip()), data[1]) for data in template_module.TEMPLATES.items()]
         else:


### PR DESCRIPTION
Backport https://github.com/divio/django-cms/pull/5649