### PR TITLE
Improved Documentation on Navigation Modifiers

### DIFF
--- a/docs/how_to/menus.rst
+++ b/docs/how_to/menus.rst
@@ -179,7 +179,7 @@ To make your modifier available, it then needs to be registered with
 Now, when a page is loaded and the menu generated, your modifier will
 be able to inspect and modify its nodes.
 
-Here is an example of a simple modifier that places a Page's attribute in the corresponding
+Here is an example of a simple modifier that places the Page's ``changed_by`` attribute in the corresponding
 ``NavigationNode``::
 
     from menus.base import Modifier
@@ -187,23 +187,28 @@ Here is an example of a simple modifier that places a Page's attribute in the co
 
     from cms.models import Page
 
-    class MyMode(Modifier):
+    class MyExampleModifier(Modifier):
         """
-
+        This modifier makes the changed_by attribute of a page
+        accessible for the menu system.
         """
         def modify(self, request, nodes, namespace, root_id, post_cut, breadcrumb):
-            # if the menu is not yet cut, don't do anything
+            # only do something when the menu is already cut
             if post_cut:
-                return nodes
-            # otherwise loop over the nodes
-            for node in nodes:
-                # does this node represent a Page?
-                if node.attr["is_page"]:
-                    # if so, put its changed_by attribute on the node
-                    node.attr["changed_by"] = Page.objects.get(id=node.id).changed_by
+                # only consider nodes that refer to cms pages
+                # and put them in a dict for efficient access
+                page_nodes = {n.id: n for n in nodes if n.attr["is_page"]}
+                # retrieve the attributes of interest from the relevant pages
+                pages = Page.objects.filter(id__in=page_nodes.keys()).values('id', 'changed_by')
+                # loop over all relevant pages
+                for page in pages:
+                    # take the node referring to the page
+                    node = page_nodes[page['id']]
+                    # put the changed_by attribute on the node
+                    node.attr["changed_by"] = page['changed_by']
             return nodes
 
-    menu_pool.register_modifier(MyMode)
+    menu_pool.register_modifier(MyExampleModifier)
 
 
 It has a method :meth:`~menus.base.Modifier.modify` that should return a list
@@ -231,7 +236,22 @@ of :class:`~menus.base.NavigationNode` instances.
   the case ``post_cut`` is ``True``.
 
 ``breadcrumb``
-  Is this breadcrumb call rather than a menu call?
+  Is this a breadcrumb call rather than a menu call?
+
+
+Note: Navigation modifiers can quickly become a performance bottleneck. Each modifier is called
+multiple times: For the breadcrumb (``breadcrumb=True``),
+for the whole menu tree (``post_cut=False``),
+for the menu tree cut to the visible part (``post_cut=True``) and perhaps for each level
+of the navigation. Performing inefficient operations inside a navigation modifier
+can hence lead to big performance issues.
+Some tips for keeping a modifier implementation fast:
+
+* Specify when exactly the modifier is necessary (in breadcrumb, before or after cut).
+* Only consider nodes and pages relevant for the modification.
+* Perform as less database queries as possible (i.e. not in a loop).
+* In database queries, fetch exactly the attributes you are interested in.
+* If you have multiple modifications to do, try to apply them in the same method.
 
 
 Here is an example of a built-in modifier that marks all node levels::
@@ -264,4 +284,3 @@ Here is an example of a built-in modifier that marks all node levels::
                 self.mark_levels(child, post_cut)
 
     menu_pool.register_modifier(Level)
-

--- a/docs/how_to/menus.rst
+++ b/docs/how_to/menus.rst
@@ -179,7 +179,7 @@ To make your modifier available, it then needs to be registered with
 Now, when a page is loaded and the menu generated, your modifier will
 be able to inspect and modify its nodes.
 
-Here is an example of a simple modifier that places the Page's ``changed_by`` attribute in the corresponding
+Here is an example of a simple modifier that places each Page's ``changed_by`` attribute in the corresponding
 ``NavigationNode``::
 
     from menus.base import Modifier
@@ -193,7 +193,7 @@ Here is an example of a simple modifier that places the Page's ``changed_by`` at
         accessible for the menu system.
         """
         def modify(self, request, nodes, namespace, root_id, post_cut, breadcrumb):
-            # only do something when the menu is already cut
+            # only do something when the menu has already been cut
             if post_cut:
                 # only consider nodes that refer to cms pages
                 # and put them in a dict for efficient access
@@ -238,22 +238,6 @@ of :class:`~menus.base.NavigationNode` instances.
 ``breadcrumb``
   Is this a breadcrumb call rather than a menu call?
 
-
-Note: Navigation modifiers can quickly become a performance bottleneck. Each modifier is called
-multiple times: For the breadcrumb (``breadcrumb=True``),
-for the whole menu tree (``post_cut=False``),
-for the menu tree cut to the visible part (``post_cut=True``) and perhaps for each level
-of the navigation. Performing inefficient operations inside a navigation modifier
-can hence lead to big performance issues.
-Some tips for keeping a modifier implementation fast:
-
-* Specify when exactly the modifier is necessary (in breadcrumb, before or after cut).
-* Only consider nodes and pages relevant for the modification.
-* Perform as less database queries as possible (i.e. not in a loop).
-* In database queries, fetch exactly the attributes you are interested in.
-* If you have multiple modifications to do, try to apply them in the same method.
-
-
 Here is an example of a built-in modifier that marks all node levels::
 
 
@@ -284,3 +268,20 @@ Here is an example of a built-in modifier that marks all node levels::
                 self.mark_levels(child, post_cut)
 
     menu_pool.register_modifier(Level)
+
+Performance issues in menu modifiers
+====================================
+
+Navigation modifiers can quickly become a performance bottleneck. Each modifier is called
+multiple times: For the breadcrumb (``breadcrumb=True``),
+for the whole menu tree (``post_cut=False``),
+for the menu tree cut to the visible part (``post_cut=True``) and perhaps for each level
+of the navigation. Performing inefficient operations inside a navigation modifier
+can hence lead to big performance issues.
+Some tips for keeping a modifier implementation fast:
+
+* Specify when exactly the modifier is necessary (in breadcrumb, before or after cut).
+* Only consider nodes and pages relevant for the modification.
+* Perform as less database queries as possible (i.e. not in a loop).
+* In database queries, fetch exactly the attributes you are interested in.
+* If you have multiple modifications to do, try to apply them in the same method.


### PR DESCRIPTION
### Summary

When I wrote a navigation modifier for the first time, I was inspired by the example from the documentation and I just had to adapt it to my needs. Unfortunately, this caused major performance issues in production because there were over 20000 executed database queries! I hadn't questioned the way the example modifier was written, so I ran into this issue. I spend a lot of time figuring out what exactly was going on and developed a way more efficient implementation of my modifier.

What was wrong with the documentation? At first, it started with
```python
# if the menu is not yet cut, don't do anything
if post_cut:
    return nodes
```
That does exactly the opposite of what the the comment is indicating. It's executed for the big uncut tree as well as the breadcrumb.

Afterwards, it executes
```python
for node in nodes:
    if node.attr["is_page"]:
        node.attr["changed_by"] = Page.objects.get(id=node.id).changed_by
```
That's a fresh database lookup for each and every node present in the tree.

No wonder that our page took 10 seconds to load. To be honest, we were doing more complex stuff with page and title extensions there. 😋 But using the same structure of how and when the QuerySet operations were performed.

### Proposed changes in this pull request

To prevent others from running into this again, I rewrote the example in the documentation and noted a few tips about performance considerations. I hope you find this useful. :)
