### PR TITLE
Revert 8fabb5c3ef8b928

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,8 +2,6 @@
 
 * Fixed a bug where canceling the publishing dialog wasn't respected.
 * Fixed a bug when after authentication us redirected on wrong url (site have only one language)
-* Fixed issue that the file 'cms/css/cms.base.css' could not be found when
-  CachedStaticFilesStorage or similar is used for STATICFILES_STORAGE
 * Changed the signature for internal ``cms.plugin_base.CMSPluginBase`` methods ``get_child_classes``
   and ``get_parent_classes`` to take an optional ``instance`` parameter.
 * Fixed error in retrieving placeholder label from configuration.

--- a/cms/templatetags/cms_static.py
+++ b/cms/templatetags/cms_static.py
@@ -28,5 +28,5 @@ def do_static_with_version(parser, token):
 class StaticWithVersionNode(StaticNode):
 
     def url(self, context):
-        self.path.var = static_with_version(self.path.resolve(context))
-        return super(StaticWithVersionNode, self).url(context)
+        url = super(StaticWithVersionNode, self).url(context)
+        return static_with_version(url)


### PR DESCRIPTION
Fixes https://github.com/divio/django-cms/issues/5907
This reverts commit 8fabb5c3ef8b9283b535ea1b76f029c51d3e9c29.
The commit in question introduced a regression.