### PR TITLE
Fixes a typo in the CMS_TOOLBAR_HIDE reference.

### DIFF
--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -1014,7 +1014,8 @@ CMS_TOOLBAR_HIDE
 default
     ``False``
 
-If True, the toolbar is hidden in the pages out django CMS.
+If True, the toolbar is not displayed in pages that use the ``{% cms_toolbar %}`` template tag if they are not
+actually being handled by a django CMS view.
 
 .. versionchanged:: 3.2.1: CMS_APP_NAME has been removed as it's no longer required.
 

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -1014,11 +1014,15 @@ CMS_TOOLBAR_HIDE
 default
     ``False``
 
-If True, the toolbar is not displayed in pages that use the ``{% cms_toolbar %}`` template tag if they are not
-actually being handled by a django CMS view.
+By default, the django CMS toolbar is displayed to logged-in admin users on all pages that use the ``{% cms_toolbar
+%}`` template tag. Its appearance can be optionally restricted to django CMS pages only (technically, pages that are
+published by a django CMS view).
+
+When this is set to ``True``, all other pages will no longer display the toolbar. This includes pages with apphooks
+applied to them, as they are handled by the other application's views, and not django CMS's.
+
 
 .. versionchanged:: 3.2.1: CMS_APP_NAME has been removed as it's no longer required.
-
 
 CMS_DEFAULT_X_FRAME_OPTIONS
 ===========================

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -1016,7 +1016,7 @@ default
 
 By default, the django CMS toolbar is displayed to logged-in admin users on all pages that use the ``{% cms_toolbar
 %}`` template tag. Its appearance can be optionally restricted to django CMS pages only (technically, pages that are
-published by a django CMS view).
+rendered by a django CMS view).
 
 When this is set to ``True``, all other pages will no longer display the toolbar. This includes pages with apphooks
 applied to them, as they are handled by the other application's views, and not django CMS's.


### PR DESCRIPTION
[ci skip]