### PR TITLE
Fixed #6213 -- Display aliased content on edit mode regardless of source page status

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,7 +7,7 @@
 * Page rendering will now use the draft page instead of public page for logged in
   users with change permissions, unless the ``preview`` GET parameter is used.
 * Fixed "Expand all / Collapse all" not reflecting real state of the placeholder tree
-* Fixed a bug where Aliased plugins would render even if their host page was unpublished.
+* Fixed a bug where Aliased plugins would render if their host page was unpublished (and user was not on edit mode).
 * Fixed a bug where focusing inputs in modal would require 2 clicks in some browsers
 * Changed the language chooser to always show all configured languages to staff members
   and public-only languages to anon users.

--- a/cms/templatetags/cms_alias_tags.py
+++ b/cms/templatetags/cms_alias_tags.py
@@ -16,7 +16,7 @@ def render_alias_plugin(context, instance):
     renderer = toolbar.content_renderer
     source = (instance.plugin or instance.alias_placeholder)
 
-    if source and source.page:
+    if not(toolbar.edit_mode_active) and source and source.page:
         # this is bad but showing unpublished content is worse
         can_see_content = source.page.is_published(instance.language)
     else:

--- a/cms/templatetags/cms_alias_tags.py
+++ b/cms/templatetags/cms_alias_tags.py
@@ -16,6 +16,8 @@ def render_alias_plugin(context, instance):
     renderer = toolbar.content_renderer
     source = (instance.plugin or instance.alias_placeholder)
 
+    # In edit mode, content is shown regardless of the source page publish status.
+    # In published mode, content is shown only if the source page is published.
     if not(toolbar.edit_mode_active) and source and source.page:
         # this is bad but showing unpublished content is worse
         can_see_content = source.page.is_published(instance.language)

--- a/cms/tests/test_alias.py
+++ b/cms/tests/test_alias.py
@@ -95,8 +95,8 @@ class AliasTestCase(TransactionCMSTestCase):
 
     def test_alias_content_plugin_display(self):
         '''
-        In edit mode, content must be shown regardless of source_page status.
-        Otherwise, content must be shown only when source_page is published.
+        In edit mode, content is shown regardless of the source page publish status.
+        In published mode, content is shown only if the source page is published.
         '''
         superuser = self.get_superuser()
         source_page = api.create_page(
@@ -151,8 +151,8 @@ class AliasTestCase(TransactionCMSTestCase):
 
     def test_alias_content_placeholder_display(self):
         '''
-        In edit mode, content must be shown regardless of source_page status.
-        Otherwise, content must be shown only when source_page is published.
+        In edit mode, content is shown regardless of the source page publish status.
+        In published mode, content is shown only if the source page is published.
         '''
         superuser = self.get_superuser()
         source_page = api.create_page(

--- a/cms/tests/test_alias.py
+++ b/cms/tests/test_alias.py
@@ -93,7 +93,11 @@ class AliasTestCase(TransactionCMSTestCase):
             self.assertEqual(response.status_code, 200)
             self.assertContains(response, '<div class="info">', html=False)
 
-    def test_alias_ref_plugin_on_unpublished_page(self):
+    def test_alias_content_plugin_display(self):
+        '''
+        In edit mode, content must be shown regardless of source_page status.
+        Otherwise, content must be shown only when source_page is published.
+        '''
         superuser = self.get_superuser()
         source_page = api.create_page(
             "Alias plugin",
@@ -122,20 +126,34 @@ class AliasTestCase(TransactionCMSTestCase):
         )
 
         with self.login_user_context(superuser):
-            # Source page is unpublished. Alias plugin should not render anything.
-            response = self.client.get(target_page.get_absolute_url() + '?edit')
+            # Not published, not edit mode: hide content
+            response = self.client.get(target_page.get_absolute_url())
             self.assertEqual(response.status_code, 200)
             self.assertNotContains(response, '<a href="https://www.django-cms.org" >A Link</a>', html=True)
 
-        source_page.publish('en')
-
-        with self.login_user_context(superuser):
-            # Source page is published. Alias plugin should render normally.
+            # Not published, edit mode: show content
             response = self.client.get(target_page.get_absolute_url() + '?edit')
             self.assertEqual(response.status_code, 200)
             self.assertContains(response, '<a href="https://www.django-cms.org" >A Link</a>', html=True)
 
-    def test_alias_ref_placeholder_on_unpublished_page(self):
+        source_page.publish('en')
+
+        with self.login_user_context(superuser):
+            # Published, not edit mode: show content
+            response = self.client.get(target_page.get_absolute_url())
+            self.assertEqual(response.status_code, 200)
+            self.assertContains(response, '<a href="https://www.django-cms.org" >A Link</a>', html=True)
+
+            # Published, edit mode: show content
+            response = self.client.get(target_page.get_absolute_url() + '?edit')
+            self.assertEqual(response.status_code, 200)
+            self.assertContains(response, '<a href="https://www.django-cms.org" >A Link</a>', html=True)
+
+    def test_alias_content_placeholder_display(self):
+        '''
+        In edit mode, content must be shown regardless of source_page status.
+        Otherwise, content must be shown only when source_page is published.
+        '''
         superuser = self.get_superuser()
         source_page = api.create_page(
             "Alias plugin",
@@ -165,15 +183,25 @@ class AliasTestCase(TransactionCMSTestCase):
         )
 
         with self.login_user_context(superuser):
-            # Source page is unpublished. Alias plugin should not render anything.
-            response = self.client.get(target_page.get_absolute_url() + '?edit')
+            # Not published, not edit mode: hide content
+            response = self.client.get(target_page.get_absolute_url())
             self.assertEqual(response.status_code, 200)
             self.assertNotContains(response, '<a href="https://www.django-cms.org" >A Link</a>', html=True)
+
+            # Not published, edit mode: show content
+            response = self.client.get(target_page.get_absolute_url() + '?edit')
+            self.assertEqual(response.status_code, 200)
+            self.assertContains(response, '<a href="https://www.django-cms.org" >A Link</a>', html=True)
 
         source_page.publish('en')
 
         with self.login_user_context(superuser):
-            # Source page is published. Alias plugin should render normally.
+            # Published, not edit mode: show content
+            response = self.client.get(target_page.get_absolute_url())
+            self.assertEqual(response.status_code, 200)
+            self.assertContains(response, '<a href="https://www.django-cms.org" >A Link</a>', html=True)
+
+            # Published, edit mode: show content
             response = self.client.get(target_page.get_absolute_url() + '?edit')
             self.assertEqual(response.status_code, 200)
             self.assertContains(response, '<a href="https://www.django-cms.org" >A Link</a>', html=True)

--- a/test_requirements/requirements_base.txt
+++ b/test_requirements/requirements_base.txt
@@ -18,3 +18,4 @@ pyflakes==1.1.0
 pyenchant
 # required to run the server for integration tests
 djangocms-helper
+mock>=2.0.0


### PR DESCRIPTION
Fixed #6213  