### PR TITLE
Fixed #6302 -- Copy the __qualname__ attribute on the cms_perms decorator

### DIFF
--- a/cms/utils/decorators.py
+++ b/cms/utils/decorators.py
@@ -23,6 +23,11 @@ def cms_perms(func):
     elif hasattr(func, '__class__'):
         inner.__name__ = func.__class__.__name__
 
+    if hasattr(func, '__qualname__'):
+        inner.__qualname__ = func.__qualname__
+    elif hasattr(func, '__class__') and hasattr(func.__class__, '__qualname__'):
+        inner.__qualname__ = func.__class__.__qualname__
+
     if getattr(func, 'csrf_exempt', False):
         # view has set csrf_exempt flag
         # so pass it down to the decorator.


### PR DESCRIPTION
#6302 Copy the `__qualname__` attribute from the wrapped view function to the wrapping function. This seems sensible as tools like django.contrib.admindocs require this attribute to be set correctly.

### Summary

Makes code documentation of CMSApp views available in admindocs (for Python 3.3+) which accesses the this attribute in order to import the view and retrieve its doc string. 

### Proposed changes in this pull request
Copy the `__qualname__` attribute from the wrapped view function. Use the view function's class as a fallback source. This covers function based views, class based views (that are included via their `as_view` method) as well as view classes that implement `__call__`. The proposed changes should be fairly harmless as they do not tamper with any attribute that was used before by cms code.