### PR TITLE
Refactored the fallbacks handling logic

### DIFF
--- a/cms/cms_toolbars.py
+++ b/cms/cms_toolbars.py
@@ -15,7 +15,7 @@ from cms.toolbar_base import CMSToolbar
 from cms.toolbar_pool import toolbar_pool
 from cms.utils import get_language_from_request, page_permissions
 from cms.utils.conf import get_cms_setting
-from cms.utils.i18n import get_language_tuple, force_language, get_language_dict, get_default_language
+from cms.utils.i18n import get_language_tuple, force_language, get_language_dict
 from cms.utils.permissions import get_user_sites_queryset
 from cms.utils.page_permissions import (
     user_can_change_page,
@@ -81,12 +81,10 @@ class PlaceholderToolbar(CMSToolbar):
             page_pk = ''
             disabled = True
 
-        lang = get_language_from_request(self.request, current_page=self.page) or get_default_language()
-
         url = '{url}?page={page}&language={lang}&edit'.format(
             url=reverse("cms_wizard_create"),
             page=page_pk,
-            lang=lang,
+            lang=self.toolbar.site_language,
         )
         self.toolbar.add_modal_button(title, url,
                                       side=self.toolbar.RIGHT,
@@ -733,7 +731,7 @@ class PageToolbar(CMSToolbar):
                     on_success=refresh,
                 )
 
-            if not self.page.is_page_type:
+            if self.current_lang and not self.page.is_page_type:
                 # revert to live
                 current_page_menu.add_break(PAGE_MENU_FOURTH_BREAK)
                 revert_action = admin_reverse('cms_page_revert_to_live', args=(self.page.pk, self.current_lang))

--- a/cms/tests/test_apphooks.py
+++ b/cms/tests/test_apphooks.py
@@ -944,6 +944,6 @@ class ApphooksPageLanguageUrlTestCase(CMSTestCase):
 
         output = tag.get_context(fake_context, 'fr')
         url = output['content']
-        self.assertEqual(url, '/fr/child_page/child_child_page/extra_1/')
+        self.assertEqual(url, '/en/child_page/child_child_page/extra_1/')
 
         self.apphook_clear()

--- a/cms/tests/test_i18n.py
+++ b/cms/tests/test_i18n.py
@@ -332,8 +332,9 @@ class TestLanguageFallbacks(CMSTestCase):
         response = self.client.get('/')
         self.assertEqual(response.status_code, 302)
         response = self.client.get('/en/')
-        self.assertEqual(response.status_code, 302)
         self.assertRedirects(response, '/fr/')
+        response = self.client.get('/fr/')
+        self.assertEqual(response.status_code, 200)
 
     @override_settings(
         CMS_LANGUAGES={

--- a/cms/tests/test_menu_page_viewperm.py
+++ b/cms/tests/test_menu_page_viewperm.py
@@ -264,9 +264,12 @@ class ViewPermissionTests(CMSTestCase):
         attrs = {
             'user': user or AnonymousUser(),
             'REQUEST': {},
+            'COOKIES': {},
+            'META': {},
             'POST': {},
             'GET': {},
             'path': path,
+            'path_info': path,
             'session': {},
         }
         return type('Request', (object,), attrs)

--- a/cms/tests/test_multilingual.py
+++ b/cms/tests/test_multilingual.py
@@ -2,9 +2,7 @@
 import copy
 
 from django.contrib.auth import get_user_model
-from django.contrib.auth.models import AnonymousUser
 from django.contrib.sites.models import Site
-from django.http import Http404, HttpResponseRedirect, QueryDict
 from django.test.utils import override_settings
 
 from cms.api import create_page, create_title, publish_page, add_plugin
@@ -13,7 +11,6 @@ from cms.exceptions import LanguageError
 from cms.models import Page, Title, EmptyTitle
 from cms.test_utils.testcases import (CMSTestCase,
                                       URL_CMS_PAGE_CHANGE_LANGUAGE, URL_CMS_PAGE_PUBLISH)
-from cms.test_utils.util.mock import AttributeObject
 from cms.utils.conf import get_cms_setting
 from cms.utils.conf import get_languages
 
@@ -185,6 +182,7 @@ class MultilingualTestCase(CMSTestCase):
             self.assertEqual(len(list_1), 2)
 
     def test_frontend_lang(self):
+        superuser = self.get_superuser()
         lang_settings = copy.deepcopy(get_cms_setting('LANGUAGES'))
         lang_settings[1][0]['public'] = False
         with self.settings(CMS_LANGUAGES=lang_settings, LANGUAGE_CODE="en"):
@@ -205,18 +203,28 @@ class MultilingualTestCase(CMSTestCase):
 
             Page.set_homepage(page)
 
+            # The "en" language is set to public -> False.
+            # Because the request is to the root (homepage),
+            # the page is redirected to the default language's homepage
             response = self.client.get("/en/")
-            self.assertRedirects(response, "/de/")
+            self.assertRedirects(response, '/de/')
+
+            # Authenticated requests to a private language
+            # will render the page normally as long as the language
+            # is available on the page
+            with self.login_user_context(superuser):
+                response = self.client.get("/en/")
+                self.assertEqual(response.status_code, 200)
+
             response = self.client.get("/en/page2/")
             self.assertEqual(response.status_code, 404)
             response = self.client.get("/de/")
             self.assertEqual(response.status_code, 200)
             response = self.client.get("/de/page2/")
             self.assertEqual(response.status_code, 200)
+
             # check if the admin can see non-public langs
-            admin = self.get_superuser()
-            if self.client.login(username=getattr(admin, get_user_model().USERNAME_FIELD),
-                                 password=getattr(admin, get_user_model().USERNAME_FIELD)):
+            with self.login_user_context(self.get_superuser()):
                 response = self.client.get("/en/page2/")
                 self.assertEqual(response.status_code, 200)
                 response = self.client.get("/en/page4/")
@@ -225,93 +233,57 @@ class MultilingualTestCase(CMSTestCase):
             response = self.client.get("/en/page4/")
             self.assertEqual(response.status_code, 404)
 
-    def test_detail_view_404_when_no_language_is_found(self):
-        page = create_page("page1", "nav_playground.html", "en")
-        create_title("de", page.get_title(), page, slug=page.get_slug())
-        page.publish('en')
-        page.publish('de')
+    def test_page_with_invalid_language_for_anon_user(self):
+        site_2 = Site.objects.create(id=2, name='example-2.com', domain='example-2.com')
+        self.create_homepage(
+            "page",
+            template='nav_playground.html',
+            language="de",
+            published=True,
+            site=site_2,
+        )
+        page_2 = create_page(
+            "page",
+            template='nav_playground.html',
+            language="de",
+            published=True,
+            site=site_2,
+        )
 
-        with self.settings(TEMPLATE_CONTEXT_PROCESSORS=[],
-            CMS_LANGUAGES={
-                1:[
-                    {'code':'x-klingon', 'name':'Klingon','public':True, 'fallbacks':[]},
-                    {'code':'x-elvish', 'name':'Elvish', 'public':True, 'fallbacks':[]},
-               ]}):
-            from cms.views import details
+        with self.settings(SITE_ID=2, LANGUAGE_CODE='en'):
+            # url uses "en" as the request language
+            # but the site is configured to use "de" and "fr"
+            response = self.client.get('/en/')
+            self.assertRedirects(response, '/de/')
+            response = self.client.get('/en/%s/' % page_2.get_path('de'))
+            self.assertEqual(response.status_code, 404)
 
-            def get_path():
-                return '/'
+    def test_page_with_invalid_language_for_auth_user(self):
+        site_2 = Site.objects.create(id=2, name='example-2.com', domain='example-2.com')
+        superuser = self.get_superuser()
+        self.create_homepage(
+            "page",
+            template='nav_playground.html',
+            language="de",
+            published=True,
+            site=site_2,
+        )
+        page_2 = create_page(
+            "page",
+            template='nav_playground.html',
+            language="de",
+            published=True,
+            site=site_2,
+        )
 
-            def is_secure():
-                return False
-
-            def get_host():
-                return 'testserver'
-
-            self.get_request()
-
-            request = AttributeObject(
-                GET=QueryDict('language=x-elvish'),
-                POST=QueryDict(''),
-                session={},
-                path='/',
-                current_page=None,
-                method='GET',
-                COOKIES={},
-                META={},
-                user=AnonymousUser(),
-                get_full_path=get_path,
-                is_secure=is_secure,
-                get_host=get_host,
-            )
-            self.assertRaises(Http404, details, request, '')
-
-    def test_detail_view_fallback_language(self):
-        '''
-        Ask for a page in elvish (doesn't exist), and assert that it fallsback
-        to English
-        '''
-        page = create_page("page1", "nav_playground.html", "en")
-        page_path = page.get_path()
-
-        with self.settings(TEMPLATE_CONTEXT_PROCESSORS=[],
-            CMS_LANGUAGES={
-                1:[
-                    {'code':'x-klingon', 'name':'Klingon', 'public':True, 'fallbacks':[]},
-                    {'code':'x-elvish', 'name':'Elvish', 'public':True, 'fallbacks':['x-klingon', 'en', ]},
-                    ]},
-            ):
-            create_title("x-klingon", "futla ak", page, slug=page.get_slug())
-            page.publish("x-klingon")
-            from cms.views import details
-
-            def get_path():
-                return page_path
-
-            def is_secure():
-                return False
-
-            def get_host():
-                return 'testserver'
-
-            User = get_user_model()
-            request = AttributeObject(
-                GET=QueryDict('language=x-elvish'),
-                POST=QueryDict(''),
-                session={},
-                path=page_path,
-                current_page=None,
-                method='GET',
-                COOKIES={},
-                META={},
-                user=User(),
-                get_full_path=get_path,
-                is_secure=is_secure,
-                get_host=get_host,
-            )
-
-            response = details(request, page_path)
-            self.assertTrue(isinstance(response, HttpResponseRedirect))
+        with self.settings(SITE_ID=2, LANGUAGE_CODE='en'):
+            with self.login_user_context(superuser):
+                # url uses "en" as the request language
+                # but the site is configured to use "de" and "fr"
+                response = self.client.get('/en/')
+                self.assertRedirects(response, '/de/')
+                response = self.client.get('/en/%s/' % page_2.get_path('de'))
+                self.assertEqual(response.status_code, 404)
 
     def test_language_fallback(self):
         """
@@ -322,22 +294,35 @@ class MultilingualTestCase(CMSTestCase):
 
         Page.set_homepage(p1)
 
+        # There's no "de" translation.
+        # Fallbacks are configured.
+        # The cms is set to redirect on fallback.
         request = self.get_request('/de/', 'de')
         response = details(request, p1.get_path())
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response['Location'], '/en/')
+
+        # There's no "de" translation.
+        # There's no fallbacks configured.
         lang_settings = copy.deepcopy(get_cms_setting('LANGUAGES'))
         lang_settings[1][0]['fallbacks'] = []
         lang_settings[1][1]['fallbacks'] = []
+
         with self.settings(CMS_LANGUAGES=lang_settings):
             response = self.client.get("/de/")
             self.assertEqual(response.status_code, 404)
+
+        # There's no "de" translation.
+        # Fallbacks are configured.
+        # The cms is set to render in place instead of redirecting
+        # to the fallback.
         lang_settings = copy.deepcopy(get_cms_setting('LANGUAGES'))
         lang_settings[1][0]['redirect_on_fallback'] = False
         lang_settings[1][1]['redirect_on_fallback'] = False
+
         with self.settings(CMS_LANGUAGES=lang_settings):
             response = self.client.get("/de/")
-            self.assertEqual(response.status_code, 302)
+            self.assertRedirects(response, '/en/')
 
     def test_publish_status(self):
         p1 = create_page("page", "nav_playground.html", "en", published=True)

--- a/cms/tests/test_templatetags.py
+++ b/cms/tests/test_templatetags.py
@@ -249,7 +249,7 @@ class TemplatetagDatabaseTests(TwoPagesFixture, CMSTestCase):
             context = self.get_context(page_3.get_absolute_url())
             context['request'].current_page = page_3.publisher_public
             res = self.render_template_obj(tpl, context.__dict__, context['request'])
-            self.assertEqual(res, "/de/page-3/")
+            self.assertEqual(res, "/en/page-3/")
         lang_settings[1][1]['hide_untranslated'] = True
 
         with self.settings(CMS_LANGUAGES=lang_settings):

--- a/cms/views.py
+++ b/cms/views.py
@@ -3,26 +3,35 @@
 from django.conf import settings
 from django.contrib.auth import login as auth_login, REDIRECT_FIELD_NAME
 from django.contrib.auth.views import redirect_to_login
-from django.core.urlresolvers import resolve, Resolver404, reverse
+from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect, HttpResponse
 from django.utils.cache import patch_cache_control
 from django.utils.http import is_safe_url, urlquote
 from django.utils.timezone import now
-from django.utils.translation import get_language
+from django.utils.translation import get_language_from_request
 from django.views.decorators.http import require_POST
 
-from cms.apphook_pool import apphook_pool
-from cms.appresolver import get_app_urls
 from cms.cache.page import get_page_cache
+from cms.exceptions import LanguageError
 from cms.forms.login import CMSToolbarLoginForm
 from cms.page_rendering import _handle_no_page, render_page, render_object_structure, _render_welcome_page
-from cms.utils import get_current_site, get_language_code, get_language_from_request
+from cms.toolbar.utils import get_toolbar_from_request
+from cms.utils import get_current_site
 from cms.utils.conf import get_cms_setting
-from cms.utils.i18n import (get_fallback_languages, force_language, get_public_languages,
+from cms.utils.i18n import (get_fallback_languages, get_public_languages,
                             get_redirect_on_fallback, get_language_list,
+                            get_default_language_for_site,
                             is_language_prefix_patterns_used)
 from cms.utils.page import get_node_queryset, get_page_from_request
 from cms.utils.page_permissions import user_can_change_page
+
+
+def _clean_redirect_url(redirect_url, language):
+    if (redirect_url and is_language_prefix_patterns_used() and redirect_url[0] == "/"
+            and not redirect_url.startswith('/%s/' % language)):
+        # add language prefix to url
+        redirect_url = "/%s/%s" % (language, redirect_url.lstrip("/"))
+    return redirect_url
 
 
 def details(request, slug):
@@ -52,6 +61,7 @@ def details(request, slug):
     # Get a Page model object from the request
     site = get_current_site()
     page = get_page_from_request(request, use_path=slug)
+    toolbar = get_toolbar_from_request(request)
     page_nodes = get_node_queryset(site)
 
     if not page and not slug and not page_nodes.exists():
@@ -65,132 +75,83 @@ def details(request, slug):
 
     request.current_page = page
 
-    current_language = request.GET.get('language', None)
-
-    if not current_language:
-        current_language = request.POST.get('language', None)
-
-    if current_language:
-        current_language = get_language_code(current_language)
-        if current_language not in get_language_list(page.site_id):
-            current_language = None
-    if current_language is None:
-        current_language = get_language_code(getattr(request, 'LANGUAGE_CODE', None))
-        if current_language:
-            current_language = get_language_code(current_language)
-            if current_language not in get_language_list(page.site_id):
-                current_language = None
-    if current_language is None:
-        current_language = get_language_code(get_language())
-    # Check that the current page is available in the desired (current) language
-    available_languages = []
-    # this will return all languages in draft mode, and published only in live mode
-    page_languages = list(page.get_published_languages())
     if hasattr(request, 'user') and request.user.is_staff:
-        user_languages = get_language_list()
+        user_languages = get_language_list(site_id=site.pk)
     else:
-        user_languages = get_public_languages()
-    for frontend_lang in user_languages:
-        if frontend_lang in page_languages:
-            available_languages.append(frontend_lang)
-    # Check that the language is in FRONTEND_LANGUAGES:
+        user_languages = get_public_languages(site_id=site.pk)
+
+    request_language = get_language_from_request(request, check_path=True)
+
+    if not page.is_home and request_language not in user_languages:
+        # The homepage is treated differently because
+        # when a request goes to the root of the site (/)
+        # without a language, Django will redirect to the user's
+        # browser language which might not be a valid cms language,
+        # this means we need to correctly redirect that request.
+        return _handle_no_page(request)
+
+    # get_published_languages will return all languages in draft mode
+    # and published only in live mode.
+    # These languages are then filtered out by the user allowed languages
+    available_languages = [
+        language for language in user_languages
+        if language in list(page.get_published_languages())
+    ]
+
     own_urls = [
-        'http%s://%s%s' % ('s' if request.is_secure() else '', request.get_host(), request.path),
+        request.build_absolute_uri(request.path),
         '/%s' % request.path,
         request.path,
     ]
-    if current_language not in user_languages:
-        #are we on root?
-        if not slug:
-            #redirect to supported language
-            languages = []
-            for language in available_languages:
-                languages.append((language, language))
-            if languages:
-                # get supported language
-                new_language = get_language_from_request(request)
-                if new_language in get_public_languages():
-                    with force_language(new_language):
-                        pages_root = reverse('pages-root')
-                        if (hasattr(request, 'toolbar') and request.user.is_staff and request.toolbar.edit_mode_active):
-                            request.toolbar.redirect_url = pages_root
-                        elif pages_root not in own_urls:
-                            return HttpResponseRedirect(pages_root)
-            elif not hasattr(request, 'toolbar') or not request.toolbar.redirect_url:
-                # raise 404
-                _handle_no_page(request)
-        else:
-            # raise 404
-            _handle_no_page(request)
-    if current_language not in available_languages:
-        # If we didn't find the required page in the requested (current)
-        # language, let's try to find a fallback
-        found = False
-        for alt_lang in get_fallback_languages(current_language):
-            if alt_lang in available_languages:
-                if get_redirect_on_fallback(current_language) or slug == "":
-                    with force_language(alt_lang):
-                        path = page.get_absolute_url(language=alt_lang, fallback=True)
-                        # In the case where the page is not available in the
-                    # preferred language, *redirect* to the fallback page. This
-                    # is a design decision (instead of rendering in place)).
-                    if (hasattr(request, 'toolbar') and request.user.is_staff
-                            and request.toolbar.edit_mode_active):
-                        request.toolbar.redirect_url = path
-                    elif path not in own_urls:
-                        return HttpResponseRedirect(path)
-                else:
-                    found = True
-        if not found and (not hasattr(request, 'toolbar') or not request.toolbar.redirect_url):
-            # There is a page object we can't find a proper language to render it
-            _handle_no_page(request)
+
+    try:
+        redirect_on_fallback = get_redirect_on_fallback(request_language, site_id=site.pk)
+    except LanguageError:
+        redirect_on_fallback = False
+
+    if request_language not in user_languages:
+        # Language is not allowed
+        # Use the default site language
+        default_language = get_default_language_for_site(site.pk)
+        fallbacks = get_fallback_languages(default_language, site_id=site.pk)
+        fallbacks = [default_language] + fallbacks
     else:
-        page_path = page.get_absolute_url(language=current_language)
-        page_slug = page.get_path(language=current_language) or page.get_slug(language=current_language)
+        fallbacks = get_fallback_languages(request_language, site_id=site.pk)
+
+    # Only fallback to languages the user is allowed to see
+    fallback_languages = [
+        language for language in fallbacks
+        if language != request_language and language in available_languages
+    ]
+    language_is_unavailable = request_language not in available_languages
+
+    if language_is_unavailable and not fallback_languages:
+        # There is no page with the requested language
+        # and there's no configured fallbacks
+        return _handle_no_page(request)
+    elif language_is_unavailable and (redirect_on_fallback or page.is_home):
+        # There is no page with the requested language and
+        # the user has explicitly requested to redirect on fallbacks,
+        # so redirect to the first configured / available fallback language
+        fallback = fallback_languages[0]
+        redirect_url = page.get_absolute_url(fallback, fallback=False)
+    else:
+        page_path = page.get_absolute_url(request_language)
+        page_slug = page.get_path(request_language) or page.get_slug(request_language)
 
         if slug and slug != page_slug and request.path[:len(page_path)] != page_path:
-            # The current language does not match it's slug.
-            #  Redirect to the current language.
-            if hasattr(request, 'toolbar') and request.user.is_staff and request.toolbar.edit_mode_active:
-                request.toolbar.redirect_url = page_path
-            else:
-                return HttpResponseRedirect(page_path)
+            # The current language does not match its slug.
+            # Redirect to the current language.
+            return HttpResponseRedirect(page_path)
+        # Check if the page has a redirect url defined for this language.
+        redirect_url = page.get_redirect(request_language, fallback=False) or ''
+        redirect_url = _clean_redirect_url(redirect_url, request_language)
 
-    if apphook_pool.get_apphooks():
-        # There are apphooks in the pool. Let's see if there is one for the
-        # current page
-        # since we always have a page at this point, applications_page_check is
-        # pointless
-        # page = applications_page_check(request, page, slug)
-        # Check for apphooks! This time for real!
-        app_urls = page.get_application_urls(current_language, False)
-        skip_app = False
-        if (not page.is_published(current_language) and hasattr(request, 'toolbar')
-                and request.toolbar.edit_mode_active):
-            skip_app = True
-        if app_urls and not skip_app:
-            app = apphook_pool.get_apphook(app_urls)
-            pattern_list = []
-            if app:
-                for urlpatterns in get_app_urls(app.get_urls(page, current_language)):
-                    pattern_list += urlpatterns
-                try:
-                    view, args, kwargs = resolve('/', tuple(pattern_list))
-                    return view(request, *args, **kwargs)
-                except Resolver404:
-                    pass
-    # Check if the page has a redirect url defined for this language.
-    redirect_url = page.get_redirect(language=current_language)
     if redirect_url:
-        if (is_language_prefix_patterns_used() and redirect_url[0] == "/"
-                and not redirect_url.startswith('/%s/' % current_language)):
-            # add language prefix to url
-            redirect_url = "/%s/%s" % (current_language, redirect_url.lstrip("/"))
-            # prevent redirect to self
-
-        if hasattr(request, 'toolbar') and request.user.is_staff and request.toolbar.edit_mode_active:
-            request.toolbar.redirect_url = redirect_url
+        if request.user.is_staff and toolbar.edit_mode_active:
+            toolbar.redirect_url = redirect_url
         elif redirect_url not in own_urls:
+            # prevent redirect to self
             return HttpResponseRedirect(redirect_url)
 
     # permission checks
@@ -204,9 +165,7 @@ def details(request, slug):
 
     if user_can_change_page(request.user, page) and structure_requested:
         return render_object_structure(request, page)
-
-    response = render_page(request, page, current_language=current_language, slug=slug)
-    return response
+    return render_page(request, page, current_language=request_language, slug=slug)
 
 
 @require_POST

--- a/cms/wizards/views.py
+++ b/cms/wizards/views.py
@@ -8,13 +8,13 @@ from django.core.exceptions import PermissionDenied
 from django.core.files.storage import FileSystemStorage
 from django.core.urlresolvers import NoReverseMatch
 from django.template.response import SimpleTemplateResponse
-from django.utils.translation import get_language_from_request
 
 from formtools.wizard.views import SessionWizardView
 
 from cms.models import Page
 from cms.utils import get_current_site
 from cms.utils.compat import DJANGO_1_10
+from cms.utils.i18n import get_site_language_from_request
 
 from .wizard_pool import wizard_pool
 from .forms import (
@@ -98,9 +98,7 @@ class WizardCreateView(SessionWizardView):
                 kwargs['wizard_page'] = Page.objects.filter(pk=page_pk).first()
             else:
                 kwargs['wizard_page'] = None
-
-            kwargs['wizard_language'] = self.request.GET.get(
-                'language', get_language_from_request(self.request))
+            kwargs['wizard_language'] = get_site_language_from_request(self.request)
 
         if kwargs['wizard_page']:
             kwargs['wizard_page_node'] = kwargs['wizard_page'].get_node_object(self.site)


### PR DESCRIPTION
Fixes https://github.com/divio/django-cms/issues/6183
Fixes https://github.com/divio/django-cms/issues/6179
Fixes https://github.com/divio/django-cms/issues/6173
Fixes https://github.com/divio/django-cms/issues/6172
Fixes https://github.com/divio/django-cms/issues/5841

**BACKARDS INCOMPATIBLE**
The `language` parameter is no longer used as a way to get the current language.
From now on, the request language (or default language) is the one used.