### PR TITLE
Django 2.0 compatibility: first steps

### DIFF
--- a/cms/__init__.py
+++ b/cms/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '3.5.0-django2'
+__version__ = '3.5.0'
 
 default_app_config = 'cms.apps.CMSConfig'

--- a/cms/__init__.py
+++ b/cms/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '3.5.0'
+__version__ = '3.5.0-django2'
 
 default_app_config = 'cms.apps.CMSConfig'

--- a/cms/appresolver.py
+++ b/cms/appresolver.py
@@ -4,8 +4,13 @@ from importlib import import_module
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.core.urlresolvers import (RegexURLResolver, Resolver404, reverse,
+try:
+    from django.urls import (RegexURLResolver, Resolver404, reverse,
                                       RegexURLPattern)
+except ImportError:
+    from django.core.urlresolvers import (RegexURLResolver, Resolver404, reverse,
+                                      RegexURLPattern)
+
 from django.db import OperationalError, ProgrammingError
 from django.utils import six
 from django.utils.translation import get_language, override

--- a/cms/cache/page.py
+++ b/cms/cache/page.py
@@ -33,7 +33,10 @@ def set_page_cache(response):
 
     request = response._request
     toolbar = get_toolbar_from_request(request)
-    is_authenticated = request.user.is_authenticated()
+    try:
+        is_authenticated = request.user.is_authenticated() # Django<1.10
+    except TypeError:
+        is_authenticated = request.user.is_authenticated # Django 1.10 - 2.x
 
     if is_authenticated or toolbar._cache_disabled or not get_cms_setting("PAGE_CACHE"):
         add_never_cache_headers(response)

--- a/cms/cms_menus.py
+++ b/cms/cms_menus.py
@@ -38,7 +38,11 @@ def get_visible_nodes(request, pages, site):
     public_for = get_cms_setting('PUBLIC_FOR')
     can_see_unrestricted = public_for == 'all' or (public_for == 'staff' and user.is_staff)
 
-    if not user.is_authenticated() and not can_see_unrestricted:
+    try:
+        is_authenticated = user.is_authenticated() # Django<1.10
+    except TypeError:
+        is_authenticated = user.is_authenticated # Django 1.10 - 2.x
+    if not is_authenticated and not can_see_unrestricted:
         # User is not authenticated and can't see unrestricted pages,
         # no need to check for page restrictions because if there's some,
         # user is anon and if there is not any, user can't see unrestricted.

--- a/cms/cms_menus.py
+++ b/cms/cms_menus.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
-from django.core.urlresolvers import reverse
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse
 from django.db.models.query import Prefetch, prefetch_related_objects
 from django.utils.functional import SimpleLazyObject
 from django.utils.translation import override as force_language

--- a/cms/cms_toolbars.py
+++ b/cms/cms_toolbars.py
@@ -4,7 +4,10 @@ from django.contrib import admin
 from django.contrib.auth import get_permission_codename, get_user_model
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.sites.models import Site
-from django.core.urlresolvers import reverse, NoReverseMatch, resolve, Resolver404
+try:
+    from django.urls import reverse, NoReverseMatch, resolve, Resolver404
+except ImportError:
+    from django.core.urlresolvers import reverse, NoReverseMatch, resolve, Resolver404
 from django.db.models import Q
 from django.utils.translation import override as force_language, ugettext_lazy as _
 

--- a/cms/extensions/admin.py
+++ b/cms/extensions/admin.py
@@ -4,7 +4,10 @@ from cms.utils.page_permissions import user_can_change_page
 from django.contrib import admin
 from django.contrib.admin.options import csrf_protect_m
 from django.core.exceptions import PermissionDenied
-from django.core.urlresolvers import reverse
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 
 

--- a/cms/extensions/toolbar.py
+++ b/cms/extensions/toolbar.py
@@ -5,7 +5,10 @@ from cms.toolbar_base import CMSToolbar
 from cms.utils import get_language_list
 from cms.utils.page_permissions import user_can_change_page
 
-from django.core.urlresolvers import NoReverseMatch
+try:
+    from django.urls import NoReverseMatch
+except ImportError:
+    from django.core.urlresolvers import NoReverseMatch
 
 
 class ExtensionToolbar(CMSToolbar):

--- a/cms/forms/fields.py
+++ b/cms/forms/fields.py
@@ -85,7 +85,7 @@ class PageSmartLinkField(forms.CharField):
                  ajax_view=None, *args, **kwargs):
         self.placeholder_text = placeholder_text
         widget = self.widget(ajax_view=ajax_view)
