### PR TITLE
Deprecated CMSPluginBase attribute; removed deprecated CMSPlugin methods

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -24,6 +24,9 @@
 * Fixed a bug where the page tree would not update correctly when a sibling page was moved
   from left to right or right to left.
 * Improved the ``fix-tree`` command to also fix non-root nodes (pages).
+* Removed the deprecated ``add_url()``, ``edit_url()``, ``move_url()``, ``delete_url()``, ``copy_url()`` methods of
+  CMSPlugin model.
+* Deprecated ``frontend_edit_template`` of CMSPluginBase.
 
 
 === 3.4.1 (2016-10-04) ===

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -24,7 +24,7 @@
 * Fixed a bug where the page tree would not update correctly when a sibling page was moved
   from left to right or right to left.
 * Improved the ``fix-tree`` command to also fix non-root nodes (pages).
-* Removed the deprecated ``add_url()``, ``edit_url()``, ``move_url()``, ``delete_url()``, ``copy_url()`` methods of
+* Removed the deprecated ``add_url()``, ``edit_url()``, ``move_url()``, ``delete_url()``, ``copy_url()`` properties of
   CMSPlugin model.
 * Deprecated ``frontend_edit_template`` of CMSPluginBase.
 

--- a/cms/models/pluginmodel.py
+++ b/cms/models/pluginmodel.py
@@ -581,41 +581,6 @@ class CMSPlugin(six.with_metaclass(PluginModelBase, MP_Node)):
     def get_copy_url(self):
         return self.placeholder.get_copy_url()
 
-    @property
-    def add_url(self):
-        """
-        Returns a custom url to add plugin instances
-        """
-        return None
-
-    @property
-    def edit_url(self):
-        """
-        Returns a custom url to edit plugin instances
-        """
-        return None
-
-    @property
-    def move_url(self):
-        """
-        Returns a custom url to move plugin instances
-        """
-        return None
-
-    @property
-    def delete_url(self):
-        """
-        Returns a custom url to delete plugin instances
-        """
-        return None
-
-    @property
-    def copy_url(self):
-        """
-        Returns a custom url to copy plugin instances
-        """
-        return None
-
 
 reversion_register(CMSPlugin)
 

--- a/cms/plugin_rendering.py
+++ b/cms/plugin_rendering.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import warnings
+
 from collections import deque
 
 from classytags.utils import flatten_context
@@ -379,6 +381,10 @@ class ContentRenderer(object):
         except AttributeError:
             content = output % {'pk': instance.pk, 'content': content}
         else:
+            warnings.warn(
+                "Attribute `frontend_edit_template` will be removed in django CMS 3.5",
+                PendingDeprecationWarning
+            )
             content = template.render(context)
 
         plugin_type = instance.plugin_type

--- a/docs/reference/plugins.rst
+++ b/docs/reference/plugins.rst
@@ -109,7 +109,9 @@ CMSPluginBase Attributes and Methods Reference
 
     ..  attribute:: frontend_edit_template
 
-        Default: ``cms/toolbar/placeholder_wrapper.html``
+        *This attribute is deprecated and will be removed in 3.5.*
+
+        Default: ``cms/toolbar/plugin.html``
 
         The template used for wrapping the plugin in frontend editing.
 
@@ -556,61 +558,6 @@ CMSPlugin Attributes and Methods Reference
 
         Returns the URL to call to copy a plugin instance; useful to implement plugin-specific
         logic in a custom view.
-
-
-    ..  method:: add_url()
-
-        Returns the URL to call to add a plugin instance; useful to implement plugin-specific
-        logic in a custom view.
-
-        This property is now deprecated. Will be removed in 3.4.
-        Use the ``get_add_url`` method instead.
-
-        Default: None (``cms_page_add_plugin`` view is used)
-
-
-    ..  method:: edit_url()
-
-        Returns the URL to call to edit a plugin instance; useful to implement plugin-specific
-        logic in a custom view.
-
-        This property is now deprecated. Will be removed in 3.4.
-        Use the ``get_edit_url`` method instead.
-
-        Default: None (``cms_page_edit_plugin`` view is used)
-
-
-    ..  method:: move_url()
-
-        Returns the URL to call to move a plugin instance; useful to implement plugin-specific
-        logic in a custom view.
-
-        This property is now deprecated. Will be removed in 3.4.
-        Use the ``get_move_url`` method instead.
-
-        Default: None (``cms_page_move_plugin`` view is used)
-
-
-    ..  method:: delete_url()
-
-        Returns the URL to call to delete a plugin instance; useful to implement plugin-specific
-        logic in a custom view.
-
-        This property is now deprecated. Will be removed in 3.4.
-        Use the ``get_delete_url`` method instead.
-
-        Default: None (``cms_page_delete_plugin`` view is used)
-
-
-    ..  method:: copy_url()
-
-        Returns the URL to call to copy a plugin instance; useful to implement plugin-specific
-        logic in a custom view.
-
-        This property is now deprecated. Will be removed in 3.4.
-        Use the ``get_copy_url`` method instead.
-
-        Default: None (``cms_page_copy_plugins`` view is used)
 
 
 ..  class:: cms.plugin_pool.PluginPool


### PR DESCRIPTION
* Removed the deprecated add_url(), edit_url(), move_url(), delete_url(), copy_url() methods of
  CMSPlugin model.
* Deprecated frontend_edit_template of CMSPluginBase.
* Updated documentation for above.
* Also corrected now-deprecated frontend_edit_template attribute name in documentation; was previously fixed in
https://github.com/divio/django-cms/pull/5438, and inadvertently overwritten in
https://github.com/divio/django-cms/pull/5427 (sorry!).