### PR TITLE
Fixed creation of model instances with PlaceholderField during migration.

### DIFF
--- a/cms/models/fields.py
+++ b/cms/models/fields.py
@@ -32,7 +32,8 @@ class PlaceholderField(models.ForeignKey):
         return name, path, args, kwargs
 
     def _get_new_placeholder(self, instance):
-        return Placeholder.objects.create(slot=self._get_placeholder_slot(instance), default_width=self.default_width)
+        return self.related_model.objects.create(
+            slot=self._get_placeholder_slot(instance), default_width=self.default_width)
 
     def _get_placeholder_slot(self, model_instance):
         from cms.utils.placeholder import validate_placeholder_name


### PR DESCRIPTION
I had this traceback during migration:
```
  Applying app.0030_auto_20171012_0649...Curricilum: hospital <class 'cms.models.placeholdermodel.Placeholder'> <class '__fake__.Placeholder'>
Traceback (most recent call last):
  File "manage.py", line 27, in <module>
    execute_from_command_line(sys.argv)
  File "/usr/local/lib/python3.6/site-packages/django/core/management/__init__.py", line 367, in execute_from_command_line
    utility.execute()
  File "/usr/local/lib/python3.6/site-packages/django/core/management/__init__.py", line 359, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/usr/local/lib/python3.6/site-packages/django/core/management/base.py", line 294, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/usr/local/lib/python3.6/site-packages/django/core/management/base.py", line 345, in execute
    output = self.handle(*args, **options)
  File "/usr/local/lib/python3.6/site-packages/django/core/management/commands/migrate.py", line 204, in handle
    fake_initial=fake_initial,
  File "/usr/local/lib/python3.6/site-packages/django/db/migrations/executor.py", line 115, in migrate
    state = self._migrate_all_forwards(state, plan, full_plan, fake=fake, fake_initial=fake_initial)
  File "/usr/local/lib/python3.6/site-packages/django/db/migrations/executor.py", line 145, in _migrate_all_forwards
    state = self.apply_migration(state, migration, fake=fake, fake_initial=fake_initial)
  File "/usr/local/lib/python3.6/site-packages/django/db/migrations/executor.py", line 244, in apply_migration
    state = migration.apply(state, schema_editor)
  File "/usr/local/lib/python3.6/site-packages/django/db/migrations/migration.py", line 129, in apply
    operation.database_forwards(self.app_label, schema_editor, old_state, project_state)
  File "/usr/local/lib/python3.6/site-packages/django/db/migrations/operations/special.py", line 189, in database_forwards
    self.code(from_state.apps, schema_editor)
  File "/app/proj/app/migrations/0030_auto_20171012_0649.py", line 15, in forwards_func
    Curriculum.objects.using(db_alias).create(name=name, description=None)
  File "/usr/local/lib/python3.6/site-packages/django/db/models/query.py", line 399, in create
    obj.save(force_insert=True, using=self.db)
  File "/usr/local/lib/python3.6/site-packages/django/db/models/base.py", line 796, in save
    force_update=force_update, update_fields=update_fields)
  File "/usr/local/lib/python3.6/site-packages/django/db/models/base.py", line 824, in save_base
    updated = self._save_table(raw, cls, force_insert, force_update, using, update_fields)
  File "/usr/local/lib/python3.6/site-packages/django/db/models/base.py", line 908, in _save_table
    result = self._do_insert(cls._base_manager, using, fields, update_pk, raw)
  File "/usr/local/lib/python3.6/site-packages/django/db/models/base.py", line 947, in _do_insert
    using=using, raw=raw)
  File "/usr/local/lib/python3.6/site-packages/django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/django/db/models/query.py", line 1045, in _insert
    return query.get_compiler(using=using).execute_sql(return_id)
  File "/usr/local/lib/python3.6/site-packages/django/db/models/sql/compiler.py", line 1053, in execute_sql
    for sql, params in self.as_sql():
  File "/usr/local/lib/python3.6/site-packages/django/db/models/sql/compiler.py", line 1006, in as_sql
    for obj in self.query.objs
  File "/usr/local/lib/python3.6/site-packages/django/db/models/sql/compiler.py", line 1006, in <listcomp>
    for obj in self.query.objs
  File "/usr/local/lib/python3.6/site-packages/django/db/models/sql/compiler.py", line 1005, in <listcomp>
    [self.prepare_value(field, self.pre_save_val(field, obj)) for field in fields]
  File "/usr/local/lib/python3.6/site-packages/django/db/models/sql/compiler.py", line 955, in pre_save_val
    return field.pre_save(obj, add=True)
  File "/usr/local/lib/python3.6/site-packages/cms/models/fields.py", line 49, in pre_save
    setattr(model_instance, self.name, self._get_new_placeholder(model_instance))
  File "/usr/local/lib/python3.6/site-packages/django/db/models/fields/related_descriptors.py", line 212, in __set__
    self.field.remote_field.model._meta.object_name,
ValueError: Cannot assign "<Placeholder: Curricilum: hospital>": "Curriculum.description" must be a "Placeholder" instance.
```