-        super(PageSmartLinkField, self).__init__(max_length, min_length,
+        super(PageSmartLinkField, self).__init__(max_length=max_length, min_length=min_length,
                                                  widget=widget, *args, **kwargs)
 
     def widget_attrs(self, widget):

--- a/cms/forms/widgets.py
+++ b/cms/forms/widgets.py
@@ -3,7 +3,10 @@ from cms.utils.compat import DJANGO_1_10
 from django.contrib.admin.templatetags.admin_static import static
 from django.contrib.auth import get_permission_codename
 from django.contrib.sites.models import Site
-from django.core.urlresolvers import NoReverseMatch, reverse_lazy
+try:
+    from django.urls import NoReverseMatch, reverse_lazy
+except ImportError:
+    from django.core.urlresolvers import NoReverseMatch, reverse_lazy
 from django.forms.widgets import Select, MultiWidget, TextInput
 from django.utils.encoding import force_text
 from django.utils.html import escape, escapejs

--- a/cms/middleware/toolbar.py
+++ b/cms/middleware/toolbar.py
@@ -5,7 +5,10 @@ Edit Toolbar middleware
 from django import forms
 from django.contrib.admin.models import LogEntry, ADDITION, CHANGE
 from django.core.exceptions import ValidationError
-from django.core.urlresolvers import resolve
+try:
+    from django.urls import resolve
+except ImportError:
+    from django.core.urlresolvers import resolve
 
 from cms.toolbar.toolbar import CMSToolbar
 from cms.toolbar.utils import get_toolbar_from_request

--- a/cms/middleware/toolbar.py
+++ b/cms/middleware/toolbar.py
@@ -73,7 +73,11 @@ class ToolbarMiddleware(MiddlewareMixin):
             request.session['cms_toolbar_disabled'] = False
 
         toolbar_enabled = not request.session.get('cms_toolbar_disabled', False)
-        can_see_toolbar = request.user.is_staff or (anonymous_on and request.user.is_anonymous())
+        try:
+            is_anonymous = request.user.is_anonymous() # Django<1.10
+        except TypeError:
+            is_anonymous = request.user.is_anonymous # Django 1.10 - 2.x
+        can_see_toolbar = request.user.is_staff or (anonymous_on and is_anonymous)
         show_toolbar = (toolbar_enabled and can_see_toolbar)
 
         if edit_enabled and show_toolbar and not request.session.get('cms_edit'):

--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -6,7 +6,10 @@ from logging import getLogger
 from os.path import join
 
 from django.contrib.sites.models import Site
-from django.core.urlresolvers import reverse
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse
 from django.db import models
 from django.db.models.functions import Concat
 from django.utils.encoding import force_text, python_2_unicode_compatible

--- a/cms/models/placeholdermodel.py
+++ b/cms/models/placeholdermodel.py
@@ -9,8 +9,11 @@ from django.db import models
 from django.template.defaultfilters import title
 from django.utils import six
 from django.utils.encoding import python_2_unicode_compatible
-from django.utils.translation import ugettext_lazy as _, force_text
-
+try:
+    from django.utils.encoding import force_text
+except ImportError:
+    from django.utils.translation import force_text
+from django.utils.translation import ugettext_lazy as _
 from cms.cache.placeholder import clear_placeholder_cache
 from cms.exceptions import LanguageError
 from cms.utils import get_site_id

--- a/cms/models/pluginmodel.py
+++ b/cms/models/pluginmodel.py
@@ -6,7 +6,11 @@ import os
 import warnings
 
 from django.conf import settings
-from django.core.urlresolvers import NoReverseMatch
+try:
+    from django.urls import NoReverseMatch
+except ImportError:
+    from django.core.urlresolvers import NoReverseMatch
+
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 from django.db.models import signals, Model, ManyToManyField

--- a/cms/models/pluginmodel.py
+++ b/cms/models/pluginmodel.py
@@ -148,6 +148,7 @@ class PluginModelBase(ModelBase):
                     related_name='%(app_label)s_%(class)s',
                     auto_created=True,
                     parent_link=True,
+                    on_delete=models.CASCADE,
                 )
 
         # create a new class (using the super-metaclass)

