### PR TITLE
Replaced the internal reset_to_live page method with revert_to_live

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -24,6 +24,7 @@
 * Fixed a 404 raised when clicking the ``Delete`` button for a page or title extension on Django >= 1.9
 * Added "How to serve multiple languages" section to documentation
 * Fixed a performance issue with nested pages when using the ``inherit`` flag on the ``{% placeholder %}`` tag.
+* Removed the internal ``reset_to_public`` page method in favour of the ``revert_to_live`` method.
 
 
 === 3.4.3 (2017-04-24) ===

--- a/cms/management/commands/subcommands/moderator.py
+++ b/cms/management/commands/subcommands/moderator.py
@@ -33,7 +33,7 @@ class ModeratorOnCommand(SubcommandsCommand):
             for language in page.get_languages():
                 if CMSPlugin.objects.filter(placeholder__page=page, language=language).exists():
                     log.debug('Reverting page pk=%d' % (page.pk,))
-                    page.publisher_draft.reset_to_public(language)
+                    page.publisher_draft.revert_to_live(language)
 
         log.info('Publishing all published drafts')
         for title in Title.objects.filter(publisher_is_draft=True, publisher_public_id__gt=0):

--- a/cms/tests/test_page.py
+++ b/cms/tests/test_page.py
@@ -334,11 +334,11 @@ class PagesTestCase(CMSTestCase):
         page = page_a.publisher_public
         self.assertRaises(PublicIsUnmodifiable, page.copy_page, 3, 1)
         self.assertRaises(PublicIsUnmodifiable, page.unpublish, 'en')
-        self.assertRaises(PublicIsUnmodifiable, page.reset_to_public, 'en')
+        self.assertRaises(PublicIsUnmodifiable, page.revert_to_live, 'en')
         self.assertRaises(PublicIsUnmodifiable, page.publish, 'en')
 
         self.assertTrue(page.get_draft_object().publisher_is_draft)
-        self.assertRaises(PublicVersionNeeded, page_b.reset_to_public, 'en')
+        self.assertRaises(PublicVersionNeeded, page_b.revert_to_live, 'en')
 
     def test_move_page_regression_left_to_right_5752(self):
         # ref: https://github.com/divio/django-cms/issues/5752

--- a/cms/tests/test_publisher.py
+++ b/cms/tests/test_publisher.py
@@ -904,7 +904,7 @@ class PublishingTests(TestCase):
         self.assertEqual(CMSPlugin.objects.count(), 3)
 
         # Now let's revert and restore
-        page.reset_to_public('en')
+        page.revert_to_live('en')
         self.assertEqual(page.get_publisher_state("en"), PUBLISHER_STATE_DEFAULT)
 
         self.assertEqual(CMSPlugin.objects.count(), 4)

--- a/docs/upgrade/3.4.4.rst
+++ b/docs/upgrade/3.4.4.rst
@@ -29,6 +29,15 @@ Deprecations
 Backward incompatible changes
 *****************************
 
+Page methods
+============
+
+The following methods have been removed from the ``Page`` model:
+
+* ``reset_to_live``
+  This internal method was removed and replaced with ``revert_to_live``.
+
+
 Placeholder utilities
 =====================
 


### PR DESCRIPTION
The `reset_to_live` method was introduced in 3.4.1 as a result of a bad merge.