### PR TITLE
Fixed #5752 -- Move pages relative to left or right siblings

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -14,13 +14,16 @@
 * Added official support for Django 1.10.
 * Fixed a bug where plugin save would incorrectly be triggered on pressing
   command and then enter in Firefox.
-* fix template inheritance setting creates spurious migration (see #3479)
+* Fixed a bug where template inheritance setting creates spurious migration (see #3479)
 * Fixed a bug which prevented the page from being marked as dirty (pending changes)
   when changing the value of the overwrite url field.
 * Adjusted ajax calls triggered when performing a placeholder operation (add plugin, etc..) to include
   a GET query called cms_path. This query points to the path where the operation originates from.
 * Added a deprecation warning to method ``render_plugin()`` in class ``CMSPluginBase``.
 * Since ``get_parent_classes()`` became a classmethod, do not instantiate plugin before invocation.
+* Fixed a bug where the page tree would not update correctly when a sibling page was moved
+  from left to right or right to left.
+* Improved the ``fix-tree`` command to also fix non-root nodes (pages).
 
 
 === 3.4.1 (2016-10-04) ===

--- a/cms/management/commands/subcommands/tree.py
+++ b/cms/management/commands/subcommands/tree.py
@@ -1,9 +1,27 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, print_function, unicode_literals
 
+from collections import OrderedDict
+
 from cms.models import Page, CMSPlugin
 
 from .base import SubcommandsCommand
+
+
+def get_descendant_ids(root_id):
+    """
+    Returns the a generator of primary keys which represent
+    descendants of the given page ID (root_id)
+    """
+    # Note this is done because get_descendants() can't be trusted
+    # as the tree can be corrupt.
+    children = Page.objects.filter(parent=root_id).values_list('pk', flat=True)
+
+    for child_id in children.iterator():
+        yield child_id
+
+        for descendant_id in get_descendant_ids(child_id):
+            yield descendant_id
 
 
 class FixTreeCommand(SubcommandsCommand):
@@ -57,6 +75,80 @@ class FixTreeCommand(SubcommandsCommand):
             public = page.publisher_public
             page.move(target=public, pos='right')
 
+        for root in root_draft_pages.order_by('site__pk', 'path'):
+            self._update_descendants_tree(root)
+
         self.stdout.write('fixing plugin tree')
         CMSPlugin.fix_tree()
         self.stdout.write('all done')
+
+    def _update_descendants_tree(self, root):
+        descendants_ids = get_descendant_ids(root.pk)
+        public_root_sibling = root.publisher_public
+
+        draft_descendants = (
+            Page
+            .objects
+            .filter(pk__in=descendants_ids)
+            .select_related('parent', 'publisher_public')
+            .order_by('depth', 'path')
+        )
+
+        descendants_by_parent = OrderedDict()
+
+        for descendant in draft_descendants.iterator():
+            parent = descendant.parent_id
+            descendants_by_parent.setdefault(parent, []).append(descendant)
+
+        for tree in descendants_by_parent.values():
+            last_draft = None
+            last_public = None
+            draft_parent = tree[0].parent
+            public_parent = draft_parent.publisher_public
+
+            for draft_page in tree:
+                draft_page.refresh_from_db()
+
+                if last_draft:
+                    # This is not the loop so this is not the first draft
+                    # child. Set this page a sibling of the last processed
+                    # draft page.
+                    draft_page.move(target=last_draft.reload(), pos='right')
+                else:
+                    # This is the first time through the loop so this is the first
+                    # draft child for this parent.
+                    draft_page.move(target=draft_parent.reload(), pos='first-child')
+
+                last_draft = draft_page
+
+                if not draft_page.publisher_public_id:
+                    continue
+
+                public_page = draft_page.publisher_public
+
+                if last_public:
+                    public_target = last_public
+                    public_position = 'right'
+                    last_public = public_page
+                elif public_parent:
+                    # always insert the first public child node found
+                    # as the first child of the public parent
+                    public_target = public_parent
+                    public_position = 'first-child'
+                    last_public = public_page
+                else:
+                    # No public parent has been found
+                    # Insert the node as a sibling to the last root sibling
+                    # Its very unlikely but possible for the root to not have
+                    # a public page. When this happens, use the root draft page
+                    # as sibling.
+                    public_target = public_root_sibling or root
+                    public_position = 'right'
+                    # This page now becomes the last root sibling
+                    public_root_sibling = public_page
+
+                public_page.refresh_from_db()
+                public_page.move(
+                    target=public_target.reload(),
+                    pos=public_position,
+                )

--- a/cms/tests/test_page.py
+++ b/cms/tests/test_page.py
@@ -340,6 +340,74 @@ class PagesTestCase(CMSTestCase):
         self.assertTrue(page.get_draft_object().publisher_is_draft)
         self.assertRaises(PublicVersionNeeded, page_b.reset_to_public, 'en')
 
+    def test_move_page_regression_left_to_right_5752(self):
+        # ref: https://github.com/divio/django-cms/issues/5752
+        # Tests tree integrity when moving sibling pages from left
+        # to right under the same parent.
+        home = create_page("Home", "nav_playground.html", "en", published=True)
+        alpha = create_page(
+            "Alpha",
+            "nav_playground.html",
+            "en",
+            published=True,
+            parent=home,
+        )
+        beta = create_page(
+            "Beta",
+            "nav_playground.html",
+            "en",
+            published=True,
+            parent=home,
+        )
+        beta.move_page(alpha, position='left')
+
+        alpha.refresh_from_db()
+        beta.refresh_from_db()
+
+        # Draft
+        self.assertEqual(home.path, '0001')
+        self.assertEqual(beta.path, '00010001')
+        self.assertEqual(alpha.path, '00010002')
+
+        # Public
+        self.assertEqual(home.publisher_public.path, '0002')
+        self.assertEqual(beta.publisher_public.path, '00020001')
+        self.assertEqual(alpha.publisher_public.path, '00020002')
+
+    def test_move_page_regression_right_to_left_5752(self):
+        # ref: https://github.com/divio/django-cms/issues/5752
+        # Tests tree integrity when moving sibling pages from right
+        # to left under the same parent.
+        home = create_page("Home", "nav_playground.html", "en", published=True)
+        alpha = create_page(
+            "Alpha",
+            "nav_playground.html",
+            "en",
+            published=True,
+            parent=home,
+        )
+        beta = create_page(
+            "Beta",
+            "nav_playground.html",
+            "en",
+            published=True,
+            parent=home,
+        )
+        beta.move_page(alpha, position='left')
+
+        alpha.refresh_from_db()
+        beta.refresh_from_db()
+
+        # Draft
+        self.assertEqual(home.path, '0001')
+        self.assertEqual(beta.path, '00010001')
+        self.assertEqual(alpha.path, '00010002')
+
+        # Public
+        self.assertEqual(home.publisher_public.path, '0002')
+        self.assertEqual(beta.publisher_public.path, '00020001')
+        self.assertEqual(alpha.publisher_public.path, '00020002')
+
     def test_move_page_regression_5640(self):
         # ref: https://github.com/divio/django-cms/issues/5640
         alpha = create_page("Alpha", "nav_playground.html", "en", published=True)

--- a/cms/utils/admin.py
+++ b/cms/utils/admin.py
@@ -105,7 +105,7 @@ def render_admin_rows(request, pages, site, filtered=False, language=None):
         if filtered:
             children = page.children.none()
         else:
-            children = page.children.all()
+            children = page.get_children()
 
         context = {
             'request': request,


### PR DESCRIPTION
Included in this PR:

* Fixes & Tests for #5752
* Extensions to the fix-tree command to also fix all non-root pages