### PR TITLE
Fixes #6027 - Removes prevent_descendant_update flag

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -10,6 +10,7 @@
 * Fixed a regression where the code following a ``{% placeholder x or %}`` declaration,
   was rendered before attempting to inherit content from parent pages.
 * Changed page/placeholder cache keys to use sha1 hash instead of md5 to be FIPS compliant.
+* Fixed a bug where the change of a slug would not propagate to all descendant pages
 
 
 === 3.4.4 (2017-06-15) ===

--- a/cms/signals/title.py
+++ b/cms/signals/title.py
@@ -51,8 +51,7 @@ def pre_save_title(instance, raw, **kwargs):
 
 def post_save_title(instance, raw, created, **kwargs):
     # Update descendants only if path changed
-    prevent_descendants = hasattr(instance, 'tmp_prevent_descendant_update')
-    if instance.path != getattr(instance, 'tmp_path', None) and not prevent_descendants:
+    if instance.path != getattr(instance, 'tmp_path', None):
         child_titles = Title.objects.filter(
             page__depth=instance.page.depth + 1,
             page__path__range=Page._get_children_path_interval(instance.page.path),
@@ -62,14 +61,11 @@ def post_save_title(instance, raw, created, **kwargs):
 
         for child_title in child_titles:
             child_title.path = ''  # just reset path
-            child_title.tmp_prevent_descendant_update = True
             child_title._publisher_keep_state = True
             child_title.save()
             # remove temporary attributes
     if hasattr(instance, 'tmp_path'):
         del instance.tmp_path
-    if prevent_descendants:
-        del instance.tmp_prevent_descendant_update
     apphook_post_title_checker(instance, **kwargs)
 
 

--- a/cms/tests/test_page.py
+++ b/cms/tests/test_page.py
@@ -1044,6 +1044,25 @@ class PageTreeTests(CMSTestCase):
         parent.publish('en')
         child = create_page('child', 'nav_playground.html', 'en', slug='child', published=True, parent=parent)
         child.publish('en')
+
+        page_title = Title.objects.get(page=parent)
+        page_title.slug = "father"
+        page_title.save()
+
+        parent = Page.objects.get(pk=parent.pk)
+        parent.publish('en')
+        child = Page.objects.get(pk=child.pk)
+
+        self.assertEqual(child.get_absolute_url(language='en'), '/en/father/child/')
+        self.assertEqual(child.publisher_public.get_absolute_url(language='en'), '/en/father/child/')
+
+    def test_rename_node_alters_descendants(self):
+        home = create_page('grandpa', 'nav_playground.html', 'en', slug='home', published=True)
+        home.publish('en')
+        parent = create_page('parent', 'nav_playground.html', 'en', slug='parent', published=True)
+        parent.publish('en')
+        child = create_page('child', 'nav_playground.html', 'en', slug='child', published=True, parent=parent)
+        child.publish('en')
         grandchild = create_page('grandchild', 'nav_playground.html', 'en', slug='grandchild', published=True,
                                  parent=child)
         grandchild.publish('en')
@@ -1060,7 +1079,6 @@ class PageTreeTests(CMSTestCase):
         self.assertEqual(child.publisher_public.get_absolute_url(language='en'), '/en/father/child/')
         self.assertEqual(grandchild.get_absolute_url(language='en'), '/en/father/child/grandchild/')
         self.assertEqual(grandchild.publisher_public.get_absolute_url(language='en'), '/en/father/child/grandchild/')
-
 
     def test_move_node(self):
         home = create_page('grandpa', 'nav_playground.html', 'en', slug='home', published=True)

--- a/cms/tests/test_page.py
+++ b/cms/tests/test_page.py
@@ -1044,6 +1044,9 @@ class PageTreeTests(CMSTestCase):
         parent.publish('en')
         child = create_page('child', 'nav_playground.html', 'en', slug='child', published=True, parent=parent)
         child.publish('en')
+        grandchild = create_page('grandchild', 'nav_playground.html', 'en', slug='grandchild', published=True,
+                                 parent=child)
+        grandchild.publish('en')
 
         page_title = Title.objects.get(page=parent)
         page_title.slug = "father"
@@ -1055,6 +1058,8 @@ class PageTreeTests(CMSTestCase):
 
         self.assertEqual(child.get_absolute_url(language='en'), '/en/father/child/')
         self.assertEqual(child.publisher_public.get_absolute_url(language='en'), '/en/father/child/')
+        self.assertEqual(grandchild.get_absolute_url(language='en'), '/en/father/child/grandchild/')
+        self.assertEqual(grandchild.publisher_public.get_absolute_url(language='en'), '/en/father/child/grandchild/')
 
 
     def test_move_node(self):

--- a/cms/tests/test_page.py
+++ b/cms/tests/test_page.py
@@ -1056,7 +1056,7 @@ class PageTreeTests(CMSTestCase):
         self.assertEqual(child.get_absolute_url(language='en'), '/en/father/child/')
         self.assertEqual(child.publisher_public.get_absolute_url(language='en'), '/en/father/child/')
 
-        def test_rename_node_alters_descendants(self):
+    def test_rename_node_alters_descendants(self):
         create_page('grandpa', 'nav_playground.html', 'en', slug='home', published=True)
         parent = create_page('parent', 'nav_playground.html', 'en', slug='parent', published=True)
         child = create_page('child', 'nav_playground.html', 'en', slug='child', published=True, parent=parent)

--- a/cms/tests/test_page.py
+++ b/cms/tests/test_page.py
@@ -1056,8 +1056,8 @@ class PageTreeTests(CMSTestCase):
         self.assertEqual(child.get_absolute_url(language='en'), '/en/father/child/')
         self.assertEqual(child.publisher_public.get_absolute_url(language='en'), '/en/father/child/')
 
-    def test_rename_node_alters_descendants(self):
-        home = create_page('grandpa', 'nav_playground.html', 'en', slug='home', published=True)
+        def test_rename_node_alters_descendants(self):
+        create_page('grandpa', 'nav_playground.html', 'en', slug='home', published=True)
         parent = create_page('parent', 'nav_playground.html', 'en', slug='parent', published=True)
         child = create_page('child', 'nav_playground.html', 'en', slug='child', published=True, parent=parent)
         grandchild_1 = create_page('grandchild-1', 'nav_playground.html', 'en', slug='grandchild-1', published=True,
@@ -1071,11 +1071,16 @@ class PageTreeTests(CMSTestCase):
         page_title.slug = "father"
         page_title.save()
 
+        # Draft pages
         self.assertEqual(grandchild_1.get_absolute_url(language='en'), '/en/father/child/grandchild-1/')
-        self.assertEqual(grandchild_1.publisher_public.get_absolute_url(language='en'), '/en/father/child/grandchild-1/')
         self.assertEqual(grandchild_2.get_absolute_url(language='en'), '/en/father/child/grandchild-2/')
-        self.assertEqual(grandchild_2.publisher_public.get_absolute_url(language='en'), '/en/father/child/grandchild-2/')
         self.assertEqual(grandchild_3.get_absolute_url(language='en'), '/en/father/child/grandchild-3/')
+
+        parent.reload().publish('en')
+
+        # Public pages
+        self.assertEqual(grandchild_1.publisher_public.get_absolute_url(language='en'), '/en/father/child/grandchild-1/')
+        self.assertEqual(grandchild_2.publisher_public.get_absolute_url(language='en'), '/en/father/child/grandchild-2/')
         self.assertEqual(grandchild_3.publisher_public.get_absolute_url(language='en'), '/en/father/child/grandchild-3/')
 
     def test_move_node(self):

--- a/cms/tests/test_page.py
+++ b/cms/tests/test_page.py
@@ -1058,27 +1058,25 @@ class PageTreeTests(CMSTestCase):
 
     def test_rename_node_alters_descendants(self):
         home = create_page('grandpa', 'nav_playground.html', 'en', slug='home', published=True)
-        home.publish('en')
         parent = create_page('parent', 'nav_playground.html', 'en', slug='parent', published=True)
-        parent.publish('en')
         child = create_page('child', 'nav_playground.html', 'en', slug='child', published=True, parent=parent)
-        child.publish('en')
-        grandchild = create_page('grandchild', 'nav_playground.html', 'en', slug='grandchild', published=True,
+        grandchild_1 = create_page('grandchild-1', 'nav_playground.html', 'en', slug='grandchild-1', published=True,
                                  parent=child)
-        grandchild.publish('en')
+        grandchild_2 = create_page('grandchild-2', 'nav_playground.html', 'en', slug='grandchild-2', published=True,
+                                 parent=child.reload())
+        grandchild_3 = create_page('grandchild-3', 'nav_playground.html', 'en', slug='grandchild-3', published=True,
+                                 parent=child.reload())
 
         page_title = Title.objects.get(page=parent)
         page_title.slug = "father"
         page_title.save()
 
-        parent = Page.objects.get(pk=parent.pk)
-        parent.publish('en')
-        child = Page.objects.get(pk=child.pk)
-
-        self.assertEqual(child.get_absolute_url(language='en'), '/en/father/child/')
-        self.assertEqual(child.publisher_public.get_absolute_url(language='en'), '/en/father/child/')
-        self.assertEqual(grandchild.get_absolute_url(language='en'), '/en/father/child/grandchild/')
-        self.assertEqual(grandchild.publisher_public.get_absolute_url(language='en'), '/en/father/child/grandchild/')
+        self.assertEqual(grandchild_1.get_absolute_url(language='en'), '/en/father/child/grandchild-1/')
+        self.assertEqual(grandchild_1.publisher_public.get_absolute_url(language='en'), '/en/father/child/grandchild-1/')
+        self.assertEqual(grandchild_2.get_absolute_url(language='en'), '/en/father/child/grandchild-2/')
+        self.assertEqual(grandchild_2.publisher_public.get_absolute_url(language='en'), '/en/father/child/grandchild-2/')
+        self.assertEqual(grandchild_3.get_absolute_url(language='en'), '/en/father/child/grandchild-3/')
+        self.assertEqual(grandchild_3.publisher_public.get_absolute_url(language='en'), '/en/father/child/grandchild-3/')
 
     def test_move_node(self):
         home = create_page('grandpa', 'nav_playground.html', 'en', slug='home', published=True)


### PR DESCRIPTION
### Summary

 - removes prevent_descendant_update flag and functionality
 - post_save_title is now triggered recursively and updates paths properly
 - modifies `test_rename_node` to test grandchild path as well

Fixes #6027 

### Links to related discussion
#6027 


### Proposed changes in this pull request
Removed the `prevent_descendant_update` flag and logic which prevented path update from propagating. Seems like this was introduced in commit 89f0974a26ea663deb68d69e40f71b5cdefd62f6. As far as I see there is no other use of this flagging mechanism in the current code.  Also modified a test which now checks grandchild path update in addition to chid path update.