### PR TITLE
Fixed #5740 -- Use the correct url when ManifestStaticFilesStorage or similar is used

### DIFF
--- a/cms/templatetags/cms_static.py
+++ b/cms/templatetags/cms_static.py
@@ -28,5 +28,7 @@ def do_static_with_version(parser, token):
 class StaticWithVersionNode(StaticNode):
 
     def url(self, context):
-        url = super(StaticWithVersionNode, self).url(context)
-        return static_with_version(url)
+        path = self.path.resolve(context)
+        path_with_version = static_with_version(path)
+
+        return self.handle_simple(path_with_version)


### PR DESCRIPTION
Fixed #5740.