### PR TITLE
Update configuration.rst  (cms_toolbars)

### DIFF
--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -986,12 +986,12 @@ Example::
 
     CMS_TOOLBARS = [
         # CMS Toolbars
-        'cms.cms_toolbar.PlaceholderToolbar',
-        'cms.cms_toolbar.BasicToolbar',
-        'cms.cms_toolbar.PageToolbar',
+        'cms.cms_toolbars.PlaceholderToolbar',
+        'cms.cms_toolbars.BasicToolbar',
+        'cms.cms_toolbars.PageToolbar',
 
         # third-party Toolbar
-        'aldryn_blog.cms_toolbar.BlogToolbar',
+        'aldryn_blog.cms_toolbars.BlogToolbar',
     ]
 
 .. _unihandecode.js: https://github.com/ojii/unihandecode.js


### PR DESCRIPTION
In the doc example of cms_toolbars configuration, we need to add an "s" at cms_toolbar for this to work.
```
In [1]: from cms import __version__

In [2]: from cms.toolbar_pool import toolbar_pool

In [3]: print (__version__)
3.4.2

In [4]: toolbar_pool.get_toolbars()
Out[4]: 
OrderedDict([('cms.cms_toolbars.PlaceholderToolbar',
              cms.cms_toolbars.PlaceholderToolbar),
             ('cms.cms_toolbars.BasicToolbar', cms.cms_toolbars.BasicToolbar),
             ('cms.cms_toolbars.PageToolbar', cms.cms_toolbars.PageToolbar)])

```