### PR TITLE
Fixed #6289 -- Don't fail silently on templates with variable extends

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,8 @@
   before toolbar.
 * Fixed a bug where CMS would incorrectly highlight plugin content when plugin
   contains invisible elements
+* Fixed a regression where templates which inherit from a template using an ``{% extends %}``
+  tag with a default would raise an exception.
 
 
 === 3.5.0 (2018-01-31) ===

--- a/cms/test_utils/project/templates/placeholder_tests/test_inherit_from_variable_extends.html
+++ b/cms/test_utils/project/templates/placeholder_tests/test_inherit_from_variable_extends.html
@@ -1,0 +1,1 @@
+{% extends "placeholder_tests/test_variable_extends.html" %}

--- a/cms/test_utils/project/templates/placeholder_tests/test_variable_extends.html
+++ b/cms/test_utils/project/templates/placeholder_tests/test_variable_extends.html
@@ -1,0 +1,3 @@
+{% extends TEMPLATE|default:"placeholder_tests/base.html" %}
+{% load cms_tags %}
+{% block four %}{% placeholder "four" %}{% endblock %}

--- a/cms/tests/test_placeholder.py
+++ b/cms/tests/test_placeholder.py
@@ -65,6 +65,14 @@ class PlaceholderTestCase(TransactionCMSTestCase, UnittestCompatMixin):
         placeholders = _get_placeholder_slots('placeholder_tests/test_one.html')
         self.assertEqual(sorted(placeholders), sorted([u'new_one', u'two', u'three']))
 
+    def test_placeholder_scanning_variable_extend(self):
+        placeholders = _get_placeholder_slots('placeholder_tests/test_variable_extends.html')
+        self.assertEqual(placeholders, [u'one', u'two', u'three', u'four'])
+
+    def test_placeholder_scanning_inherit_from_variable_extend(self):
+        placeholders = _get_placeholder_slots('placeholder_tests/test_inherit_from_variable_extends.html')
+        self.assertEqual(placeholders, [u'one', u'two', u'three', u'four'])
+
     def test_placeholder_scanning_sekizai_extend(self):
         placeholders = _get_placeholder_slots('placeholder_tests/test_one_sekizai.html')
         self.assertEqual(sorted(placeholders), sorted([u'new_one', u'two', u'three']))

--- a/cms/utils/placeholder.py
+++ b/cms/utils/placeholder.py
@@ -12,7 +12,7 @@ from django.template.loader import get_template
 from django.template.loader_tags import BlockNode, ExtendsNode, IncludeNode
 from django.utils import six
 
-from sekizai.helpers import get_varname, is_variable_extend_node
+from sekizai.helpers import get_varname
 
 from cms.exceptions import DuplicatePlaceholderWarning
 from cms.utils.conf import get_cms_setting
@@ -279,10 +279,6 @@ def get_static_placeholders(template, context):
 
 
 def _get_block_nodes(extend_node):
-    # we don't support variable extensions
-    if is_variable_extend_node(extend_node):
-        return []
-
     parent = extend_node.get_parent(get_context())
     parent_nodelist = _get_nodelist(parent)
     parent_nodes = parent_nodelist.get_nodes_by_type(BlockNode)
@@ -315,10 +311,6 @@ def _get_placeholder_nodes_from_extend(extend_node, node_class):
     Returns a list of placeholders found in the parent template(s) of this
     ExtendsNode
     """
-    # we don't support variable extensions
-    if is_variable_extend_node(extend_node):
-        return []
-
     # This is a dictionary mapping all BlockNode instances found
     # in the template that contains the {% extends %} tag
     block_nodes = _get_block_nodes(extend_node)


### PR DESCRIPTION
Fixed #6289

This fixes the regression raised when using an extends node with a variable and default.
Note that using a variable alone like `{% extends SOMETHING %}` is still not supported as per https://github.com/divio/django-cms/issues/1847 and will raise a `SyntaxError`.

The only supported cases are:

`{% extends "explicit.html" %}` or `{% extends SOMETHING|default:"explicit.html" %}`.

On that last case, is important to note that it can lead to unexpected results because when the cms scans it, it will **always** default to `explicit.html` but when the page is rendered and the correct context is passed, then the template might use `SOMETHING`, while the structure placeholders come from `explicit.html`.

Ideally we should raise a warning or prevent these templates all-together.