### PR TITLE
Added official Django 1.10 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -159,39 +159,6 @@ matrix:
 
   allow_failures:
 
-    - python: 3.5
-      env: DJANGO=1.10 DATABASE_URL='sqlite://localhost/:memory:' MIGRATE_OPTION='--migrate'
-    - python: 3.5
-      env: DJANGO=1.10 DATABASE_URL='mysql://root@127.0.0.1/djangocms_test'
-    - python: 3.5
-      env: DJANGO=1.10 DATABASE_URL='postgres://postgres@127.0.0.1/djangocms_test' MIGRATE_OPTION='--migrate'
-    - python: 3.5
-      env: DJANGO=1.10 DATABASE_URL='postgres://postgres@127.0.0.1/djangocms_test' AUTH_USER_MODEL='emailuserapp.EmailUser'
-    - python: 3.5
-      env: DJANGO=1.10 DATABASE_URL='postgres://postgres@127.0.0.1/djangocms_test' AUTH_USER_MODEL='customuserapp.User'
-
-    - python: 3.4
-      env: DJANGO=1.10 DATABASE_URL='sqlite://localhost/:memory:' MIGRATE_OPTION='--migrate'
-    - python: 3.4
-      env: DJANGO=1.10 DATABASE_URL='mysql://root@127.0.0.1/djangocms_test'
-    - python: 3.4
-      env: DJANGO=1.10 DATABASE_URL='postgres://postgres@127.0.0.1/djangocms_test' MIGRATE_OPTION='--migrate'
-    - python: 3.4
-      env: DJANGO=1.10 DATABASE_URL='postgres://postgres@127.0.0.1/djangocms_test' AUTH_USER_MODEL='emailuserapp.EmailUser'
-    - python: 3.4
-      env: DJANGO=1.10 DATABASE_URL='postgres://postgres@127.0.0.1/djangocms_test' AUTH_USER_MODEL='customuserapp.User'
-
-    - python: 2.7
-      env: DJANGO=1.10 DATABASE_URL='sqlite://localhost/:memory:' MIGRATE_OPTION='--migrate'
-    - python: 2.7
-      env: DJANGO=1.10 DATABASE_URL='mysql://root@127.0.0.1/djangocms_test'
-    - python: 2.7
-      env: DJANGO=1.10 DATABASE_URL='postgres://postgres@127.0.0.1/djangocms_test' MIGRATE_OPTION='--migrate'
-    - python: 2.7
-      env: DJANGO=1.10 DATABASE_URL='postgres://postgres@127.0.0.1/djangocms_test' AUTH_USER_MODEL='emailuserapp.EmailUser'
-    - python: 2.7
-      env: DJANGO=1.10 DATABASE_URL='postgres://postgres@127.0.0.1/djangocms_test' AUTH_USER_MODEL='customuserapp.User'
-
     - python: 2.7
       env: DJANGO=1.8 DATABASE_URL='mysql://root@127.0.0.1/djangocms_test'
     - python: 2.7

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,6 +11,7 @@
   was set to ``True`` and an anon user had ``cms_edit`` set to ``True`` on their session.
 * Fixed a regression which prevented users from overriding content in an inherited
   placeholder.
+* Added official support for Django 1.10.
 
 
 === 3.4.1 (2016-10-04) ===

--- a/docs/how_to/install.rst
+++ b/docs/how_to/install.rst
@@ -22,9 +22,9 @@ Requirements
 ************
 
 * `Python`_ 2.7, 3.3, 3.4 or 3.5.
-* `Django`_ 1.8.x, 1.9.x
+* `Django`_ 1.8.x, 1.9.x, 1.10.x
 * `django-classy-tags`_ 0.7.0 or higher
-* `django-treebeard`_ 4.0
+* `django-treebeard`_ 4.x
 * `django-sekizai`_ 0.8.2 or higher
 * `djangocms-admin-style`_ 1.0 or higher
 * An installed and working instance of one of the databases listed in the

--- a/setup.py
+++ b/setup.py
@@ -21,10 +21,11 @@ CLASSIFIERS = [
     'Framework :: Django',
     'Framework :: Django :: 1.8',
     'Framework :: Django :: 1.9',
+    'Framework :: Django :: 1.10',
 ]
 
 INSTALL_REQUIREMENTS = [
-    'Django>=1.8,<1.10',
+    'Django>=1.8,<1.11',
     'django-classy-tags>=0.7.2',
     'django-formtools>=1.0',
     'django-treebeard>=4.0.1',


### PR DESCRIPTION
With the release of treebeard 4.1 we can now support Django 1.10 officially
This PR:
* "promotes" relevant travis matrix items
* Uses official treebeard package
* Change dependency and metadata accordingly
* No code change is required