### PR TITLE
Fix Issue 6345: Fixed a bug where creating a page via the cms.api.create_page ignores left/right positions

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -265,6 +265,7 @@ Contributors (based on gitlog, 497 unique authors):
 * Keryn Knight
 * Kevin Burton
 * Kevin Funk
+* Kevin Möllering
 * Kevin Richardson
 * Kim Thoenen
 * kochin

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,7 @@
+* Fixed a bug where creating a page via the cms.api.create_page ignores left/right
+  positions
+
+
 === 3.5.2 (2018-04-11) ===
 
 * Fixed a bug where shortcuts menu entry would stop working after toolbar reload

--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -1648,7 +1648,7 @@ class TreeNode(MP_Node):
             kwargs['instance'].parent_id = self.parent_id
         else:
             kwargs['parent_id'] = self.parent_id
-        return super(TreeNode, self).add_sibling(*args, **kwargs)
+        return super(TreeNode, self).add_sibling(*args, pos=pos, **kwargs)
 
     def update(self, **data):
         cls = self.__class__

--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -1648,7 +1648,7 @@ class TreeNode(MP_Node):
             kwargs['instance'].parent_id = self.parent_id
         else:
             kwargs['parent_id'] = self.parent_id
-        return super(TreeNode, self).add_sibling(*args, pos=pos, **kwargs)
+        return super(TreeNode, self).add_sibling(pos, *args, **kwargs)
 
     def update(self, **data):
         cls = self.__class__

--- a/cms/tests/test_page.py
+++ b/cms/tests/test_page.py
@@ -501,6 +501,16 @@ class PagesTestCase(TransactionCMSTestCase):
         # Now there should be "en", "de" and "fr" on the public page
         self.assertSequenceEqual(sorted(page.publisher_public.get_languages()), ['de', 'en', 'fr'])
 
+    def test_create_page_with_position_regression_6345(self):
+        # ref: https://github.com/divio/django-cms/issues/6345
+        parent = create_page("p", "nav_playground.html", "en")
+        rightmost = create_page("r", "nav_playground.html", "en",parent=parent)
+        leftmost = create_page("l", "nav_playground.html", "en",parent=rightmost, position="left")
+        create_page("m", "nav_playground.html", "en",parent=leftmost, position="right")
+        children_titles = list(p.get_title("de") for p in parent.get_child_pages())
+        self.assertEqual(children_titles, ["l","m","r"])
+
+
     def test_move_page_inherit(self):
         parent = create_page("Parent", 'col_three.html', "en")
         child = create_page("Child", constants.TEMPLATE_INHERITANCE_MAGIC,


### PR DESCRIPTION
### Summary
Fixes #6345
Fixed a bug where creating a page via the cms.api.create_page ignores left/right positions.
During the last refactor of the pagemodel add_sibling function the position parameter got lost.


### Proposed changes in this pull request
Forward the parameter to the page node again.

### Documentation checklist

* [x] I have updated CHANGELOG.txt if appropriate
* [x] I have updated the release notes document if appropriate, with:
    * [x] general notes
    * [x] bug-fixes
    * [x] improvements/new features
    * [x] backwards-incompatible changes
    * [x] required upgrade steps
    * [x] names of contributors
* [x] I have updated other documentation
* [x] I have added my name to the AUTHORS file
* [ ] This PR's documentation has been approved by Daniele Procida
