### PR TITLE
Fixed bug where empty placeholder would render as 'None'

### DIFF
--- a/cms/plugin_rendering.py
+++ b/cms/plugin_rendering.py
@@ -254,7 +254,7 @@ class ContentRenderer(object):
         current_page = self.current_page
 
         if not current_page:
-            return
+            return ''
 
         content = self._render_page_placeholder(
             context=context,


### PR DESCRIPTION
This bug would appear when "placeholder" template tag appeared in a
template being rendered by a non-CMS view.

The render_page_placeholder function had a bare "return" instead of
returning an explicit empty string.

See also the code that would be executed for the same case in
django-cms 3.3.x (in cms_tags.py:render_tag in that release):

        page = request.current_page
        if not page or page == 'dummy':
            if nodelist:
                return nodelist.render(context)
            return ''

Note: I'd like to contribute a test case for this as well. The existing test at cms.tests.test_rendering.RenderingTestCase.test_placeholder looks like
the closest thing for this. I'm just not sure what it would take to modify that
test case so that it would hit the conditional return modified by this code.
(Just changing self.test_page to None did not do the trick.) When I've
exercised this bug manually, I've done it by creating a non-CMS view that
renders with a template that contains a placeholder template tag.

Perhaps that would be an easy test to write for someone with more
experience writing Django tests. Any guidance you might be able to give
me on how to write that test would be appreciated.
