### PR TITLE
Fixes #5297: Allows unicode slugs

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,6 +9,7 @@
 * Fixed "Expand all / Collapse all" not reflecting real state of the placeholder tree
 * Fixed a bug where Aliased plugins would render even if their host page was unpublished.
 * Fixed a bug where focusing inputs in modal would require 2 clicks in some browsers
+* Allowing Unicode Slugs for Pages.
 
 
 === 3.4.5 (2017-10-12) ===

--- a/cms/models/titlemodels.py
+++ b/cms/models/titlemodels.py
@@ -32,7 +32,7 @@ class Title(models.Model):
                                   help_text=_("overwrite the title in the menu"))
     meta_description = models.TextField(_("description"), max_length=155, blank=True, null=True,
                                         help_text=_("The text displayed in search engines."))
-    slug = models.SlugField(_("slug"), max_length=255, db_index=True, unique=False)
+    slug = models.SlugField(_("slug"), max_length=255, db_index=True, unique=False, allow_unicode=True)
     path = models.CharField(_("Path"), max_length=255, db_index=True)
     has_url_overwrite = models.BooleanField(_("has url overwrite"), default=False, db_index=True, editable=False)
     redirect = models.CharField(_("redirect"), max_length=2048, blank=True, null=True)


### PR DESCRIPTION
### Summary

At the moment only ASCII page slugs are accepted and user cannot enter Unicode character as slugs.
Unicode Slugs are very important when it comes to CMS.

This pull requests makes Django CMS PageTitle model to Allows Unicode slugs.

* Fixes #5297


### Links to related discussion

* https://github.com/divio/django-cms/issues/5297
* http://support.divio.com/project-types/django-cms/unicode-characters-in-url-slugs


### Proposed changes in this pull request

The `cms.models.Title.slug` gets a `allows_unicode` parameter. (since https://github.com/django/django/pull/4518)
