### PR TITLE
Fixed #6227 -- migrations should only depend on initial content type migration

### DIFF
--- a/cms/migrations/0010_migrate_use_structure.py
+++ b/cms/migrations/0010_migrate_use_structure.py
@@ -71,7 +71,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ('cms', '0009_merge'),
-        ('contenttypes', '__latest__'),
+        ('contenttypes', '0001_initial'),
     ]
 
     operations = [

--- a/cms/migrations/0014_auto_20160404_1908.py
+++ b/cms/migrations/0014_auto_20160404_1908.py
@@ -46,7 +46,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ('cms', '0013_urlconfrevision'),
-        ('contenttypes', '__latest__'),
+        ('contenttypes', '0001_initial'),
     ]
 
     operations = [


### PR DESCRIPTION
Fixed #6227 
Regression introduced in https://github.com/divio/django-cms/pull/4325