### PR TITLE
Fixed #6074 -- Added a destroy method for the Plugin javascript class

### DIFF
--- a/cms/static/cms/js/modules/cms.base.js
+++ b/cms/static/cms/js/modules/cms.base.js
@@ -31,8 +31,8 @@ export const $window = $(window);
 export const $document = $(document);
 
 /**
- * Creates always an unique identifier if calles
- * @returns {Numner} incremental numbers starting from 0
+ * Creates always an unique identifier if called
+ * @returns {Number} incremental numbers starting from 0
  */
 export const uid = (function() {
     let i = 0;

--- a/cms/static/cms/js/modules/cms.base.js
+++ b/cms/static/cms/js/modules/cms.base.js
@@ -25,6 +25,21 @@ var _ns = function nameSpaceEvent(events) {
         .join(' ');
 };
 
+// Handy shortcut to cache the window and the document objects
+// in a jquery wrapper
+export const $window = $(window);
+export const $document = $(document);
+
+/**
+ * Creates always an unique identifier if calles
+ * @returns {Numner} incremental numbers starting from 0
+ */
+export const uid = (function() {
+    let i = 0;
+
+    return () => ++i;
+})();
+
 /**
  * Provides various helpers that are mixed in all CMS classes.
  *
@@ -42,6 +57,12 @@ export const Helpers = {
      * @private
      */
     _isReloading: false,
+
+    // aliasing the $window and the $document objects
+    $window,
+    $document,
+
+    uid,
 
     once,
     debounce,

--- a/cms/static/cms/js/modules/cms.plugins.js
+++ b/cms/static/cms/js/modules/cms.plugins.js
@@ -58,6 +58,9 @@ var Plugin = new Class({
         }
     },
 
+    // these properties will be filled later
+    modal: null,
+
     initialize: function initialize(container, options) {
         this.options = $.extend(true, {}, this.options, options);
 
@@ -814,7 +817,12 @@ var Plugin = new Class({
     destroy() {
         // close the plugin modal if it was open
         // TODO: shouldn't the modal be destroyed as well at this point?
-        this.ui.modal.close();
+        if (this.modal) {
+            this.modal.close();
+            // unsubscribe to all the modal events
+            this.modal.off();
+        }
+
         // remove all the plugin UI DOM elements
         // notice that $.remove will remove also all the ui specific events
         // previously attached to them
@@ -1118,8 +1126,8 @@ var Plugin = new Class({
             var isPlaceholder = !dragItem.length;
             var childrenList;
 
-            // make sure also the modal is part of the ui collection
-            this.ui.modal = modal = new Modal({
+            // make sure also the modal is available to this instance
+            this.modal = modal = new Modal({
                 minWidth: 400,
                 minHeight: 400
             });
@@ -1245,20 +1253,21 @@ var Plugin = new Class({
     /**
      * Returns a specific plugin namespaced event postfixing the plugin uid to it
      * in order to properly manage it via jQuery $.on and $.off
+     * TODO: move this in cms.base.js
      *
      * @method _getNamepacedEvent
      * @private
-     * @param {String} type - plugin event type
+     * @param {String} base - plugin event type
      * @param {String} additionalNS - additional namespace (like '.traverse' for example)
      * @returns {String} a specific plugin event
      *
      * @example
      *
-     * plugin._getNamepacedEvent(Plugin.click); // 'click.cms.plugin.uid-42'
-     * plugin._getNamepacedEvent(Plugin.keyDown, '.traverse'); // 'keydown.cms.plugin.traverse.uid-42'
+     * plugin._getNamepacedEvent(Plugin.click); // 'click.cms.plugin.42'
+     * plugin._getNamepacedEvent(Plugin.keyDown, '.traverse'); // 'keydown.cms.plugin.traverse.42'
      */
-    _getNamepacedEvent(type, additionalNS = '') {
-        return `${ Plugin[type] }${ additionalNS ? '.'.concat(additionalNS) : '' }.uid-${ this.uid }`;
+    _getNamepacedEvent(base, additionalNS = '') {
+        return `${ base }${ additionalNS ? '.'.concat(additionalNS) : '' }.${ this.uid }`;
     },
 
     /**

--- a/cms/static/cms/js/modules/cms.plugins.js
+++ b/cms/static/cms/js/modules/cms.plugins.js
@@ -811,10 +811,13 @@ var Plugin = new Class({
      * Destroys the current plugin instance removing only the DOM listeners
      *
      * @method destroy
+     * @param {Object}  options - destroy config options
      * @param {Boolean} options.mustCleanup - if true it will remove also the plugin UI components from the DOM
      * @returns {void}
      */
-    destroy({ mustCleanup }) {
+    destroy(options = {}) {
+        const mustCleanup = options.mustCleanup || false;
+
         // close the plugin modal if it was open
         // TODO: shouldn't the modal be destroyed as well at this point?
         if (this.modal) {

--- a/cms/static/cms/js/modules/cms.plugins.js
+++ b/cms/static/cms/js/modules/cms.plugins.js
@@ -811,10 +811,10 @@ var Plugin = new Class({
      * Destroys the current plugin instance removing only the DOM listeners
      *
      * @method destroy
-     * @param {Boolean} mustCleanup - if true it will remove also the plugin UI components from the DOM
+     * @param {Boolean} options.mustCleanup - if true it will remove also the plugin UI components from the DOM
      * @returns {void}
      */
-    destroy(mustCleanup) {
+    destroy({ mustCleanup }) {
         // close the plugin modal if it was open
         // TODO: shouldn't the modal be destroyed as well at this point?
         if (this.modal) {

--- a/cms/static/cms/js/modules/cms.plugins.js
+++ b/cms/static/cms/js/modules/cms.plugins.js
@@ -808,13 +808,13 @@ var Plugin = new Class({
     },
 
     /**
-     * Destroys the current plugin instance removing DOM elements
-     * and plugin specific (global) events
+     * Destroys the current plugin instance removing only the DOM listeners
      *
      * @method destroy
+     * @param {Boolean} mustCleanup - if true it will remove also the plugin UI components from the DOM
      * @returns {void}
      */
-    destroy() {
+    destroy(mustCleanup) {
         // close the plugin modal if it was open
         // TODO: shouldn't the modal be destroyed as well at this point?
         if (this.modal) {
@@ -823,14 +823,33 @@ var Plugin = new Class({
             this.modal.off();
         }
 
+        if (mustCleanup) {
+            this.cleanup();
+        }
+
+        // remove event bound to global elements like document or window
+        $document.off(`.${ this.uid }`);
+        $window.off(`.${ this.uid }`);
+
+        // TODO: It would be better to return something at this point
+        // but we don't do it anywhere so let's keep it void for now
+        // return this;
+    },
+
+    /**
+     * Remove the plugin specific ui elements from the DOM
+     *
+     * @method cleanup
+     * @returns {void}
+     */
+    cleanup() {
         // remove all the plugin UI DOM elements
         // notice that $.remove will remove also all the ui specific events
         // previously attached to them
         Object.keys(this.ui).forEach(el => this.ui[el].remove());
 
-        // remove event bound to global elements like document or window
-        $document.off(`.${ this.uid }`);
-        $window.off(`.${ this.uid }`);
+        // TODO: see above
+        // return this;
     },
 
     /**

--- a/cms/static/cms/js/modules/cms.plugins.js
+++ b/cms/static/cms/js/modules/cms.plugins.js
@@ -10,11 +10,9 @@ import nextUntil from './nextuntil';
 import { toPairs, isNaN, debounce, findIndex, find, uniqWith, once } from 'lodash';
 
 import Class from 'classjs';
-import { Helpers, KEYS } from './cms.base';
+import { Helpers, KEYS, $window, $document, uid } from './cms.base';
 import { filter as fuzzyFilter } from 'fuzzaldrin';
 
-var doc;
-const win = $(Helpers._getWindow());
 var clipboardDraggable;
 var path = window.location.pathname + window.location.search;
 
@@ -62,6 +60,9 @@ var Plugin = new Class({
 
     initialize: function initialize(container, options) {
         this.options = $.extend(true, {}, this.options, options);
+
+        // create an unique for this component to use it internally
+        this.uid = uid();
 
         this._setupUI(container);
         this._ensureData();
@@ -264,7 +265,7 @@ var Plugin = new Class({
             this.ui.dragitem
                 .on('mouseenter', e => {
                     e.stopPropagation();
-                    if (!doc.data('expandmode')) {
+                    if (!$document.data('expandmode')) {
                         return;
                     }
                     if (this.ui.draggable.find('> .cms-dragitem > .cms-plugin-disabled').length) {
@@ -312,10 +313,13 @@ var Plugin = new Class({
     },
 
     _setPluginContentEvents: function _setPluginContentEvents() {
+
+        const pluginDoubleClickEvent = this._getNamepacedEvent(Plugin.doubleClick);
+
         this.ui.container
             .off('mouseover.cms.plugins')
             .on('mouseover.cms.plugins', e => {
-                if (!doc.data('expandmode')) {
+                if (!$document.data('expandmode')) {
                     return;
                 }
                 if (CMS.settings.mode !== 'structure') {
@@ -340,10 +344,10 @@ var Plugin = new Class({
             });
 
         if (!Plugin._isContainingMultiplePlugins(this.ui.container)) {
-            doc
-                .off(Plugin.doubleClick, `.cms-plugin-${this.options.plugin_id}`)
+            $document
+                .off(pluginDoubleClickEvent, `.cms-plugin-${this.options.plugin_id}`)
                 .on(
-                    Plugin.doubleClick,
+                    pluginDoubleClickEvent,
                     `.cms-plugin-${this.options.plugin_id}`,
                     this._dblClickToEditHandler.bind(this)
                 );
@@ -801,6 +805,27 @@ var Plugin = new Class({
     },
 
     /**
+     * Destroys the current plugin instance removing DOM elements
+     * and plugin specific (global) events
+     *
+     * @method destroy
+     * @returns {void}
+     */
+    destroy() {
+        // close the plugin modal if it was open
+        // TODO: shouldn't the modal be destroyed as well at this point?
+        this.ui.modal.close();
+        // remove all the plugin UI DOM elements
+        // notice that $.remove will remove also all the ui specific events
+        // previously attached to them
+        Object.keys(this.ui).forEach(el => this.ui[el].remove());
+
+        // remove event bound to global elements like document or window
+        $document.off(`.${ this.uid }`);
+        $window.off(`.${ this.uid }`);
+    },
+
+    /**
      * Moves the plugin according to the place it should have in content mode.
      *
      * @method _setPosition
@@ -1051,7 +1076,7 @@ var Plugin = new Class({
         var duration = opts && opts.duration !== undefined ? opts.duration : DEFAULT_DURATION;
         var offset = opts && opts.offset !== undefined ? opts.offset : DEFAULT_OFFSET;
         var scrollable = el.offsetParent();
-        var scrollHeight = win.height();
+        var scrollHeight = $window.height();
         var scrollTop = scrollable.scrollTop();
         var elPosition = el.position().top;
         var elHeight = el.height();
@@ -1093,7 +1118,8 @@ var Plugin = new Class({
             var isPlaceholder = !dragItem.length;
             var childrenList;
 
-            modal = new Modal({
+            // make sure also the modal is part of the ui collection
+            this.ui.modal = modal = new Modal({
                 minWidth: 400,
                 minHeight: 400
             });
@@ -1214,6 +1240,25 @@ var Plugin = new Class({
         }
 
         return plugins;
+    },
+
+    /**
+     * Returns a specific plugin namespaced event postfixing the plugin uid to it
+     * in order to properly manage it via jQuery $.on and $.off
+     *
+     * @method _getNamepacedEvent
+     * @private
+     * @param {String} type - plugin event type
+     * @param {String} additionalNS - additional namespace (like '.traverse' for example)
+     * @returns {String} a specific plugin event
+     *
+     * @example
+     *
+     * plugin._getNamepacedEvent(Plugin.click); // 'click.cms.plugin.uid-42'
+     * plugin._getNamepacedEvent(Plugin.keyDown, '.traverse'); // 'keydown.cms.plugin.traverse.uid-42'
+     */
+    _getNamepacedEvent(type, additionalNS = '') {
+        return `${ Plugin[type] }${ additionalNS ? '.'.concat(additionalNS) : '' }.uid-${ this.uid }`;
     },
 
     /**
@@ -1422,14 +1467,15 @@ var Plugin = new Class({
      */
     _setupKeyboardTraversing: function _setupKeyboardTraversing() {
         var dropdown = $('.cms-modal-markup .cms-plugin-picker');
+        const keyDownTraverseEvent = this._getNamepacedEvent(Plugin.keyDown, 'traverse');
 
         if (!dropdown.length) {
             return;
         }
         // add key events
-        doc.off(Plugin.keyDown + '.traverse');
+        $document.off(keyDownTraverseEvent);
         // istanbul ignore next: not really possible to reproduce focus state in unit tests
-        doc.on(Plugin.keyDown + '.traverse', function(e) {
+        $document.on(keyDownTraverseEvent, function(e) {
             var anchors = dropdown.find('.cms-submenu-item:visible a');
             var index = anchors.index(anchors.filter(':focus'));
 
@@ -1477,7 +1523,7 @@ var Plugin = new Class({
 
         // calculate dropdown positioning
         if (
-            win.height() + win.scrollTop() - nav.offset().top - dropdown.height() <= MIN_SCREEN_MARGIN &&
+            $window.height() + $window.scrollTop() - nav.offset().top - dropdown.height() <= MIN_SCREEN_MARGIN &&
             nav.offset().top - dropdown.height() >= 0
         ) {
             dropdown.removeClass('cms-submenu-dropdown-top').addClass('cms-submenu-dropdown-bottom');
@@ -1577,7 +1623,7 @@ var Plugin = new Class({
                 .find('> .cms-collapsable-container')
                 .addClass('cms-hidden');
 
-            if (doc.data('expandmode')) {
+            if ($document.data('expandmode')) {
                 items = draggable.find('.cms-draggable').find('.cms-dragitem-collapsable');
                 if (!items.length) {
                     return false;
@@ -1598,7 +1644,7 @@ var Plugin = new Class({
                 .find('> .cms-collapsable-container')
                 .removeClass('cms-hidden');
 
-            if (doc.data('expandmode')) {
+            if ($document.data('expandmode')) {
                 items = draggable.find('.cms-draggable').find('.cms-dragitem-collapsable');
                 if (!items.length) {
                     return false;
@@ -1614,7 +1660,7 @@ var Plugin = new Class({
         }
 
         // make sure structurboard gets updated after expanding
-        win.trigger('resize.sideframe');
+        $document.trigger('resize.sideframe');
 
         // save settings
         Helpers.setSettings(settings);
@@ -1788,6 +1834,7 @@ var Plugin = new Class({
     }
 });
 
+// TODO: It would be nicer to have them under a nested object like Plugin.events = {} IMHO
 Plugin.click = 'click.cms.plugin';
 Plugin.pointerUp = 'pointerup.cms.plugin';
 Plugin.pointerDown = 'pointerdown.cms.plugin';
@@ -1869,7 +1916,6 @@ Plugin._initializeGlobalHandlers = function _initializeGlobalHandlers() {
     var timer;
     var clickCounter = 0;
 
-    doc = $(document);
     Plugin._updateClipboard();
 
     // Structureboard initialized too late
@@ -1889,7 +1935,7 @@ Plugin._initializeGlobalHandlers = function _initializeGlobalHandlers() {
         }
     }, 0);
 
-    doc
+    $document
         .off(Plugin.pointerUp)
         .off(Plugin.keyDown)
         .off(Plugin.keyUp)
@@ -1902,7 +1948,7 @@ Plugin._initializeGlobalHandlers = function _initializeGlobalHandlers() {
         })
         .on(Plugin.keyDown, function(e) {
             if (e.keyCode === KEYS.SHIFT) {
-                doc.data('expandmode', true);
+                $document.data('expandmode', true);
                 try {
                     $('.cms-plugin:hover').last().trigger('mouseenter');
                     $('.cms-dragitem:hover').last().trigger('mouseenter');
@@ -1911,7 +1957,7 @@ Plugin._initializeGlobalHandlers = function _initializeGlobalHandlers() {
         })
         .on(Plugin.keyUp, function(e) {
             if (e.keyCode === KEYS.SHIFT) {
-                doc.data('expandmode', false);
+                $document.data('expandmode', false);
                 try {
                     $(':hover').trigger('mouseleave');
                 } catch (err) {}
@@ -1944,8 +1990,8 @@ Plugin._initializeGlobalHandlers = function _initializeGlobalHandlers() {
     // have to delegate here because there might be plugins that
     // have their content replaced by something dynamic. in case that tool
     // copies the classes - double click to edit would still work
-    doc.on(Plugin.click, '.cms-plugin', Plugin._clickToHighlightHandler);
-    doc.on(`${Plugin.pointerOverAndOut} ${Plugin.touchStart}`, '.cms-plugin', function(e) {
+    $document.on(Plugin.click, '.cms-plugin', Plugin._clickToHighlightHandler);
+    $document.on(`${Plugin.pointerOverAndOut} ${Plugin.touchStart}`, '.cms-plugin', function(e) {
         // required for both, click and touch
         // otherwise propagation won't work to the nested plugin
 
@@ -1979,9 +2025,9 @@ Plugin._initializeGlobalHandlers = function _initializeGlobalHandlers() {
         CMS.API.Tooltip.displayToggle(e.type === 'pointerover' || e.type === 'touchstart', e, name, id);
     });
 
-    $(window).on('blur.cms', () => {
+    $window.on('blur.cms', () => {
         // TODO should be called differently tbh
-        doc.data('expandmode', false);
+        $document.data('expandmode', false);
     });
 };
 
@@ -2105,7 +2151,7 @@ Plugin._highlightPluginContent = function _highlightPluginContent(
     coordinates.width = Math.max(...positions.map(pos => pos.x2)) - coordinates.left;
     coordinates.height = Math.max(...positions.map(pos => pos.y2)) - coordinates.top - htmlMargin;
 
-    win.scrollTop(coordinates.top - win.height() * OVERLAY_POSITION_TO_WINDOW_HEIGHT_RATIO);
+    $window.scrollTop(coordinates.top - $window.height() * OVERLAY_POSITION_TO_WINDOW_HEIGHT_RATIO);
 
     $(
         `
@@ -2159,6 +2205,9 @@ Plugin._initializeTree = function _initializeTree() {
     CMS._instances = CMS._plugins.map(function(args) {
         return new CMS.Plugin(args[0], args[1]);
     });
+
+    // return the cms plugin instances just created
+    return CMS._instances;
 };
 
 Plugin._updateClipboard = function _updateClipboard() {

--- a/cms/tests/frontend/unit/cms.base.test.js
+++ b/cms/tests/frontend/unit/cms.base.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import CMS, { Helpers, KEYS } from '../../../static/cms/js/modules/cms.base';
+import CMS, { Helpers, KEYS, uid } from '../../../static/cms/js/modules/cms.base';
 var jQuery = require('jquery');
 var $ = jQuery;
 var Class = require('classjs');
@@ -38,7 +38,7 @@ describe('cms.base.js', function() {
         it('exists', function() {
             expect(CMS.API.Helpers).toEqual(jasmine.any(Object));
             // this expectation is here so no one ever forgets to add a test
-            expect(Object.keys(CMS.API.Helpers).length).toEqual(20);
+            expect(Object.keys(CMS.API.Helpers).length).toEqual(23);
         });
 
         describe('.reloadBrowser()', function() {
@@ -982,6 +982,16 @@ describe('cms.base.js', function() {
         describe('._getWindow()', function() {
             it('returns window', function() {
                 expect(CMS.API.Helpers._getWindow()).toEqual(window);
+            });
+        });
+
+        describe('.uid()', function() {
+            it('returns a number', function() {
+                expect(uid()).toEqual(jasmine.any(Number));
+            });
+
+            it('returns always different ids', function() {
+                expect(uid()).not.toBe(uid());
             });
         });
 

--- a/cms/tests/frontend/unit/cms.plugins.test.js
+++ b/cms/tests/frontend/unit/cms.plugins.test.js
@@ -1433,7 +1433,7 @@ describe('CMS.Plugin', function() {
         });
 
         it('removes all the plugin markup', function() {
-            plugin.destroy(true);
+            plugin.destroy({ mustCleanup: true });
             expect($('.cms-plugin-1').length).toBe(0);
         });
 

--- a/cms/tests/frontend/unit/cms.plugins.test.js
+++ b/cms/tests/frontend/unit/cms.plugins.test.js
@@ -35,6 +35,7 @@ describe('CMS.Plugin', function() {
         expect(CMS.Plugin.prototype.movePlugin).toEqual(jasmine.any(Function));
         expect(CMS.Plugin.prototype.deletePlugin).toEqual(jasmine.any(Function));
         expect(CMS.Plugin.prototype.destroy).toEqual(jasmine.any(Function));
+        expect(CMS.Plugin.prototype.cleanup).toEqual(jasmine.any(Function));
         expect(CMS.Plugin.prototype.editPluginPostAjax).toEqual(jasmine.any(Function));
     });
 
@@ -1432,7 +1433,7 @@ describe('CMS.Plugin', function() {
         });
 
         it('removes all the plugin markup', function() {
-            plugin.destroy();
+            plugin.destroy(true);
             expect($('.cms-plugin-1').length).toBe(0);
         });
 
@@ -1443,6 +1444,44 @@ describe('CMS.Plugin', function() {
 
             plugin.destroy();
             CMS.API.Helpers.$document.trigger(plugin._getNamepacedEvent(Plugin.click));
+        });
+    });
+
+    describe('.cleanup()', function() {
+        var plugin;
+
+        beforeEach(function(done) {
+            fixture.load('plugins.html');
+            CMS.config = {
+                csrf: 'CSRF_TOKEN',
+                lang: {}
+            };
+            CMS.settings = {
+                dragbars: [],
+                states: []
+            };
+            $(function() {
+                plugin = new CMS.Plugin('cms-plugin-1', {
+                    type: 'plugin',
+                    plugin_id: 1,
+                    plugin_type: 'TextPlugin',
+                    plugin_name: 'Test Text Plugin',
+                    placeholder_id: 1,
+                    urls: {
+                        add_plugin: '/en/admin/cms/page/add-plugin/',
+                        edit_plugin: '/en/admin/cms/page/edit-plugin/1/',
+                        move_plugin: '/en/admin/cms/page/move-plugin/',
+                        delete_plugin: '/en/admin/cms/page/delete-plugin/1/',
+                        copy_plugin: '/en/admin/cms/page/copy-plugins/'
+                    }
+                });
+                done();
+            });
+        });
+
+        it('removes all the plugin markup', function() {
+            plugin.cleanup();
+            expect($('.cms-plugin-1').length).toBe(0);
         });
     });
 

--- a/cms/tests/frontend/unit/cms.plugins.test.js
+++ b/cms/tests/frontend/unit/cms.plugins.test.js
@@ -34,6 +34,7 @@ describe('CMS.Plugin', function() {
         expect(CMS.Plugin.prototype.pastePlugin).toEqual(jasmine.any(Function));
         expect(CMS.Plugin.prototype.movePlugin).toEqual(jasmine.any(Function));
         expect(CMS.Plugin.prototype.deletePlugin).toEqual(jasmine.any(Function));
+        expect(CMS.Plugin.prototype.destroy).toEqual(jasmine.any(Function));
         expect(CMS.Plugin.prototype.editPluginPostAjax).toEqual(jasmine.any(Function));
     });
 
@@ -1398,6 +1399,53 @@ describe('CMS.Plugin', function() {
         });
     });
 
+    describe('.destroy()', function() {
+        var plugin;
+
+        beforeEach(function(done) {
+            fixture.load('plugins.html');
+            CMS.config = {
+                csrf: 'CSRF_TOKEN',
+                lang: {}
+            };
+            CMS.settings = {
+                dragbars: [],
+                states: []
+            };
+            $(function() {
+                plugin = new CMS.Plugin('cms-plugin-1', {
+                    type: 'plugin',
+                    plugin_id: 1,
+                    plugin_type: 'TextPlugin',
+                    plugin_name: 'Test Text Plugin',
+                    placeholder_id: 1,
+                    urls: {
+                        add_plugin: '/en/admin/cms/page/add-plugin/',
+                        edit_plugin: '/en/admin/cms/page/edit-plugin/1/',
+                        move_plugin: '/en/admin/cms/page/move-plugin/',
+                        delete_plugin: '/en/admin/cms/page/delete-plugin/1/',
+                        copy_plugin: '/en/admin/cms/page/copy-plugins/'
+                    }
+                });
+                done();
+            });
+        });
+
+        it('removes all the plugin markup', function() {
+            plugin.destroy();
+            expect($('.cms-plugin-1').length).toBe(0);
+        });
+
+        it('removes all the plugin events', function() {
+            CMS.API.Helpers.$document.on(plugin._getNamepacedEvent(Plugin.click), function() {
+                throw new Error('This event should never be triggered');
+            });
+
+            plugin.destroy();
+            CMS.API.Helpers.$document.trigger(plugin._getNamepacedEvent(Plugin.click));
+        });
+    });
+
     describe('.editPluginPostAjax()', function() {
         var plugin;
 
@@ -1780,22 +1828,22 @@ describe('CMS.Plugin', function() {
         });
 
         afterEach(function() {
-            $(document).off(Plugin.keyDown + '.traverse');
+            $(document).off('.traverse');
             fixture.cleanup();
         });
 
         it('returns if there is no plugin picker in the modal', function() {
             expect(plugin._setupKeyboardTraversing()).toEqual(undefined);
-            expect($(document)).not.toHandle(Plugin.keyDown + '.traverse');
+            expect($(document)).not.toHandle(plugin._getNamepacedEvent(Plugin.keyDown, 'traverse'));
         });
 
         it('unbinds old traversing keydown events', function() {
             $(fixture.el).append('<div class="cms-modal-markup"></div>');
             plugin.ui.dragitem.find('.cms-plugin-picker').appendTo('.cms-modal-markup');
             var spy = jasmine.createSpy();
-            $(document).on(Plugin.keyDown + '.traverse', spy);
+            $(document).on(plugin._getNamepacedEvent(Plugin.keyDown, 'traverse'), spy);
             plugin._setupKeyboardTraversing();
-            $(document).trigger(Plugin.keyDown + '.traverse');
+            $(document).trigger(plugin._getNamepacedEvent(Plugin.keyDown, 'traverse'));
             expect(spy).not.toHaveBeenCalled();
         });
 
@@ -1804,16 +1852,16 @@ describe('CMS.Plugin', function() {
             plugin.ui.dragitem.find('.cms-plugin-picker').show().appendTo('.cms-modal-markup');
             plugin._setupKeyboardTraversing();
 
-            var down = new $.Event(Plugin.keyDown + '.traverse', {
+            var down = new $.Event(plugin._getNamepacedEvent(Plugin.keyDown, 'traverse'), {
                 keyCode: CMS.KEYS.DOWN
             });
-            var down1 = new $.Event(Plugin.keyDown + '.traverse', {
+            var down1 = new $.Event(plugin._getNamepacedEvent(Plugin.keyDown, 'traverse'), {
                 keyCode: CMS.KEYS.TAB
             });
-            var up = new $.Event(Plugin.keyDown + '.traverse', {
+            var up = new $.Event(plugin._getNamepacedEvent(Plugin.keyDown, 'traverse'), {
                 keyCode: CMS.KEYS.UP
             });
-            var up1 = new $.Event(Plugin.keyDown + '.traverse', {
+            var up1 = new $.Event(plugin._getNamepacedEvent(Plugin.keyDown, 'traverse'), {
                 keyCode: CMS.KEYS.TAB,
                 shiftKey: true
             });
@@ -2074,6 +2122,13 @@ describe('CMS.Plugin', function() {
             ]);
 
             expect($.grep).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    describe('_getNamepacedEvent', function() {
+        it('returns a valid namespaced string', function() {
+            expect(CMS.Plugin.prototype._getNamepacedEvent('click')).toEqual(jasmine.any(String));
+            expect(CMS.Plugin.prototype._getNamepacedEvent('click', 'traverse')).toMatch(/\.traverse/);
         });
     });
 


### PR DESCRIPTION
This feature is not tested because the integration tests seem to be broken on the `develop` branch 

### Summary

- Add the `uid` helper to properly identify any UI Element
- Create aliases to the wrapped `$(window)` and `$(document)` objects
- Add the `destroy` method to the Plugin class removing DOM and events

Fixes #6074


### Links to related discussion

https://github.com/divio/django-cms/issues/6074

### Proposed changes in this pull request

See https://github.com/divio/django-cms/issues/6074