### PR TITLE
Improve documentation for `copy_relations` method

### DIFF
--- a/docs/how_to/custom_plugins.rst
+++ b/docs/how_to/custom_plugins.rst
@@ -361,6 +361,11 @@ new plugin::
         title = models.CharField(max_length=50)
 
         def copy_relations(self, oldinstance):
+            # Before copying related objects from the old instance, the ones
+            # on the current one need to be deleted. Otherwise, duplicates may
+            # appear on the public version of the page
+            self.associated_item.all().delete()
+
             for associated_item in oldinstance.associated_item.all():
                 # instance.pk = None; instance.pk.save() is the slightly odd but
                 # standard Django way of copying a saved model instance


### PR DESCRIPTION
Before coping related objects from old instance current one need to be deleted or at public version of the page can appear duplicates.

This is the same PR as #5591 but against `release/3.4.x`