### PR TITLE
Fixed #5778 -- Don't set cache when cms_edit is True on session.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,8 @@
 * Fixed a bug which prevented certain migrations from running in a multi-db setup.
 * Fixed a regression which prevented the ``Page`` model from rendering correctly
   when used in a ``raw_id_field``.
+* Fixed a regression which caused the CMS to cache the toolbar when ``CMS_PAGE_CACHE``
+  was set to ``True`` and an anon user had ``cms_edit`` set to ``True`` on their session.
 
 
 === 3.4.1 (2016-10-04) ===

--- a/cms/toolbar/toolbar.py
+++ b/cms/toolbar/toolbar.py
@@ -68,7 +68,7 @@ class CMSToolbar(ToolbarAPIMixin):
         # This attribute is modified by the placeholder rendering
         # mechanism in case a placeholder rendered by the current
         # request cannot be cached.
-        self._cache_disabled = self.edit_mode
+        self._cache_disabled = self.edit_mode or self.show_toolbar
 
         with force_language(self.language):
             try:
@@ -404,7 +404,7 @@ class EmptyToolbar(object):
     is_staff = False
     edit_mode = False
     show_toolbar = False
-    _cache_disabled = False
+    _cache_disabled = True
 
     def __init__(self, request):
         self.request = request


### PR DESCRIPTION
Fixed #5778