### PR TITLE
Fixes #5740 -- Use the correct url when ManifestStaticFilesStorage or similar is used

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -28,6 +28,8 @@
 * Fixed a bug in which the placeholder cache was not consistently cleared when a page was published.
 * Enhanced the plugin menu to not show plugins the user does not have permission to add.
 * Fixed a regression which prevented users from setting a redirect to the homepage.
+* Fixed a ``ValueError`` raised when using ``ManifestStaticFilesStorage`` or similar for static files.
+  This only affects Django >= 1.10
 
 
 === 3.4.3 (2017-04-24) ===

--- a/cms/templatetags/cms_static.py
+++ b/cms/templatetags/cms_static.py
@@ -28,5 +28,7 @@ def do_static_with_version(parser, token):
 class StaticWithVersionNode(StaticNode):
 
     def url(self, context):
-        url = super(StaticWithVersionNode, self).url(context)
-        return static_with_version(url)
+        path = self.path.resolve(context)
+        path_with_version = static_with_version(path)
+
+        return self.handle_simple(path_with_version)


### PR DESCRIPTION
### Summary

Fixes #5740

This just adds a test for the changes proposed by @sephii in https://github.com/divio/django-cms/pull/5964. I've mocked the staticfiles storage in order to avoid having to collect static files in the test environment.

I tried adding a test for #5907 as well but I could never reproduce the described problem (neither in a test nor in production).

### Alternatives

If the goal of the static files versioning is just cache busting (which is already solved in the `ManifestStaticFilesStorage`), one could also replicate the static files without the version prefix and let `collectstatic` pick it up. This wouldn't require any code changes but a replication of the static files in two locations (with and without the version prefix).