### PR TITLE
Improved CMSApp.get_urls()

### DIFF
--- a/cms/appresolver.py
+++ b/cms/appresolver.py
@@ -164,7 +164,7 @@ def get_app_urls(urls):
                     "URLConf `%s` has no urlpatterns attribute" % urlconf)
             yield getattr(mod, 'urlpatterns')
         else:
-            yield urlconf
+            yield [urlconf]
 
 
 def get_patterns_for_title(path, title):

--- a/cms/appresolver.py
+++ b/cms/appresolver.py
@@ -163,6 +163,8 @@ def get_app_urls(urls):
                 raise ImproperlyConfigured(
                     "URLConf `%s` has no urlpatterns attribute" % urlconf)
             yield getattr(mod, 'urlpatterns')
+        elif isinstance(urlconf, (list, tuple)):
+            yield urlconf
         else:
             yield [urlconf]
 

--- a/cms/test_utils/project/fourth_cms_urls_for_apphook_tests.py
+++ b/cms/test_utils/project/fourth_cms_urls_for_apphook_tests.py
@@ -1,0 +1,29 @@
+from cms.apphook_pool import apphook_pool
+from cms.utils.compat.dj import is_installed
+from cms.views import details
+from django.conf import settings
+from django.conf.urls import url, include
+
+if settings.APPEND_SLASH:
+    reg = url(r'^(?P<slug>[0-9A-Za-z-_.//]+)/$', details, name='pages-details-by-slug')
+else:
+    reg = url(r'^(?P<slug>[0-9A-Za-z-_.//]+)$', details, name='pages-details-by-slug')
+
+urlpatterns = [
+    # Public pages
+    url(r'^$', details, {'slug':''}, name='pages-root'),
+    reg,
+]
+
+if apphook_pool.get_apphooks():
+    """If there are some application urls, add special resolver, so we will
+    have standard reverse support.
+    """
+    from cms.appresolver import get_app_patterns
+    urlpatterns = get_app_patterns() + urlpatterns
+
+if settings.DEBUG and is_installed('debug_toolbar'):
+    import debug_toolbar
+    urlpatterns += [
+        url(r'^__debug__/', include(debug_toolbar.urls)),
+    ]

--- a/cms/test_utils/project/fourth_urls_for_apphook_tests.py
+++ b/cms/test_utils/project/fourth_urls_for_apphook_tests.py
@@ -1,0 +1,31 @@
+from django.views.i18n import javascript_catalog
+from django.views.static import serve
+
+from cms.utils import get_cms_setting
+from cms.utils.compat.dj import is_installed
+from django.conf import settings
+from django.conf.urls import include, url
+from django.conf.urls.i18n import i18n_patterns
+from django.contrib import admin
+
+admin.autodiscover()
+
+urlpatterns = [
+    url(r'^admin/', include(admin.site.urls)),
+    url(r'^media/(?P<path>.*)$', serve,
+        {'document_root': settings.MEDIA_ROOT, 'show_indexes': True}),
+    url(r'^media/cms/(?P<path>.*)$', serve,
+        {'document_root': get_cms_setting('MEDIA_ROOT'), 'show_indexes': True}),
+    url(r'^jsi18n/(?P<packages>\S+?)/$', javascript_catalog),
+]
+
+urlpatterns += i18n_patterns(
+    url(r'^', include('cms.test_utils.project.fourth_cms_urls_for_apphook_tests')),
+)
+
+
+if settings.DEBUG and is_installed('debug_toolbar'):
+    import debug_toolbar
+    urlpatterns += [
+        url(r'^__debug__/', include(debug_toolbar.urls)),
+    ]

--- a/cms/test_utils/project/sampleapp/cms_apps.py
+++ b/cms/test_utils/project/sampleapp/cms_apps.py
@@ -1,6 +1,8 @@
 from cms.app_base import CMSApp
 from cms.test_utils.project.sampleapp.cms_menus import SampleAppMenu, StaticMenu3, StaticMenu4
 from cms.apphook_pool import apphook_pool
+from django.conf.urls import url
+from django.http import HttpResponse
 from django.utils.translation import ugettext_lazy as _
 
 
@@ -30,6 +32,21 @@ class SampleApp2(CMSApp):
     menus = [StaticMenu3]
 
 apphook_pool.register(SampleApp2)
+
+
+class SampleApp3(CMSApp):
+    # CMSApp which returns the url directly rather than trough another Python module
+    name = _("Sample App 3")
+
+    def get_urls(self, page=None, language=None, **kwargs):
+        def my_view(request):
+            return HttpResponse("Sample App 3 Response")
+
+        return [
+            url(r'^$', my_view, name='sample-app-3'),
+        ]
+
+apphook_pool.register(SampleApp3)
 
 
 class NamespacedApp(CMSApp):

--- a/cms/test_utils/project/sampleapp/cms_apps.py
+++ b/cms/test_utils/project/sampleapp/cms_apps.py
@@ -43,7 +43,7 @@ class SampleApp3(CMSApp):
             return HttpResponse("Sample App 3 Response")
 
         return [
-            url(r'^$', my_view, name='sample-app-3'),
+            url(r'^$', my_view, name='sample3-root'),
         ]
 
 apphook_pool.register(SampleApp3)

--- a/cms/tests/test_apphooks.py
+++ b/cms/tests/test_apphooks.py
@@ -536,6 +536,22 @@ class ApphooksTestCase(CMSTestCase):
         self.assertTemplateUsed(response, 'sampleapp/home.html')
         self.assertContains(response, 'my_params: is-my-param-really-in-the-context-QUESTIONMARK')
 
