### PR TITLE
Fix static_with_version template tag for manifest static storage

### DIFF
--- a/cms/templatetags/cms_static.py
+++ b/cms/templatetags/cms_static.py
@@ -28,5 +28,5 @@ def do_static_with_version(parser, token):
 class StaticWithVersionNode(StaticNode):
 
     def url(self, context):
-        url = super(StaticWithVersionNode, self).url(context)
-        return static_with_version(url)
+        path = static_with_version(self.path.resolve(context))
+        return self.handle_simple(path)


### PR DESCRIPTION
### Summary

When using `ManifestStaticFileStorage` `django-cms` gives a bad url as documented in #5740.

Fixes #5740

### Proposed changes in this pull request

This PR first does the versioning and then handles the static file path instead of the other way around. This allows manifest static file storage to find the file in question.