### PR TITLE
Fixed #5858 -- Double slashes in admin login url

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,7 @@
 === 3.4.3 (unreleased) ===
 
 * Fixed a bug where canceling the publishing dialog wasn't respected.
+* Fixed a bug when after authentication us redirected on wrong url (site have only one language)
 
 
 === 3.4.2 (2017-01-23) ===

--- a/cms/templates/cms/welcome.html
+++ b/cms/templates/cms/welcome.html
@@ -92,7 +92,11 @@
                 }
             });
         {% else %}
-            window.location.href = '{% url "admin:login" %}?next=/{{ LANGUAGE_CODE }}/?{{ cms_edit_on }}';
+            {% if LANGUAGE_CODE %}
+                window.location.href = '{% url "admin:login" %}?next=/{{ LANGUAGE_CODE }}/?{{ cms_edit_on }}';
+            {% else %}
+                window.location.href = '{% url "admin:login" %}?next=/?{{ cms_edit_on }}';
+            {% endif %}
         {% endif %}
     </script>
 </body>


### PR DESCRIPTION
### Summary

Fixes #5858


### Links to related discussion



### Proposed changes in this pull request
In my case I have only one language in LANGUAGES list. In url it don't placed (main page is: http://localhost:8000/). But redirect to admin login we paste current LANGUAGE_CODE in login url and take: "//?" (if we have more languages it will be "/ru/?" or "/en/?" as example).

I add little check to have or not LANGUAGE_CODE in current page.