--- a/cms/page_rendering.py
+++ b/cms/page_rendering.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 from django.conf import settings
-from django.core.urlresolvers import resolve, Resolver404, reverse
+try:
+    from django.urls import resolve, Resolver404, reverse
+except ImportError:
+    from django.core.urlresolvers import resolve, Resolver404, reverse
 from django.http import Http404
 from django.shortcuts import render
 from django.template.response import TemplateResponse

--- a/cms/signals/apphook.py
+++ b/cms/signals/apphook.py
@@ -2,7 +2,10 @@
 import logging
 import sys
 from django.core.management import color_style
-from django.core.urlresolvers import clear_url_caches
+try:
+    from django.urls import clear_url_caches
+except ImportError:
+    from django.core.urlresolvers import clear_url_caches
 from django.core.signals import request_finished
 from cms.utils.apphook_reload import mark_urlconf_as_changed
 

--- a/cms/signals/permissions.py
+++ b/cms/signals/permissions.py
@@ -15,7 +15,11 @@ def post_save_user(instance, raw, created, **kwargs):
     from cms.utils.permissions import get_current_user
     # read current user from thread locals
     creator = get_current_user()
-    if not creator or not created or creator.is_anonymous():
+    try:
+        is_anonymous = request.user.is_anonymous() # Django<1.10
+    except TypeError:
+        is_anonymous = request.user.is_anonymous # Django 1.10 - 2.x
+    if not creator or not created or is_anonymous:
         return
 
     page_user = PageUser(user_ptr_id=instance.pk, created_by=creator)

--- a/cms/templatetags/cms_tags.py
+++ b/cms/templatetags/cms_tags.py
@@ -7,7 +7,10 @@ from django import template
 from django.conf import settings
 from django.contrib.sites.models import Site
 from django.core.mail import mail_managers
-from django.core.urlresolvers import reverse
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse
 from django.db.models import Model
 from django.middleware.common import BrokenLinkEmailsMiddleware
 from django.template.loader import render_to_string

--- a/cms/test_utils/project/extensionapp/cms_toolbars.py
+++ b/cms/test_utils/project/extensionapp/cms_toolbars.py
@@ -3,7 +3,10 @@ from cms.api import get_page_draft
 from cms.test_utils.project.extensionapp.models import MyTitleExtension, MyPageExtension
 from cms.utils.page_permissions import user_can_change_page
 from cms.utils.urlutils import admin_reverse
-from django.core.urlresolvers import NoReverseMatch
+try:
+    from django.urls import NoReverseMatch
+except ImportError:
+    from django.core.urlresolvers import NoReverseMatch
 from django.utils.translation import ugettext_lazy as _
 
 from cms.toolbar_pool import toolbar_pool

--- a/cms/test_utils/project/placeholderapp/models.py
+++ b/cms/test_utils/project/placeholderapp/models.py
@@ -1,4 +1,7 @@
-from django.core.urlresolvers import reverse
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
 

--- a/cms/test_utils/project/sampleapp/cms_apps.py
+++ b/cms/test_utils/project/sampleapp/cms_apps.py
@@ -1,6 +1,9 @@
 from django.conf.urls import url
 from django.core.exceptions import ObjectDoesNotExist
-from django.core.urlresolvers import reverse
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse
 from django.http import HttpResponse
 from django.utils.translation import ugettext_lazy as _
 

--- a/cms/test_utils/project/sampleapp/cms_menus.py
+++ b/cms/test_utils/project/sampleapp/cms_menus.py
@@ -1,6 +1,9 @@
 from cms.menu_bases import CMSAttachMenu
 from cms.test_utils.project.sampleapp.models import Category
-from django.core.urlresolvers import reverse, NoReverseMatch
+try:
+    from django.urls import reverse, NoReverseMatch
+except ImportError:
+    from django.core.urlresolvers import reverse, NoReverseMatch
 from django.utils.translation import ugettext_lazy as _
 from menus.base import Menu, NavigationNode
 from menus.menu_pool import menu_pool

