### PR TITLE
Don't use multilingual URLs on the welcome template redirect

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -13,6 +13,7 @@
   and public-only languages to anon users.
 * Introduced logic to copy pages to different sites from the admin.
 * Removed "View on Site" button when adding a page
+* Welcome page no longer uses multilingual URLs when not required.
 
 
 === 3.4.5 (2017-10-12) ===

--- a/cms/page_rendering.py
+++ b/cms/page_rendering.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from django.conf import settings
-from django.core.urlresolvers import resolve, Resolver404
+from django.core.urlresolvers import resolve, Resolver404, reverse
 from django.http import Http404
 from django.shortcuts import render
 from django.template.response import TemplateResponse
@@ -75,5 +75,6 @@ def _render_welcome_page(request):
         'cms_version': __version__,
         'cms_edit_on': get_cms_setting('CMS_TOOLBAR_URL__EDIT_ON'),
         'django_debug': settings.DEBUG,
+        'next_url': reverse('pages-root'),
     }
     return TemplateResponse(request, "cms/welcome.html", context)

--- a/cms/templates/cms/welcome.html
+++ b/cms/templates/cms/welcome.html
@@ -98,7 +98,7 @@
                 }
             });
         {% else %}
-            window.location.href = '{% url "admin:login" %}?next={{ next_url }}';
+            window.location.href = '{% url "admin:login" %}?next={{ next_url }}?{{ cms_edit_on }}';
         {% endif %}
     </script>
     {% endlanguage %}

--- a/cms/templates/cms/welcome.html
+++ b/cms/templates/cms/welcome.html
@@ -98,11 +98,7 @@
                 }
             });
         {% else %}
-            {% if LANGUAGE_CODE %}
-                window.location.href = '{% url "admin:login" %}?next=/{{ LANGUAGE_CODE }}/?{{ cms_edit_on }}';
-            {% else %}
-                window.location.href = '{% url "admin:login" %}?next=/?{{ cms_edit_on }}';
-            {% endif %}
+            window.location.href = '{% url "admin:login" %}?next=/?{{ cms_edit_on }}';
         {% endif %}
     </script>
     {% endlanguage %}

--- a/cms/templates/cms/welcome.html
+++ b/cms/templates/cms/welcome.html
@@ -98,7 +98,7 @@
                 }
             });
         {% else %}
-            window.location.href = '{% url "admin:login" %}?next=/?{{ cms_edit_on }}';
+            window.location.href = '{% url "admin:login" %}?next={{ next_url }}';
         {% endif %}
     </script>
     {% endlanguage %}


### PR DESCRIPTION
### Summary

Fixes #5070

### Proposed changes in this pull request

Not everyone uses multilingual URLs so use the normal URLs.