### PR TITLE
Fixed #6227 -- migrations should only depend on initial content type migration

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -10,6 +10,8 @@
 * Fixed a bug where the sitemap would ignore the ``public`` setting of the site languages
   and thus display hidden languages.
 * Fixed an ``AttributeError`` raised when adding or removing apphooks in Django 1.11.
+* Fixed an ``InconsistentMigrationHistory`` error raised when the contenttypes app
+  has a pending migration after the user has applied the ``0010_migrate_use_structure`` migration.
 
 
 === 3.4.5 (2017-10-12) ===

--- a/cms/migrations/0010_migrate_use_structure.py
+++ b/cms/migrations/0010_migrate_use_structure.py
@@ -71,7 +71,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ('cms', '0009_merge'),
-        ('contenttypes', '__latest__'),
+        ('contenttypes', '0001_initial'),
     ]
 
     operations = [

--- a/cms/migrations/0014_auto_20160404_1908.py
+++ b/cms/migrations/0014_auto_20160404_1908.py
@@ -46,7 +46,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ('cms', '0013_urlconfrevision'),
-        ('contenttypes', '__latest__'),
+        ('contenttypes', '0001_initial'),
     ]
 
     operations = [


### PR DESCRIPTION
Backport https://github.com/divio/django-cms/pull/6260