### PR TITLE
scriptname fixed in page resolver

### DIFF
--- a/cms/utils/page_resolver.py
+++ b/cms/utils/page_resolver.py
@@ -104,7 +104,9 @@ def get_page_from_request(request, use_path=None):
     if use_path is not None:
         path = use_path
     else:
-        path = request.path_info
+        # path = request.path_info
+        script_name = request.environ.get('SCRIPT_NAME', '')
+        path = script_name + request.path_info
         pages_root = unquote(reverse("pages-root"))
         # otherwise strip off the non-cms part of the URL
         if is_installed('django.contrib.admin'):


### PR DESCRIPTION
### Summary

I've noticed that if you run django (django-cms) under a subfolder, the Page Tollbar item for an app-hook page disappeared. 

Fixes #


Fixes page_resolver in order to take the scriptname (env SCRIPT_NAME) in account.