--- a/cms/test_utils/project/sampleapp/models.py
+++ b/cms/test_utils/project/sampleapp/models.py
@@ -1,5 +1,8 @@
 from cms.models.fields import PlaceholderField
-from django.core.urlresolvers import reverse
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
 from treebeard.mp_tree import MP_Node

--- a/cms/test_utils/testcases.py
+++ b/cms/test_utils/testcases.py
@@ -9,7 +9,10 @@ from django.contrib.auth.models import AnonymousUser, Permission
 from django.contrib.sites.models import Site
 from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist
-from django.core.urlresolvers import reverse
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse
 from django.forms.models import model_to_dict
 from django.template import engines
 from django.template.context import Context

--- a/cms/tests/test_admin.py
+++ b/cms/tests/test_admin.py
@@ -10,7 +10,10 @@ from django.contrib.admin.sites import site
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
 from django.contrib.sites.models import Site
-from django.core.urlresolvers import reverse
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse
 from django.http import (Http404, HttpResponseBadRequest,
                          HttpResponseNotFound)
 from django.utils.encoding import force_text, smart_str

--- a/cms/tests/test_apphooks.py
+++ b/cms/tests/test_apphooks.py
@@ -7,7 +7,10 @@ from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.sites.models import Site
 from django.core.cache import cache
-from django.core.urlresolvers import clear_url_caches, reverse, resolve, NoReverseMatch
+try:
+    from django.urls import clear_url_caches, reverse, resolve, NoReverseMatch
+except ImportError:
+    from django.core.urlresolvers import clear_url_caches, reverse, resolve, NoReverseMatch
 from django.test.utils import override_settings
 from django.utils import six
 from django.utils.timezone import now

--- a/cms/tests/test_no_i18n.py
+++ b/cms/tests/test_no_i18n.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.core.urlresolvers import clear_url_caches
+try:
+    from django.urls import clear_url_caches
+except ImportError:
+    from django.core.urlresolvers import clear_url_caches
 from django.template import Template
 from django.test import RequestFactory
 from django.test.utils import override_settings

--- a/cms/tests/test_page.py
+++ b/cms/tests/test_page.py
@@ -9,7 +9,10 @@ from django.core.cache import cache
 from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
 from django.core.exceptions import ValidationError
-from django.core.urlresolvers import reverse
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse
 from django.http import HttpResponse, HttpResponseNotFound
 from django.utils.timezone import now as tz_now
 from django.utils.translation import override as force_language

--- a/cms/tests/test_page_admin.py
+++ b/cms/tests/test_page_admin.py
@@ -4,7 +4,10 @@ import json
 import sys
 
 from django.core.cache import cache
-from django.core.urlresolvers import clear_url_caches
+try:
+    from django.urls import clear_url_caches
+except ImportError:
+    from django.core.urlresolvers import clear_url_caches
 from django.contrib import admin
 from django.contrib.sites.models import Site
 from django.forms.models import model_to_dict

--- a/cms/tests/test_permmod.py
+++ b/cms/tests/test_permmod.py
@@ -6,7 +6,10 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser, Group, Permission
 from django.contrib.sites.models import Site
 from django.core.management import call_command
-from django.core.urlresolvers import reverse
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse
 from django.db.models import Q
 from django.test.client import RequestFactory
 from django.test.utils import override_settings

--- a/cms/tests/test_publisher.py
+++ b/cms/tests/test_publisher.py
@@ -5,7 +5,10 @@ from django.contrib.sites.models import Site
 from django.core.cache import cache
 from django.core.management.base import CommandError
 from django.core.management import call_command
-from django.core.urlresolvers import reverse
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse
 from django.utils.translation import override as force_language
 
 from cms.api import create_page, add_plugin, create_title

--- a/cms/tests/test_toolbar.py
+++ b/cms/tests/test_toolbar.py
@@ -9,7 +9,10 @@ from django.contrib import admin
 from django.contrib.admin.models import LogEntry, CHANGE
 from django.contrib.auth.models import AnonymousUser, Permission
 from django.contrib.contenttypes.models import ContentType
-from django.core.urlresolvers import reverse
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse
 from django.template.defaultfilters import truncatewords
 from django.test import TestCase
 from django.test.client import RequestFactory

