### PR TITLE
Update extending_page_title.rst (Handling relations)

### DIFF
--- a/docs/how_to/extending_page_title.rst
+++ b/docs/how_to/extending_page_title.rst
@@ -308,13 +308,13 @@ Handling relations
 ==================
 
 If your ``PageExtension`` or ``TitleExtension`` includes a ForeignKey *from* another
-model or includes a ManyToMany field, you should also override the method
+model or includes a ManyToManyField, you should also override the method
 ``copy_relations(self, oldinstance, language)`` so that these fields are
 copied appropriately when the CMS makes a copy of your extension to support
 versioning, etc.
 
 
-Here's an example that uses a ``ManyToMany``` field::
+Here's an example that uses a ``ManyToManyField`` ::
 
     from django.db import models
     from cms.extensions import PageExtension
@@ -323,7 +323,7 @@ Here's an example that uses a ``ManyToMany``` field::
 
     class MyPageExtension(PageExtension):
 
-        page_categories = models.ManyToMany('categories.Category', blank=True, null=True)
+        page_categories = models.ManyToManyField(Category, blank=True)
 
         def copy_relations(self, oldinstance, language):
             for page_category in oldinstance.page_categories.all():


### PR DESCRIPTION
In the doc example of "Handling relations",  we need to change ManyToMany to  ManyToManyField  because that back these errors:
> AttributeError: module 'django.db.models' has no attribute 'ManyToMany'
> project.MyPageExtension.page_categories: (fields.W340) null has no effect on ManyToManyField.
