### PR TITLE
Pinned intersphinx_mapping for Django to version 1.10

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,7 +33,7 @@ sys.path.append(os.path.join(os.path.abspath('.'), '_ext'))
 extensions = ['djangocms', 'sphinx.ext.intersphinx', 'sphinx.ext.todo', 'sphinx.ext.autodoc']
 intersphinx_mapping = {
     'python': ('http://docs.python.org/3/', None),
-    'django': ('http://docs.djangoproject.com/en/dev/', 'http://docs.djangoproject.com/en/dev/_objects/'),
+    'django': ('https://docs.djangoproject.com/en/1.10/', 'https://docs.djangoproject.com/en/1.10/_objects/'),
     'classytags': ('http://readthedocs.org/docs/django-classy-tags/en/latest/', None),
     'sekizai': ('http://readthedocs.org/docs/django-sekizai/en/latest/', None),
     'treebeard': ('http://django-treebeard.readthedocs.io/en/latest/', None),


### PR DESCRIPTION
Occasionally, Django documentation references change; this will prevent unexpected breakage of links.

Also, we don't support Django's master branch, so we should refer to the latest supported release instead (currently 1.10).