### PR TITLE
Fixed a bug due to incorrect localization in toolbar JS

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,7 @@
 === 3.5.1 (unreleased) ===
 
+* Fixed a bug where editing pages with primary keys greater than 9999 would throw an
+  exception.
 * Fixed a ``MultipleObjectsReturned`` exception raised on the page types migration
   with multiple page types per site.
 * Fixed a bug which prevented toolbar js from working correctly when rendered

--- a/cms/templates/cms/toolbar/toolbar_javascript.html
+++ b/cms/templates/cms/toolbar/toolbar_javascript.html
@@ -18,8 +18,8 @@ CMS.config = {
     'request': {
         'language': '{{ cms_toolbar.language }}',
         'model': '{{ cms_toolbar.get_object_model }}',
-        'page_id': '{% if request.current_page.publisher_is_draft %}{{ request.current_page.pk }}{% else %}{{ request.current_page.publisher_public_id }}{% endif %}',
-        'pk': '{{ cms_toolbar.get_object_pk }}',
+        'page_id': '{% if request.current_page.publisher_is_draft %}{{ request.current_page.pk|unlocalize }}{% else %}{{ request.current_page.publisher_public_id|unlocalize }}{% endif %}',
+        'pk': '{{ cms_toolbar.get_object_pk|unlocalize }}',
         'url': '{% language cms_toolbar.language %}{% cms_admin_url "cms_page_resolve" %}{% endlanguage %}',
         'toolbar': '{% language cms_toolbar.language %}{% cms_admin_url "cms_usersettings_get_toolbar" %}{% endlanguage %}'
     },


### PR DESCRIPTION
Fixed https://github.com/divio/django-cms/issues/6296
When editing a page with a pk > 9999 and having `USE_THOUSAND_SEPARATOR = True` in my settings, `ValueError` is thrown. This change fixes the issue for me.

Note: I did not read through the code to check if there are more instances where values should be unlocalized. It seems like a good idea to do that. Maybe it would be even better to turn off localization in some templates and explicitly localize values instead.