### PR TITLE
Changed rendering logic to use draft page unless live is explicitly requested

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -15,6 +15,8 @@
 * Changed page/placeholder cache keys to use sha1 hash instead of md5 to be FIPS compliant.
 * Fixed a bug where the change of a slug would not propagate to all descendant pages
 * Rename publish buttons to no longer reference "page"
+* Page rendering will now use the draft page instead of public page for logged in
+  users with change permissions, unless the ``preview`` GET parameter is used.
 
 
 === 3.4.4 (unreleased) ===

--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -1106,11 +1106,11 @@ class PageAdmin(PlaceholderAdminMixin, admin.ModelAdmin):
                         path = page.get_absolute_url(language, fallback=True)
                     else:
                         public_page = Page.objects.get(publisher_public=page.pk)
-                        path = '%s?%s' % (public_page.get_absolute_url(language, fallback=True), get_cms_setting('CMS_TOOLBAR_URL__EDIT_OFF'))
+                        path = '%s?preview&%s' % (public_page.get_absolute_url(language, fallback=True), get_cms_setting('CMS_TOOLBAR_URL__EDIT_OFF'))
                 else:
-                    path = '%s?%s' % (referrer, get_cms_setting('CMS_TOOLBAR_URL__EDIT_OFF'))
+                    path = '%s?preview&%s' % (referrer, get_cms_setting('CMS_TOOLBAR_URL__EDIT_OFF'))
             else:
-                path = '/?%s' % get_cms_setting('CMS_TOOLBAR_URL__EDIT_OFF')
+                path = '/?preview&%s' % get_cms_setting('CMS_TOOLBAR_URL__EDIT_OFF')
 
         return HttpResponseRedirect(path)
 

--- a/cms/middleware/toolbar.py
+++ b/cms/middleware/toolbar.py
@@ -52,8 +52,8 @@ class ToolbarMiddleware(MiddlewareMixin):
         edit_off = get_cms_setting('CMS_TOOLBAR_URL__EDIT_OFF')
         disable = get_cms_setting('CMS_TOOLBAR_URL__DISABLE')
         anonymous_on = get_cms_setting('TOOLBAR_ANONYMOUS_ON')
-        edit_enabled = edit_on in request.GET
-        edit_disabled = edit_off in request.GET
+        edit_enabled = edit_on in request.GET and 'preview' not in request.GET
+        edit_disabled = edit_off in request.GET or 'preview' in request.GET
 
         if disable in request.GET:
             request.session['cms_toolbar_disabled'] = True
@@ -70,12 +70,17 @@ class ToolbarMiddleware(MiddlewareMixin):
             # User has explicitly enabled mode
             # AND can see the toolbar
             request.session['cms_edit'] = True
+            request.session['cms_preview'] = False
 
         if edit_disabled or not show_toolbar and request.session.get('cms_edit'):
             # User has explicitly disabled the toolbar
             # OR user has explicitly turned off edit mode
             # OR user can't see toolbar
             request.session['cms_edit'] = False
+
+        if 'preview' in request.GET and not request.session.get('cms_preview'):
+            # User has explicitly requested a preview of the live page.
+            request.session['cms_preview'] = True
 
         if request.user.is_staff:
             try:

--- a/cms/templates/cms/toolbar/items/live_draft.html
+++ b/cms/templates/cms/toolbar/items/live_draft.html
@@ -2,7 +2,7 @@
 <div class="cms-toolbar-item cms-toolbar-item-buttons cms-toolbar-item-switch-save-edit">
     {% if cms_toolbar.edit_mode_active %}
     <a class="cms-btn cms-btn-switch-save"
-        href="{% firstof cms_toolbar.get_object_public_url cms_toolbar.request_path %}?{{ cms_toolbar.edit_mode_url_off }}">
+        href="{% firstof cms_toolbar.get_object_public_url cms_toolbar.request_path %}?preview&amp;{{ cms_toolbar.edit_mode_url_off }}">
         <span>{% trans "View published" %}</span>
     </a>
     {% else %}

--- a/cms/tests/test_menu.py
+++ b/cms/tests/test_menu.py
@@ -370,7 +370,7 @@ class FixturesMenuTests(MenusFixture, BaseMenuTest):
         public_page = self.get_page(1)
         draft_page = public_page.publisher_public
         edit_on_path = draft_page.get_absolute_url() + '?%s' % get_cms_setting('CMS_TOOLBAR_URL__EDIT_ON')
-        edit_off_path = public_page.get_absolute_url() + '?%s' % get_cms_setting('CMS_TOOLBAR_URL__EDIT_OFF')
+        edit_off_path = public_page.get_absolute_url() + '?preview&%s' % get_cms_setting('CMS_TOOLBAR_URL__EDIT_OFF')
         superuser = self.get_superuser()
 
         # Prime the draft menu cache
@@ -383,6 +383,7 @@ class FixturesMenuTests(MenusFixture, BaseMenuTest):
         with self.login_user_context(superuser):
             context = self.get_context(path=edit_off_path, page=public_page)
             context['request'].session['cms_edit'] = False
+            context['request'].session['cms_preview'] = True
             Template("{% load menu_tags %}{% show_menu %}").render(context)
 
         # All nodes should be public nodes

