### PR TITLE
Use add-another CSS class in app config select

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,8 @@
 * Fixed a bug where the direct children of the homepage would get a leading ``/``
   character when the homepage was moved or published.
 * Fixed a bug where non-staff user would be able to open empty structure board
+* Fixed a bug where a static file from Django admin was referenced that no
+  longer existed in Django 1.9 and up.
 
 
 === 3.5.1 (2018-03-05) ===

--- a/cms/forms/widgets.py
+++ b/cms/forms/widgets.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from cms.utils.compat import DJANGO_1_10
-from django.contrib.admin.templatetags.admin_static import static
 from django.contrib.auth import get_permission_codename
 from django.contrib.sites.models import Site
 from django.core.urlresolvers import NoReverseMatch, reverse_lazy
@@ -306,10 +305,9 @@ class ApplicationConfigSelect(Select):
             output.append(self._build_script(name, value, attrs))
 
             related_url = ''
-            output.append('<a href="%s" class="add-another" id="add_%s" onclick="return showAddAnotherPopup(this);"> '
-                          % (related_url, name))
-            output.append('<img src="%s" width="10" height="10" alt="%s"/></a>'
-                          % (static('admin/img/icon_addlink.gif'), _('Add Another')))
+            output.append('<a href="%s" class="add-another" id="add_%s" title="%s" onclick="return showAddAnotherPopup(this);">'
+                          % (related_url, name, _('Add Another')))
+            output.append('</a>')
             return mark_safe(''.join(output))
         else:
             return super(ApplicationConfigSelect, self).render(name, value, attrs, renderer)

--- a/cms/templates/cms/widgets/applicationconfigselect.html
+++ b/cms/templates/cms/widgets/applicationconfigselect.html
@@ -1,6 +1,4 @@
 {% load i18n static %}
 {% include 'django/forms/widgets/select.html' %}
 {{ widget.script_init|safe }}
-<a href="" class="add-another" id="add_{{ widget.name }}" onclick="return showAddAnotherPopup(this);"
-    ><img src="{% static 'admin/img/icon_addlink.gif' %}" width="10" height="10" alt="{% trans 'Add Another' %}"
-/></a>
+<a href="" class="add-another" id="add_{{ widget.name }}" onclick="return showAddAnotherPopup(this);" title="{% trans 'Add Another' %}"></a>


### PR DESCRIPTION
Remove direct use of static file `"admin/img/icon_addlink.gif"` and rely on CSS class `"add-another"` that is provided in Django 1.8 - 1.11 and  should render the correct icon.


### Summary

Fixes #6317 


### Proposed changes in this pull request


### Documentation checklist

* [x] I have updated CHANGELOG.txt if appropriate
* [ ] I have updated the release notes document if appropriate, with:
    * [ ] general notes
    * [ ] bug-fixes
    * [ ] improvements/new features
    * [ ] backwards-incompatible changes
    * [ ] required upgrade steps
    * [ ] names of contributors
* [ ] I have updated other documentation
* [ ] I have added my name to the AUTHORS file
* [ ] This PR's documentation has been approved by Daniele Procida
