### PR TITLE
Docs: Run the django CMS installer in debug mode

### DIFF
--- a/docs/introduction/install.rst
+++ b/docs/introduction/install.rst
@@ -49,11 +49,12 @@ Create a new directory to work in, and ``cd`` into it::
 
 Run it to create a new Django project called ``mysite``::
 
-    djangocms -f -p . mysite
+    djangocms -w -f -p . mysite
 
 This means:
 
 * run the django CMS installer
+* use wizard mode (``-w``) - **required for this tutorial**
 * install Django Filer too (``-f``) - **required for this tutorial**
 * use the current directory as the parent of the new project directory (``-p .``)
 * call the new project directory ``mysite``


### PR DESCRIPTION
-Since django CMS installer version 0.9, the installer runs by default in batch mode. (Source: https://github.com/nephila/djangocms-installer/issues/291#issuecomment-250995737)
-With the previous tutorial the django CMS installer version >= 0.9 will not ask any questions.
-To run the django CMS installer in wizard mode, one must set the -w flag