--- a/cms/tests/test_views.py
+++ b/cms/tests/test_views.py
@@ -4,7 +4,10 @@ import sys
 from django.core.cache import cache
 from django.conf import settings
 from django.contrib.auth.models import Permission
-from django.core.urlresolvers import clear_url_caches
+try:
+    from django.urls import clear_url_caches
+except ImportError:
+    from django.core.urlresolvers import clear_url_caches
 from django.http import Http404
 from django.template import Variable
 from django.test.utils import override_settings

--- a/cms/tests/test_wizards.py
+++ b/cms/tests/test_wizards.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 
 from django import forms
-from django.core.urlresolvers import reverse
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse
 from django.core.exceptions import ImproperlyConfigured
 from django.forms.models import ModelForm
 from django.template import TemplateSyntaxError

--- a/cms/toolbar/toolbar.py
+++ b/cms/toolbar/toolbar.py
@@ -21,7 +21,10 @@ from cms.utils.i18n import get_site_language_from_request
 from classytags.utils import flatten_context
 
 from django.conf import settings
-from django.core.urlresolvers import resolve, Resolver404
+try:
+    from django.urls import resolve, Resolver404
+except ImportError:
+    from django.core.urlresolvers import resolve, Resolver404
 from django.middleware.csrf import get_token
 from django.template.loader import render_to_string
 from django.utils.functional import cached_property

--- a/cms/utils/apphook_reload.py
+++ b/cms/utils/apphook_reload.py
@@ -8,7 +8,10 @@ import uuid
 from threading import local
 
 from django.conf import settings
-from django.core.urlresolvers import reverse, clear_url_caches
+try:
+    from django.urls import reverse, clear_url_caches
+except ImportError:
+    from django.core.urlresolvers import reverse, clear_url_caches
 
 # Py2 and Py3 compatible reload
 from imp import reload

--- a/cms/utils/helpers.py
+++ b/cms/utils/helpers.py
@@ -2,7 +2,10 @@
 import re
 
 from django.utils.timezone import get_current_timezone_name
-from django.utils.translation import force_text
+try:
+    from django.utils.encoding import force_text
+except ImportError:
+    from django.utils.translation import force_text
 
 
 def find_placeholder_relation(obj):

--- a/cms/utils/i18n.py
+++ b/cms/utils/i18n.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 from contextlib import contextmanager
 
-from django.core.urlresolvers import get_resolver, LocaleRegexURLResolver
+try:
+    from django.urls import get_resolver, LocaleRegexURLResolver
+except ImportError:
+    from django.core.urlresolvers import get_resolver, LocaleRegexURLResolver
 from django.conf import settings
 from django.utils import translation
 from django.utils.translation import ugettext_lazy as _

--- a/cms/utils/i18n.py
+++ b/cms/utils/i18n.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 from contextlib import contextmanager
 
+from django import VERSION as DJANGO_VERSION
 try:
-    from django.urls import get_resolver, LocaleRegexURLResolver
+    from django.urls import get_resolver, LocalePrefixPattern
 except ImportError:
     from django.core.urlresolvers import get_resolver, LocaleRegexURLResolver
 from django.conf import settings
