### PR TITLE
supported django versions

### DIFF
--- a/docs/introduction/install.rst
+++ b/docs/introduction/install.rst
@@ -8,7 +8,7 @@ We'll get started by setting up our environment.
 Requirements
 ************
 
-django CMS requires Django 1.8, and Python 2.7, 3.3 or 3.4.
+django CMS requires Django 1.8, 1.9 or 1.10 and Python 2.7, 3.3 or 3.4.
 
 ************************
 Your working environment


### PR DESCRIPTION
### Summary

changed docs to reflect that django'cms supports django 1.9 and 1.10 in addition to django 1.8
