### PR TITLE
Rename draft publish buttons

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -14,6 +14,7 @@
   was rendered before attempting to inherit content from parent pages.
 * Changed page/placeholder cache keys to use sha1 hash instead of md5 to be FIPS compliant.
 * Fixed a bug where the change of a slug would not propagate to all descendant pages
+* Rename publish buttons to no longer reference "page"
 
 
 === 3.4.4 (unreleased) ===

--- a/cms/locale/en/LC_MESSAGES/django.po
+++ b/cms/locale/en/LC_MESSAGES/django.po
@@ -1662,7 +1662,7 @@ msgstr "Available plugins"
 #: templates/cms/toolbar/items/live_draft.html:6
 #, fuzzy
 #| msgid "View published"
-msgid "View published page"
+msgid "View published"
 msgstr "View published"
 
 #: templates/cms/toolbar/items/live_draft.html:11

--- a/cms/templates/cms/toolbar/items/live_draft.html
+++ b/cms/templates/cms/toolbar/items/live_draft.html
@@ -3,12 +3,12 @@
     {% if cms_toolbar.edit_mode_active %}
     <a class="cms-btn cms-btn-switch-save"
         href="{% firstof cms_toolbar.get_object_public_url cms_toolbar.request_path %}?{{ cms_toolbar.edit_mode_url_off }}">
-        <span>{% trans "View published page" %}</span>
+        <span>{% trans "View published" %}</span>
     </a>
     {% else %}
     <a class="cms-btn cms-btn-action cms-btn-switch-edit"
         href="{% firstof cms_toolbar.get_object_draft_url cms_toolbar.request_path %}?{{ cms_toolbar.edit_mode_url_on }}">
-        {% trans "Edit page" %}
+        {% trans "Edit" %}
     </a>
     {% endif %}
 </div>

--- a/cms/tests/test_toolbar.py
+++ b/cms/tests/test_toolbar.py
@@ -244,7 +244,7 @@ class ToolbarTests(ToolbarTestBase):
 
         output = (
             '<a class="cms-btn cms-btn-action cms-btn-switch-edit" '
-            'href="/en/example/latest/?{}">Edit page</a>'
+            'href="/en/example/latest/?{}">Edit</a>'
         ).format(get_cms_setting('CMS_TOOLBAR_URL__EDIT_ON'))
 
         Example1.objects.create(

--- a/cms/tests/test_views.py
+++ b/cms/tests/test_views.py
@@ -224,7 +224,7 @@ class ViewTests(CMSTestCase):
             self.assertContains(
                 response,
                 '<a class="cms-btn cms-btn-switch-save" href="/fr/?{}">'
-                '<span>View published page</span></a>'.format(edit_off),
+                '<span>View published</span></a>'.format(edit_off),
                 count=1,
                 html=True,
             )
@@ -237,7 +237,7 @@ class ViewTests(CMSTestCase):
             )
             self.assertContains(
                 response,
-                '<a class="cms-btn cms-btn-action cms-btn-switch-edit" href="/fr/?{}">Edit page</a>'.format(edit_on),
+                '<a class="cms-btn cms-btn-action cms-btn-switch-edit" href="/fr/?{}">Edit</a>'.format(edit_on),
                 count=1,
                 html=True,
             )


### PR DESCRIPTION
### Summary

Removes "page" text from the draft/publish buttons

The buttons at the top right in the Toolbar used to be called
"Edit page" and "View published page". Since there is an increasing
number of non Page content using those buttons, I removed the reference
to page to make it more universal and shorter.

This has changed a translation string, so the translations need to be updated too.
