### PR TITLE
Menu: don't deepcopy because it is redundant

### DIFF
--- a/menus/menu_pool.py
+++ b/menus/menu_pool.py
@@ -205,7 +205,6 @@ class MenuRenderer(object):
         if not site_id:
             site_id = Site.objects.get_current().pk
         nodes = self._build_nodes(site_id)
-        nodes = copy.deepcopy(nodes)
         nodes = self.apply_modifiers(
             nodes=nodes,
             namespace=namespace,


### PR DESCRIPTION
``MenuRenderer.get_nodes()`` always calls ``self._build_nodes()``, which either returns a node list read from the cache or freshly generated. In either case there is no need to do a ``copy.deep_copy()``.
``copy.deep_copy()`` is an expensive operation that takes about 1s with 10k pages and 22ms with 350 Pages.
It is called once per occurrence of the ``{% show_menu %}`` templatetag.

Tests have shown that multiple cache fetches are faster than deepcopy (tested with redis cache on the same host), which is why I chose this approach. The alternative would have been to keep the ``copy.deepcopy()`` and instead cache the full pagetree at python level on the request to avoid multiple cache fetches per request.