### PR TITLE
Fixed #6196 -- Prevent users from passing a public page as parent in create_page api function

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -14,7 +14,7 @@
 * Introduced logic to copy pages to different sites from the admin.
 * Removed "View on Site" button when adding a page
 * Welcome page no longer uses multilingual URLs when not required.
-* Prevent users from passing a public page as parent in create_page api function
+* Prevent users from passing a public page as parent in ``create_page`` api function
 
 
 === 3.4.5 (2017-10-12) ===

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -14,6 +14,7 @@
 * Introduced logic to copy pages to different sites from the admin.
 * Removed "View on Site" button when adding a page
 * Welcome page no longer uses multilingual URLs when not required.
+* Prevent users from passing a public page as parent in create_page api function
 
 
 === 3.4.5 (2017-10-12) ===

--- a/cms/api.py
+++ b/cms/api.py
@@ -130,7 +130,7 @@ def create_page(title, template, language, menu_title=None, slug=None,
     # validate parent
     if parent:
         assert isinstance(parent, Page)
-        assert parent.publisher_is_draft==True
+        assert parent.publisher_is_draft
 
     # validate publication date
     if publication_date:

--- a/cms/api.py
+++ b/cms/api.py
@@ -130,6 +130,7 @@ def create_page(title, template, language, menu_title=None, slug=None,
     # validate parent
     if parent:
         assert isinstance(parent, Page)
+        assert parent.publisher_is_draft==True
 
     # validate publication date
     if publication_date:

--- a/cms/tests/test_api.py
+++ b/cms/tests/test_api.py
@@ -231,3 +231,10 @@ class PythonAPITests(CMSTestCase):
         page = page.reload()
         self.assertTrue(page.is_published('en'))
         self.assertEqual(page.changed_by, user.get_username())
+
+    def test_create_page_assert_parent_is_draft(self):
+        page_attrs = self._get_default_create_page_arguments()
+        page_attrs['published'] = True
+        parent_page = create_page(**page_attrs)
+        parent_page = parent_page.get_public_object()
+        self.assertRaises(AssertionError, create_page, parent=parent_page, **page_attrs)

--- a/cms/tests/test_api.py
+++ b/cms/tests/test_api.py
@@ -236,5 +236,5 @@ class PythonAPITests(CMSTestCase):
         page_attrs = self._get_default_create_page_arguments()
         page_attrs['published'] = True
         parent_page = create_page(**page_attrs)
-        parent_page = parent_page.get_public_object()
-        self.assertRaises(AssertionError, create_page, parent=parent_page, **page_attrs)
+        parent_page_public = parent_page.get_public_object()
+        self.assertRaises(AssertionError, create_page, parent=parent_page_public, **page_attrs)

--- a/cms/tests/test_apphooks.py
+++ b/cms/tests/test_apphooks.py
@@ -812,7 +812,7 @@ class ApphooksTestCase(CMSTestCase):
 
         page2 = create_page('page2', 'nav_playground.html',
                             'en', created_by=self.superuser, published=True,
-                            parent=titles[0].page.get_parent_page(),
+                            parent=titles[0].page.get_parent_page().get_draft_object(),
                             apphook='VariableUrlsApp', reverse_id='page2')
         create_title('de', 'de_title', page2, slug='slug')
         page2.publish('de')
@@ -854,7 +854,7 @@ class ApphooksTestCase(CMSTestCase):
 
         page2 = create_page('page2', 'nav_playground.html',
                             'en', created_by=self.superuser, published=True,
-                            parent=titles[0].page.get_parent_page(),
+                            parent=titles[0].page.get_parent_page().get_draft_object(),
                             in_navigation=True,
                             apphook='VariableUrlsApp', reverse_id='page2')
         create_title('de', 'de_title', page2, slug='slug')


### PR DESCRIPTION
Fixed #6196
A "published" parent will be accepted but will raise into problems, because of a wrong page tree.

I just add a assertment in `api.create_page()` and fix some tests that have used the published page as parent.