--- a/cms/tests/test_toolbar.py
+++ b/cms/tests/test_toolbar.py
@@ -45,7 +45,7 @@ from cms.views import details
 class ToolbarTestBase(CMSTestCase):
 
     def get_page_request(self, page, user, path=None, edit=False,
-                         structure=False, lang_code='en', disable=False):
+                         preview=False, structure=False, lang_code='en', disable=False):
         if not path:
             path = page.get_absolute_url()
 
@@ -54,6 +54,9 @@ class ToolbarTestBase(CMSTestCase):
 
         if structure:
             path += '?%s' % get_cms_setting('CMS_TOOLBAR_URL__BUILD')
+
+        if preview:
+            path += '?preview'
 
         request = RequestFactory().get(path)
         request.session = {}
@@ -317,12 +320,12 @@ class ToolbarTests(ToolbarTestBase):
             response = self.client.get('%s?%s' % (
                 page_2.get_absolute_url(), get_cms_setting('CMS_TOOLBAR_URL__EDIT_ON')))
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, 'href="%s?%s"' % (
+        self.assertContains(response, 'href="%s?preview&amp;%s"' % (
             page_2.get_public_url(), get_cms_setting('CMS_TOOLBAR_URL__EDIT_OFF')
         ))
         # check when in live mode
         with self.login_user_context(superuser):
-            response = self.client.get('%s?%s' % (
+            response = self.client.get('%s?preview&%s' % (
                 page_2.get_absolute_url(), get_cms_setting('CMS_TOOLBAR_URL__EDIT_OFF')))
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'href="%s?%s"' % (
@@ -338,12 +341,12 @@ class ToolbarTests(ToolbarTestBase):
             response = self.client.get('%s?%s' % (
                 page_2.get_absolute_url(), get_cms_setting('CMS_TOOLBAR_URL__EDIT_ON')))
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, 'href="%s?%s"' % (
+        self.assertContains(response, 'href="%s?preview&amp;%s"' % (
             page_2.get_public_url(), get_cms_setting('CMS_TOOLBAR_URL__EDIT_OFF')
         ))
         # check when in live mode
         with self.login_user_context(superuser):
-            response = self.client.get('%s?%s' % (
+            response = self.client.get('%s?preview&%s' % (
                 page_2.get_public_url(), get_cms_setting('CMS_TOOLBAR_URL__EDIT_OFF')))
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'href="%s?%s"' % (
@@ -1007,11 +1010,11 @@ class EditModelTemplateTagTest(ToolbarTestBase):
         request = self.get_page_request(page, superuser, edit=True)
         response = detail_view(request, ex1.pk)
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, 'href="%s?%s"' % (
+        self.assertContains(response, 'href="%s?preview&amp;%s"' % (
             ex1.get_public_url(), get_cms_setting('CMS_TOOLBAR_URL__EDIT_OFF')
         ))
         # check when in live mode
-        request = self.get_page_request(page, superuser, edit=False)
+        request = self.get_page_request(page, superuser, preview=True)
         response = detail_view(request, ex1.pk)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'href="%s?%s"' % (

--- a/cms/tests/test_views.py
+++ b/cms/tests/test_views.py
@@ -228,12 +228,12 @@ class ViewTests(CMSTestCase):
             )
             self.assertContains(
                 response,
-                '<a class="cms-btn cms-btn-switch-save" href="/fr/?{}">'
+                '<a class="cms-btn cms-btn-switch-save" href="/fr/?preview&{}">'
                 '<span>View published</span></a>'.format(edit_off),
                 count=1,
                 html=True,
             )
-            response = self.client.get("/fr/?{}".format(edit_off))
+            response = self.client.get("/fr/?preview&{}".format(edit_off))
             self.assertContains(
                 response,
                 expected,

--- a/cms/utils/moderator.py
+++ b/cms/utils/moderator.py
@@ -1,22 +1,16 @@
 # -*- coding: utf-8 -*-
-from cms.utils.conf import get_cms_setting
 
 
 def use_draft(request):
-    if request:
-        structure = get_cms_setting('CMS_TOOLBAR_URL__BUILD')
-        is_staff = request.user.is_authenticated() and request.user.is_staff
-        edit_mode_active = is_staff and request.session.get('cms_edit', False)
-        structure_mode_active = is_staff and structure in request.GET
-        return bool(edit_mode_active or structure_mode_active)
-    return False
+    is_staff = (request.user.is_authenticated() and request.user.is_staff)
+    return is_staff and not request.session.get('cms_preview')
 
 
 def get_model_queryset(model, request=None):
     """Decision function used in frontend - says which model should be used.
     Public models are used unless looking at preview or edit versions of the page.
     """
-    if use_draft(request):
+    if request and use_draft(request):
         return model.objects.drafts()
     return model.objects.public()
 


### PR DESCRIPTION
By default the cms will render draft pages unless the user explicitly enables preview mode.
Preview mode persists across requests via a session flag.

`?preview` enables preview mode (public only pages) and disables edit mode
`?edit` enables edit mode and disables preview mode
`?edit_off` disables edit mode