### PR TITLE
Sample testing plugin context missing `cms_content_renderer` key

### DIFF
--- a/docs/how_to/testing.rst
+++ b/docs/how_to/testing.rst
@@ -97,9 +97,7 @@ it or the context provided to its template::
                 MyPlugin,
                 'en',
             )
-            context = {
-                'cms_content_renderer': ContentRenderer(request=RequestFactory())
-            }
-            html = model_instance.render_plugin(context)
+            renderer = ContentRenderer(request=RequestFactory())
+            html = renderer.render_plugin(model_instance, {})
             self.assertEqual(html, '<strong>Test</strong>')
 

--- a/docs/how_to/testing.rst
+++ b/docs/how_to/testing.rst
@@ -68,9 +68,11 @@ it or the context provided to its template::
 
 
     from django.test import TestCase
+    from django.test.client import RequestFactory
 
     from cms.api import add_plugin
     from cms.models import Placeholder
+    from cms.plugin_rendering import ContentRenderer
 
     from myapp.cms_plugins import MyPlugin
     from myapp.models import MyappPlugin
@@ -95,6 +97,9 @@ it or the context provided to its template::
                 MyPlugin,
                 'en',
             )
-            html = model_instance.render_plugin({})
+            context = {
+                'cms_content_renderer': ContentRenderer(request=RequestFactory())
+            }
+            html = model_instance.render_plugin(context)
             self.assertEqual(html, '<strong>Test</strong>')
 


### PR DESCRIPTION
After this PR  #5558 , code for plugin testing changes but didn't reflected at documentation yet

> Placeholder.render() now requires a cms_content_renderer instance in the context.
> CMSPlugin.render() now requires a cms_content_renderer instance in the context.