+    @override_settings(ROOT_URLCONF='cms.test_utils.project.urls_for_apphook_tests')
+    def test_apphooks_return_urls_directly(self):
+        self.apphook_clear()
+        superuser = get_user_model().objects.create_superuser('admin', 'admin@admin.com', 'admin')
+        page = create_page("apphooked-page", "nav_playground.html", "en",
+                           created_by=superuser, published=True, apphook="SampleApp3")
+        create_title("de", "aphooked-page-direct-url", page)
+        self.assertTrue(page.publish('en'))
+        self.reload_urls()
+
+        path = reverse('sample-app-3')
+        response = self.client.get(path)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Sample App 3 Response')
+        self.apphook_clear()
+
     @override_settings(ROOT_URLCONF='cms.test_utils.project.third_urls_for_apphook_tests')
     def test_multiple_apphooks(self):
         # test for #1538

--- a/cms/tests/test_apphooks.py
+++ b/cms/tests/test_apphooks.py
@@ -143,7 +143,7 @@ class ApphooksTestCase(CMSTestCase):
         self.apphook_clear()
         hooks = apphook_pool.get_apphooks()
         app_names = [hook[0] for hook in hooks]
-        self.assertEqual(len(hooks), 7)
+        self.assertEqual(len(hooks), 8)
         self.assertIn(NS_APP_NAME, app_names)
         self.assertIn(APP_NAME, app_names)
         self.apphook_clear()
@@ -536,22 +536,6 @@ class ApphooksTestCase(CMSTestCase):
         self.assertTemplateUsed(response, 'sampleapp/home.html')
         self.assertContains(response, 'my_params: is-my-param-really-in-the-context-QUESTIONMARK')
 
-    @override_settings(ROOT_URLCONF='cms.test_utils.project.urls_for_apphook_tests')
-    def test_apphooks_return_urls_directly(self):
-        self.apphook_clear()
-        superuser = get_user_model().objects.create_superuser('admin', 'admin@admin.com', 'admin')
-        page = create_page("apphooked-page", "nav_playground.html", "en",
-                           created_by=superuser, published=True, apphook="SampleApp3")
-        create_title("de", "aphooked-page-direct-url", page)
-        self.assertTrue(page.publish('en'))
-        self.reload_urls()
-
-        path = reverse('sample-app-3')
-        response = self.client.get(path)
-        self.assertEqual(response.status_code, 200)
-        self.assertContains(response, 'Sample App 3 Response')
-        self.apphook_clear()
-
     @override_settings(ROOT_URLCONF='cms.test_utils.project.third_urls_for_apphook_tests')
     def test_multiple_apphooks(self):
         # test for #1538
@@ -565,6 +549,21 @@ class ApphooksTestCase(CMSTestCase):
 
         reverse('sample-root')
         reverse('sample2-root')
+        self.apphook_clear()
+
+    @override_settings(ROOT_URLCONF='cms.test_utils.project.fourth_urls_for_apphook_tests')
+    def test_apphooks_return_urls_directly(self):
+        self.apphook_clear()
+        superuser = get_user_model().objects.create_superuser('admin', 'admin@admin.com', 'admin')
+        page = create_page("apphooked3-page", "nav_playground.html", "en",
+                           created_by=superuser, published=True, apphook="SampleApp3")
+        self.assertTrue(page.publish('en'))
+        self.reload_urls()
+
+        path = reverse('sample3-root')
+        response = self.client.get(path)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Sample App 3 Response')
         self.apphook_clear()
 
     def test_apphook_pool_register_returns_apphook(self):

--- a/docs/how_to/namespaced_apphooks.rst
+++ b/docs/how_to/namespaced_apphooks.rst
@@ -22,8 +22,10 @@ have an ``app_name`` attribute::
 
     class MyApphook(CMSApp):
         name = _("My Apphook")
-        urls = ["myapp.urls"]
         app_name = "myapp"
+
+        def get_urls(self, page=None, language=None, **kwargs):
+            return ["myapp.urls"]
 
 The ``app_name`` does three key things:
 

--- a/docs/introduction/apphooks.rst
+++ b/docs/introduction/apphooks.rst
@@ -35,8 +35,24 @@ This is a very basic example of an apphook for a django CMS application:
         def get_urls(self, page=None, language=None, **kwargs):
             return ["polls.urls"]
 
-
     apphook_pool.register(PollsApphook)  # register the application
+
+
+Instead of defining the URL patterns in another file ``polls/urls.py``, it also is possible
+to return them directly, for instance as:
+
+.. code-block:: python
+
+    from django.conf.urls import url
+    from polls.views import PollListView, PollDetailView
+
+    class PollsApphook(CMSApp):
+        # ...
+        def get_urls(self, page=None, language=None, **kwargs):
+            return [
+                url(r'^$', PollListView.as_view()),
+                url(r'^(?P<slug>[\w-]+)/?$', PollDetailView.as_view()),
+            ]
 
 
 What this all means


### PR DESCRIPTION
### Summary

One would expect that it should also be possible to create an apphook using the ``get_urls()`` method such as:

```
class MyApp(CMSApp):
    name = _("My App")

    def get_urls(self, page=None, language=None, **kwargs):
        return [
            url(r'^$', MyListView.as_view()),
            url(r'^(?P<slug>[\w-]+)/?$', MyDetailView.as_view()),
        ]
```

instead of returning a list of urlpatterns in a file.

Looking at function ``cms.appresolver.get_app_urls()`` this behavior apparently was intended, but not yet documented. Also, the first ``yield`` statement returns a list, while the second returns a single URL pattern.

Now both ``yield`` statements return a list, as intended.

Fixes #5898 