### PR TITLE
removed deprecated argument current_app

### DIFF
--- a/cms/admin/placeholderadmin.py
+++ b/cms/admin/placeholderadmin.py
@@ -741,5 +741,4 @@ class PlaceholderAdminMixin(object):
             "opts": opts,
             "app_label": app_label,
         }
-        return TemplateResponse(request, "admin/cms/page/plugin/delete_confirmation.html", context,
-                                current_app=self.admin_site.name)
+        return TemplateResponse(request, "admin/cms/page/plugin/delete_confirmation.html", context)


### PR DESCRIPTION
The argument current_app is deprecated since Django-1.9, so it's safe to remove it completety