### PR TITLE
Update sitemap.rst - Django 1.10 no longer specify views as a string

### DIFF
--- a/docs/how_to/sitemap.rst
+++ b/docs/how_to/sitemap.rst
@@ -21,7 +21,8 @@ Configuration
  * add :mod:`django.contrib.sitemaps` to your project's :setting:`django:INSTALLED_APPS`
    setting
  * add ``from cms.sitemaps import CMSSitemap`` to the top of your main ``urls.py``
- * add ``url(r'^sitemap\.xml$', 'django.contrib.sitemaps.views.sitemap', {'sitemaps': {'cmspages': CMSSitemap}}),``
+ * add ``from django.contrib.sitemaps.views import sitemap`` in order alpabetics of your main ``urls.py``
+ * add ``url(r'^sitemap\.xml$', sitemap, {'sitemaps': {'cmspages': CMSSitemap}}),``
    to your ``urlpatterns``
 
 

--- a/docs/how_to/sitemap.rst
+++ b/docs/how_to/sitemap.rst
@@ -21,7 +21,7 @@ Configuration
  * add :mod:`django.contrib.sitemaps` to your project's :setting:`django:INSTALLED_APPS`
    setting
  * add ``from cms.sitemaps import CMSSitemap`` to the top of your main ``urls.py``
- * add ``from django.contrib.sitemaps.views import sitemap`` in order alpabetics of your main ``urls.py``
+ * add ``from django.contrib.sitemaps.views import sitemap`` to ``urls.py```
  * add ``url(r'^sitemap\.xml$', sitemap, {'sitemaps': {'cmspages': CMSSitemap}}),``
    to your ``urlpatterns``
 


### PR DESCRIPTION
Without these changes this error appears :

> raise TypeError('view must be a callable or a list/tuple in the case of include().')
> TypeError: view must be a callable or a list/tuple in the case of include().