### PR TITLE
Switch md5 for sha1 for caching hash function

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,6 +11,7 @@
   was rendered before attempting to inherit content from parent pages.
 * Changed page/placeholder cache keys to use sha1 hash instead of md5 to be FIPS compliant.
 
+
 === 3.4.4 (2017-06-15) ===
 
 * Fixed a bug in which cancelling the publishing dialog wasn't respected.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,7 +9,7 @@
   is cached in an ancestor page.
 * Fixed a regression where the code following a ``{% placeholder x or %}`` declaration,
   was rendered before attempting to inherit content from parent pages.
-
+* Changed page/placeholder cache keys to use sha1 hash instead of md5 to be FIPS compliant.
 
 === 3.4.4 (2017-06-15) ===
 

--- a/cms/cache/page.py
+++ b/cms/cache/page.py
@@ -17,11 +17,11 @@ from cms.utils.helpers import get_timezone_name
 
 
 def _page_cache_key(request):
-    #md5 key of current path
+    #sha1 key of current path
     cache_key = "%s:%d:%s" % (
         get_cms_setting("CACHE_PREFIX"),
         settings.SITE_ID,
-        hashlib.md5(iri_to_uri(request.get_full_path()).encode('utf-8')).hexdigest()
+        hashlib.sha1(iri_to_uri(request.get_full_path()).encode('utf-8')).hexdigest()
     )
     if settings.USE_TZ:
         cache_key += '.%s' % get_timezone_name()

--- a/cms/cache/placeholder.py
+++ b/cms/cache/placeholder.py
@@ -47,7 +47,7 @@ def _get_placeholder_cache_version_key(placeholder, lang, site_id):
     if len(key) > 250:
         key = '{prefix}|{hash}'.format(
             prefix=prefix,
-            hash=hashlib.md5(key.encode('utf-8')).hexdigest(),
+            hash=hashlib.sha1(key.encode('utf-8')).hexdigest(),
         )
     return key
 
@@ -131,7 +131,7 @@ def _get_placeholder_cache_key(placeholder, lang, site_id, request, soft=False):
     if len(cache_key) > 250:
         cache_key = '{prefix}|{hash}'.format(
             prefix=prefix,
-            hash=hashlib.md5(cache_key.encode('utf-8')).hexdigest(),
+            hash=hashlib.sha1(cache_key.encode('utf-8')).hexdigest(),
         )
 
     return cache_key

--- a/cms/tests/test_cache.py
+++ b/cms/tests/test_cache.py
@@ -820,8 +820,8 @@ class PlaceholderCacheTestCase(CMSTestCase):
             # Prove that it is hashed...
             crazy_cache_key = _get_placeholder_cache_key(self.placeholder, 'en', 1, en_crazy_request)
             key_length = len(crazy_cache_key)
-            # 213 = 180 (prefix length) + 1 (separator) + 32 (md5 hash)
-            self.assertTrue('render_placeholder' not in crazy_cache_key and key_length == 213)
+            # 221 = 180 (prefix length) + 1 (separator) + 40 (sha1 hash)
+            self.assertTrue('render_placeholder' not in crazy_cache_key and key_length == 221)
 
             # Prove it still works as expected
             cached_en_crazy_content = get_placeholder_cache(self.placeholder, 'en', 1, en_crazy_request)


### PR DESCRIPTION
FIPS[0] is not a support crytographic function on FIPS compliant
systems, and is thus disabled.  Moving md5 hashing to use sha256, we can
use django-cms on FIPS compliant systems.

Test updated to include new function output.

[0] http://csrc.nist.gov/groups/STM/cmvp/documents/140-1/140val-all.htm

### Summary

On FIPS enabled systems, md5() functions are not available.  Moving to sha256, django-cms can be used.