@@ -200,8 +201,11 @@ def is_language_prefix_patterns_used():
     Returns `True` if the `LocaleRegexURLResolver` is used
     at root level of the urlpatterns, else it returns `False`.
     """
-    return any(isinstance(url_pattern, LocaleRegexURLResolver)
-               for url_pattern in get_resolver(None).url_patterns)
+    if DJANGO_VERSION < (2,0):
+        return any(isinstance(url_pattern, LocaleRegexURLResolver)
+               for url_pattern in get_resolver(None).url_patterns)    
+    return any(isinstance(url_pattern.pattern, LocalePrefixPattern)
+           for url_pattern in get_resolver(None).url_patterns)
 
 
 def is_valid_site_language(language, site_id):

--- a/cms/utils/moderator.py
+++ b/cms/utils/moderator.py
@@ -2,7 +2,11 @@
 
 
 def use_draft(request):
-    is_staff = (request.user.is_authenticated() and request.user.is_staff)
+    try:
+        is_authenticated = request.user.is_authenticated() # Django<1.10
+    except TypeError:
+        is_authenticated = request.user.is_authenticated # Django 1.10 - 2.x
+    is_staff = (is_authenticated and request.user.is_staff)
     return is_staff and not request.session.get('cms_preview')
 
 

--- a/cms/utils/page.py
+++ b/cms/utils/page.py
@@ -2,7 +2,10 @@
 from __future__ import unicode_literals
 import re
 
-from django.core.urlresolvers import reverse
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse
 from django.db.models import Q
 from django.utils import timezone
 from django.utils.encoding import force_text

--- a/cms/utils/page_permissions.py
+++ b/cms/utils/page_permissions.py
@@ -78,7 +78,7 @@ def auth_permission_required(action):
     def decorator(func):
         @wraps(func, assigned=available_attrs(func))
         def wrapper(user, *args, **kwargs):
-            if not user.is_authenticated():
+            if not user.is_authenticated:
                 return False
 
             permissions = _django_permissions_by_action[action]
@@ -292,7 +292,7 @@ def user_can_view_page(user, page, site=None):
         # Page has no restrictions and project is configured
         # to allow everyone to see unrestricted pages.
         return True
-    elif not user.is_authenticated():
+    elif not user.is_authenticated:
         # Page has restrictions or project is configured
         # to require staff user status to see pages.
         return False
@@ -357,7 +357,7 @@ def user_can_view_all_pages(user, site):
         can_see_unrestricted = public_for == 'all' or (public_for == 'staff' and user.is_staff)
         return can_see_unrestricted
 
-    if not user.is_authenticated():
+    if not user.is_authenticated:
         return False
 
     if user.has_perm(PAGE_VIEW_CODENAME):

--- a/cms/utils/urlutils.py
+++ b/cms/utils/urlutils.py
@@ -2,7 +2,10 @@
 import re
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse
 from django.utils.encoding import force_text
 from django.utils.http import urlencode
 from django.utils.six.moves.urllib.parse import urlparse

--- a/cms/views.py
+++ b/cms/views.py
@@ -3,7 +3,10 @@
 from django.conf import settings
 from django.contrib.auth import login as auth_login, REDIRECT_FIELD_NAME
 from django.contrib.auth.views import redirect_to_login
-from django.core.urlresolvers import reverse
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect, HttpResponse
 from django.utils.cache import patch_cache_control
 from django.utils.http import is_safe_url, urlquote

--- a/cms/views.py
+++ b/cms/views.py
@@ -44,11 +44,15 @@ def details(request, slug):
     page.
     """
     response_timestamp = now()
+    try:
+        is_authenticated = request.user.is_authenticated() # Django<1.10
+    except TypeError:
+        is_authenticated = request.user.is_authenticated # Django 1.10 - 2.x
     if get_cms_setting("PAGE_CACHE") and (
         not hasattr(request, 'toolbar') or (
             not request.toolbar.edit_mode_active and
             not request.toolbar.show_toolbar and
-            not request.user.is_authenticated()
+            not is_authenticated
         )
     ):
         cache_content = get_page_cache(request)
@@ -159,7 +163,11 @@ def details(request, slug):
             return HttpResponseRedirect(redirect_url)
 
     # permission checks
-    if page.login_required and not request.user.is_authenticated():
+    try:
+        is_authenticated = request.user.is_authenticated() # Django<1.10
+    except TypeError:
+        is_authenticated = request.user.is_authenticated # Django 1.10 - 2.x
+    if page.login_required and not is_authenticated:
         return redirect_to_login(urlquote(request.get_full_path()), settings.LOGIN_URL)
 
     if hasattr(request, 'toolbar'):
@@ -179,7 +187,11 @@ def login(request):
     if not is_safe_url(url=redirect_to, host=request.get_host()):
         redirect_to = reverse("pages-root")
 
-    if request.user.is_authenticated():
+    try:
+        is_authenticated = request.user.is_authenticated() # Django<1.10
+    except TypeError:
+        is_authenticated = request.user.is_authenticated # Django 1.10 - 2.x
+    if is_authenticated:
         return HttpResponseRedirect(redirect_to)
 
     form = CMSToolbarLoginForm(request=request, data=request.POST)

