### PR TITLE
Disabled spelling in documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -236,8 +236,11 @@ latex_documents = [
 
 # Spelling check needs an additional module that is not installed by default.
 # Add it only if spelling check is requested so docs can be generated without it.
-if 'spelling' in sys.argv:
-    extensions.append("sphinxcontrib.spelling")
+
+# temporarily disabled because of an issue on RTD. see docs/requirements.txt
+
+# if 'spelling' in sys.argv:
+#     extensions.append("sphinxcontrib.spelling")
 
 # Spelling language.
 spelling_lang = 'en_GB'

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,7 +2,8 @@
 MarkupSafe==0.23
 Pygments==2.0.2
 sphinx
-sphinxcontrib-spelling
+# temporarily disabled because of an issue on RTD. see also conf.py
+#sphinxcontrib-spelling
 pyenchant
 sphinx-autobuild
 sphinx_rtd_theme


### PR DESCRIPTION
Removed sphinxcontrib-spelling from docs/requirements.txt, as it
was causing build errors on Read the Docs.

This will need to be reinstated in due course.