### PR TITLE
Fixed a bug where non-staff user would be able to open empty structureboard

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,7 @@
   opened with blank page
 * Fixed a bug where the direct children of the homepage would get a leading ``/``
   character when the homepage was moved or published.
+* Fixed a bug where non-staff user would be able to open empty structure board
 
 
 === 3.5.1 (2018-03-05) ===

--- a/cms/templates/cms/toolbar/toolbar_javascript.html
+++ b/cms/templates/cms/toolbar/toolbar_javascript.html
@@ -112,7 +112,7 @@ CMS.config = {
     'settings': {
         'version': '{{ cms_version }}',
         'toolbar': 'expanded',
-        'mode': {% if cms_toolbar.content_mode_active %}'edit'{% else %}'structure'{% endif %},
+        'mode': {% if cms_toolbar.structure_mode_active %}'structure'{% else %}'edit'{% endif %},
         'sideframe': { 'url': '' },
         'states': [],
         'edit': '{{ cms_edit_on }}',

--- a/cms/tests/frontend/integration/nonadmin.js
+++ b/cms/tests/frontend/integration/nonadmin.js
@@ -1,0 +1,87 @@
+'use strict';
+
+var helpers = require('djangocms-casper-helpers');
+var globals = helpers.settings;
+var casperjs = require('casper');
+var xPath = casperjs.selectXPath;
+var cms = helpers(casperjs);
+
+casper.test.setUp(function(done) {
+    casper
+        .start()
+        .then(cms.login())
+        .then(cms.addPage({ title: 'Home page' }))
+        .then(
+            cms.addPlugin({
+                type: 'TextPlugin',
+                content: {
+                    id_body: 'Random text'
+                }
+            })
+        )
+        .then(cms.publishPage({ page: 'Home page', language: 'en' }))
+        .run(done);
+});
+
+casper.test.tearDown(function(done) {
+    casper.start().then(cms.login()).then(cms.removePage()).then(cms.logout()).run(done);
+});
+
+casper.test.begin('Non admin user cannot open structureboard', function(test) {
+    casper
+        .start()
+        .then(cms.logout())
+        .then(
+            cms.login({
+                username: 'normal',
+                password: 'normal'
+            })
+        )
+        .thenOpen(globals.editUrl)
+        .waitForSelector('.cms-ready', function() {
+            this.mouse.doubleclick(
+                // pick a div with class cms-plugin that has a p that has text "Random text"
+                xPath('//*[contains(@class, "cms-plugin")][contains(text(), "Random text")]')
+            );
+        })
+        .waitUntilVisible('.cms-modal-open')
+        .withFrame(0, function() {
+            casper.waitUntilVisible('body', function() {
+                test.assertSelectorHasText('body', 'You do not have permission to edit this plugin');
+            });
+        })
+        .then(function() {
+            this.click('.cms-modal-open .cms-modal-item-buttons:last-child > a');
+        })
+        .waitWhileVisible('.cms-modal-iframe')
+        .then(function() {
+            // normally nothing happens on click, but we are making sure there are no regressions
+            this.mouse.click(
+                // pick a div with class cms-plugin that has a p that has text "Random text"
+                xPath('//*[contains(@class, "cms-plugin")][contains(text(), "Random text")]')
+            );
+        })
+        .then(function() {
+            test.assertSelectorDoesntHaveText('.cms-structure', 'Placeholder_Content_1');
+        })
+        .then(function() {
+            this.evaluate(function() {
+                CMS.$(document).data('expandmode', true);
+            });
+            // normally nothing happens on click, but we are making sure there are no regressions
+            this.mouse.click(
+                // pick a div with class cms-plugin that has a p that has text "Random text"
+                xPath('//*[contains(@class, "cms-plugin")][contains(text(), "Random text")]')
+            );
+        })
+        .then(function() {
+            test.assertSelectorDoesntHaveText('.cms-structure', 'Placeholder_Content_1');
+        })
+        .wait(3000, function() {
+            test.assertSelectorDoesntHaveText('.cms-structure', 'Placeholder_Content_1');
+        })
+        .then(cms.logout())
+        .run(function() {
+            test.done();
+        });
+});

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -99,7 +99,8 @@ var INTEGRATION_TESTS = [
         'dragndrop',
         'copy-apphook-page',
         // 'revertLive', // disabled
-        'narrowScreen'
+        'narrowScreen',
+        'nonadmin'
     ]
 ];
 

--- a/testserver.py
+++ b/testserver.py
@@ -152,7 +152,11 @@ else:
 
 def _helper_patch(*args, **kwargs):
     from django.core.management import call_command
+    from djangocms_helper import utils
+
     call_command('migrate', run_syncdb=True)
+    utils.create_user('normal', 'normal@normal.normal', 'normal', is_staff=True, base_cms_permissions=True,
+            permissions=['view_page'])
 
 
 def run():


### PR DESCRIPTION
`content_mode_active` is only active when the user is staff: https://github.com/divio/django-cms/blob/52d31944afbda90dc5281b5a2ae7e99f2e2a931b/cms/toolbar/toolbar.py#L102

the js expects that whenever user is in edit mode CMS.settings.mode to be `edit` and not `structure` as it was before.