### PR TITLE
Fixed #6149 -- Don't render aliased plugins/placeholders if the host page is unpublished

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,7 @@
 * Page rendering will now use the draft page instead of public page for logged in
   users with change permissions, unless the ``preview`` GET parameter is used.
 * Fixed "Expand all / Collapse all" not reflecting real state of the placeholder tree
+* Fixed a bug where Aliased plugins would render even if their host page was unpublished.
 
 
 === 3.4.5 (2017-10-12) ===

--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -843,7 +843,7 @@ class Page(six.with_metaclass(PageMetaClass, models.Model)):
         return True
 
     def is_published(self, language, force_reload=False):
-        title_obj = self.get_title_obj(language, False, force_reload=force_reload)
+        title_obj = self.get_title_obj(language, fallback=False, force_reload=force_reload)
         return title_obj.published and title_obj.publisher_state != PUBLISHER_STATE_PENDING
 
     def is_reachable(self):


### PR DESCRIPTION
Fixed #6149

This only fixes the condition where the source page (if any) is unpublished.
There's still the [issue](https://github.com/divio/django-cms/issues/5844) where content that is still not public on a published page is rendered.

Also this introduces a change in behavior, as a result it will **not** be backported to 3.4.x