### PR TITLE
Improved Page and Title extension documentation

### DIFF
--- a/cms/extensions/toolbar.py
+++ b/cms/extensions/toolbar.py
@@ -9,43 +9,6 @@ from django.core.urlresolvers import NoReverseMatch
 
 
 class ExtensionToolbar(CMSToolbar):
-    """
-    ExtensionToolbar provides utility functions to handle much of the boilerplate involved in creating a toolbar for
-    PageExtension and TitleExtension.
-
-    The basic implementation of an extension toolbar using this class is::
-
-        @toolbar_pool.register
-        class SampleExtension(ExtensionToolbar):
-            model = ExtModel  # The PageExtension / TitleExtension you are working with
-
-            def populate(self):
-                current_page_menu = self._setup_extension_toolbar()
-                if current_page_menu:
-                    position = 0
-                    page_extension, url = self.get_page_extension_admin()
-                    if url:
-                        current_page_menu.add_modal_item('Item label', url=url,
-                                                         disabled=not self.toolbar.edit_mode,
-                                                         position=position)
-
-    For TitleExtension use ``get_title_extension_admin`` and cycle on the resulting title extensions and urls
-
-        @toolbar_pool.register
-        class SampleExtension(ExtensionToolbar):
-            model = ExtModel  # The PageExtension / TitleExtension you are working with
-
-            def populate(self):
-                current_page_menu = self._setup_extension_toolbar()
-                if current_page_menu:
-                    position = 0
-                    urls = self.get_title_extension_admin()
-                    for title_extension, url in urls:
-                        current_page_menu.add_modal_item('Item label', url=url,
-                                                         disabled=not self.toolbar.edit_mode,
-                                                         position=position)
-
-    """
     model = None
     page = None
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -110,8 +110,6 @@ django CMS is a well-tested CMS platform that powers sites both large and
 small. Here are a few of the key features:
 
 * robust internationalisation (i18n) support for creating multilingual sites
-* virtually unlimited undo history, allowing editors to revert to a previous
-  version
 * front-end editing, providing rapid access to the content management interface
 * support for a variety of editors with advanced text editing features.
 * a flexible plugins system that lets developers put powerful tools at the

--- a/docs/reference/pages.rst
+++ b/docs/reference/pages.rst
@@ -6,3 +6,6 @@ Models
 
     A ``Page`` is the basic unit of site structure in django CMS. The CMS uses a hierachical page model: each page
     stands in relation to other pages as parent, child or sibling.
+
+    A ``Page`` also has language-specific properties - for example, it will have a title and a slugfor each language it
+    exists in. These properties are managed by the :class:`cms.models.Title` model.

--- a/docs/reference/pages.rst
+++ b/docs/reference/pages.rst
@@ -5,7 +5,8 @@ Models
 ..  class:: cms.models.Page
 
     A ``Page`` is the basic unit of site structure in django CMS. The CMS uses a hierachical page model: each page
-    stands in relation to other pages as parent, child or sibling.
+    stands in relation to other pages as parent, child or sibling. This hierarchy is managed by the `django-treebeard
+    <http://django-treebeard.readthedocs.io/en/latest/>`_ library.
 
-    A ``Page`` also has language-specific properties - for example, it will have a title and a slugfor each language it
+    A ``Page`` also has language-specific properties - for example, it will have a title and a slug for each language it
     exists in. These properties are managed by the :class:`cms.models.Title` model.

--- a/docs/reference/titles.rst
+++ b/docs/reference/titles.rst
@@ -3,3 +3,9 @@ Titles
 ######
 
 ..  class:: cms.models.Title
+
+    Titles support pages by providing a storage mechanism, amongst other things, for language-specific
+    properties of :class:`cms.models.Page`, such as its title, slug, meta description and so on.
+
+    Each ``Title`` has a foreign key to :class:`cms.models.Page`; each :class:`cms.models.Page` may have several
+    ``Titles``.


### PR DESCRIPTION
* improved Page example
* corrected Title example so it actually works properly
* removed broken example from cms.toolbar.ExtensionToolbar comments
* bonus: removed out-of-date note about redo/undo from documentation home page

Fixes #5092
Fixes #5083

[ci skip]