### PR TITLE
Fix language used in page settings link

### DIFF
--- a/cms/utils/admin.py
+++ b/cms/utils/admin.py
@@ -114,7 +114,7 @@ def render_admin_rows(request, pages, site, filtered=False, language=None):
             'filtered': filtered,
             'metadata': metadata,
             'page_languages': page.get_languages(),
-            'preview_language': language,
+            'preview_language': lang,
             'has_add_page_permission': user_can_add(user, target=page),
             'has_change_permission': user_can_change(user, page),
             'has_change_advanced_settings_permission': user_can_change_advanced_settings(user, page),


### PR DESCRIPTION
The language used for the settings button in the admin pages menu always points to the last language because it's using a loop variable instead of the proper language.

This is already fixed in master but I'm not sure if master is used for bugfix releases so feel free to close this PR if you think it's not necessary.