--- a/cms/wizards/views.py
+++ b/cms/wizards/views.py
@@ -6,7 +6,10 @@ from django.forms import Form
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.core.files.storage import FileSystemStorage
-from django.core.urlresolvers import NoReverseMatch
+try:
+    from django.urls import NoReverseMatch
+except ImportError:
+    from django.core.urlresolvers import NoReverseMatch
 from django.template.response import SimpleTemplateResponse
 
 from formtools.wizard.views import SessionWizardView

--- a/cms/wizards/wizard_base.py
+++ b/cms/wizards/wizard_base.py
@@ -7,9 +7,12 @@ from django.forms.models import ModelForm
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.functional import cached_property
 
+try:
+    from django.utils.encoding import force_text
+except ImportError:
+    from django.utils.translation import force_text
 from django.utils.translation import (
     override as force_language,
-    force_text,
     ugettext as _
 )
 

--- a/docs/how_to/extending_page_title.rst
+++ b/docs/how_to/extending_page_title.rst
@@ -351,7 +351,10 @@ low-level API to edit the toolbar according to your needs::
     from cms.toolbar_base import CMSToolbar
     from cms.utils import get_cms_setting
     from cms.utils.page_permissions import user_can_change_page
-    from django.core.urlresolvers import reverse, NoReverseMatch
+    try:
+        from django.urls import reverse, NoReverseMatch
+    except ImportError:
+        from django.core.urlresolvers import reverse, NoReverseMatch
     from django.utils.translation import ugettext_lazy as _
     from .models import IconExtension
 

--- a/docs/how_to/toolbar.rst
+++ b/docs/how_to/toolbar.rst
@@ -109,7 +109,10 @@ items survive upgrades.
 Following our :doc:`/introduction/toolbar`, let's add the poll app
 to the toolbar::
 
-    from django.core.urlresolvers import reverse
+    try:
+        from django.urls import reverse
+    except ImportError:
+        from django.core.urlresolvers import reverse
     from django.utils.translation import ugettext_lazy as _
     from cms.toolbar_pool import toolbar_pool
     from cms.toolbar_base import CMSToolbar
@@ -131,7 +134,10 @@ To do this, you can use positional insertion coupled with the fact that
 menus::
 
 
-    from django.core.urlresolvers import reverse
+    try:
+        from django.urls import reverse
+    except ImportError:
+        from django.core.urlresolvers import reverse
     from django.utils.translation import ugettext_lazy as _
     from cms.toolbar_pool import toolbar_pool
     from cms.toolbar.items import Break
@@ -191,7 +197,10 @@ when they come from multiple applications.
 An example is shown here for an 'Offices' app, which allows handy access to
 certain admin functions for managing office locations in a project::
 
-    from django.core.urlresolvers import reverse
+    try:
+        from django.urls import reverse
+    except ImportError:
+        from django.core.urlresolvers import reverse
     from django.utils.translation import ugettext_lazy as _
     from cms.toolbar_base import CMSToolbar
     from cms.toolbar_pool import toolbar_pool
@@ -279,7 +288,10 @@ Another way to add items to the toolbar is through our own views (``polls/views.
 This method can be useful if you need to access certain variables, in our case e.g. the
 selected poll and its sub-methods::
 
-    from django.core.urlresolvers import reverse
+    try:
+        from django.urls import reverse
+    except ImportError:
+        from django.core.urlresolvers import reverse
     from django.shortcuts import get_object_or_404, render
     from django.utils.translation import ugettext_lazy as _
 

--- a/docs/introduction/menu.rst
+++ b/docs/introduction/menu.rst
@@ -21,7 +21,10 @@ For this we need a file called ``cms_menus.py`` in our application. Add ``cms_me
 
 .. code-block:: python
 
-    from django.core.urlresolvers import reverse
+    try:
+        from django.urls import reverse
+    except ImportError:
+        from django.core.urlresolvers import reverse
     from django.utils.translation import ugettext_lazy as _
 
     from cms.menu_bases import CMSAttachMenu

--- a/menus/menu_pool.py
+++ b/menus/menu_pool.py
@@ -115,7 +115,11 @@ class MenuRenderer(object):
 
         key = '%smenu_nodes_%s_%s' % (prefix, self.request_language, self.site.pk)
 
-        if self.request.user.is_authenticated():
+        try:
+            is_authenticated = self.request.user.is_authenticated() # Django<1.10
+        except TypeError:
+            is_authenticated = self.request.user.is_authenticated # Django 1.10 - 2.x
+        if is_authenticated:
             key += '_%s_user' % self.request.user.pk
 
         if self.draft_mode_active:

--- a/menus/menu_pool.py
+++ b/menus/menu_pool.py
@@ -6,7 +6,10 @@ from django.contrib import messages
 from django.contrib.sites.models import Site
 from django.core.cache import cache
 from django.core.exceptions import ValidationError
-from django.core.urlresolvers import NoReverseMatch
+try:
+    from django.urls import NoReverseMatch
+except ImportError:
+    from django.core.urlresolvers import NoReverseMatch
 from django.utils.functional import cached_property
 from django.utils.module_loading import autodiscover_modules
 from django.utils.translation import get_language_from_request, ugettext_lazy as _

--- a/menus/modifiers.py
+++ b/menus/modifiers.py
@@ -92,11 +92,15 @@ class AuthVisibility(Modifier):
         if post_cut or breadcrumb:
             return nodes
         final = []
+        try:
+            is_authenticated = request.user.is_authenticated() # Django<1.10
+        except TypeError:
+            is_authenticated = request.user.is_authenticated # Django 1.10 - 2.x
         for node in nodes:
             if (node.attr.get('visible_for_authenticated', True) and \
-                 request.user.is_authenticated()) or \
+                 is_authenticated) or \
                 (node.attr.get('visible_for_anonymous', True) and \
-                 not request.user.is_authenticated()):
+                 not request.user.is_authenticated):
                 final.append(node)
             else:
                 if node.parent and node in node.parent.children:

--- a/menus/templatetags/menu_tags.py
+++ b/menus/templatetags/menu_tags.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 from django import template
 from django.contrib.sites.models import Site
-from django.core.urlresolvers import reverse, NoReverseMatch
+try:
+    from django.urls import reverse, NoReverseMatch
+except ImportError:
+    from django.core.urlresolvers import reverse, NoReverseMatch
 from django.utils.encoding import force_text
 from django.utils.six.moves.urllib.parse import unquote
 from django.utils.translation import get_language, ugettext

--- a/menus/utils.py
+++ b/menus/utils.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 from django.conf import settings
-from django.core.urlresolvers import NoReverseMatch, reverse, resolve
+try:
+    from django.urls import NoReverseMatch, reverse, resolve
+except ImportError:
+    from django.core.urlresolvers import NoReverseMatch, reverse, resolve
 
 from cms.utils import get_current_site, get_language_from_request
 from cms.utils.i18n import (

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ CLASSIFIERS = [
 ]
 
 INSTALL_REQUIREMENTS = [
-    'Django>=1.8,<2.0',
+    'Django>=1.8',
     'django-classy-tags>=0.7.2',
     'django-formtools>=1.0',
     'django-treebeard>=4.0.1',


### PR DESCRIPTION
### Summary

Squashing some incompatibilities between Django 1.11 and 2.0 with some try/except shims. I have knocked out basic errors on django-cms, django-filer, and many plugins that raise exceptions when trying to run django-cms 3.5.0 on Django 2.0.2.  I sent separate pull requests to those repos.  Should be backwards compatible with Django versions <2.0.  My test site ran fine on Django 1.10 and 1.11 with these changes.  Many basic features worked ok on Django 2.0, but there is much work to be done still.  I just wanted to help get a jump start on this to speed the transition.

If django-cms 3.6.x will drop support for Django < 1.11, then a few of these shims might not be necessary.  Most deal with breaking differences between 1.11 and 2.0, though.  Maybe this should get pulled to czpython:future/3.6.x referenced in #6279 .

Fixes #

* Added on_delete=models.CASCADE on all model foreign key fields and in all older migrations.
* Shimmed module naming and location inconsistencies between Django<=1.11 and 2.0.
* Attempted some shims on some Django API changes in 2.0.


### Remaining Issues

* Order of form media javascript files is different on plugin admin forms rendered by Django 2.0.  This causes problems with jQuery not being loaded before plugins.  This needs to be addressed in django-cms, djangocms-??? plugins that use filer, and possibly django-filer itself.  For example, adding image plugins (or file, folder, etc) does not work, but adding text and link plugins works as expected.
* I'm sure many many more things that need to get resolved as part of a bigger push for Django 2.0 compatibility.