### PR TITLE
Fixed #6336 -- request.current_page should always respect draft/live state

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,9 @@
 
 * Fixed ``TreeNode.DoesNotExist`` exception raised when exporting
   and loading database contents via ``dumpdata`` and ``loaddata``.
+* Fixed a bug where ``request.current_page`` would always be the public page,
+  regardless of the toolbar status (draft / live). This only affected custom
+  urls from an apphook.
 
 
 === 3.5.2 (2018-04-11) ===

--- a/cms/appresolver.py
+++ b/cms/appresolver.py
@@ -15,6 +15,7 @@ from cms.models.pagemodel import Page
 from cms.utils import get_current_site
 from cms.utils.compat import DJANGO_1_8, DJANGO_1_9
 from cms.utils.i18n import get_language_list
+from cms.utils.moderator import use_draft
 
 APP_RESOLVERS = []
 
@@ -38,6 +39,9 @@ def applications_page_check(request, current_page=None, path=None):
     for lang in get_language_list():
         if path.startswith(lang + "/"):
             path = path[len(lang + "/"):]
+
+    use_public = not use_draft(request)
+
     for resolver in APP_RESOLVERS:
         try:
             page_id = resolver.resolve_page_id(path)
@@ -46,7 +50,7 @@ def applications_page_check(request, current_page=None, path=None):
             # If current page was matched, then we have some override for
             # content from cms, but keep current page. Otherwise return page
             # to which was application assigned.
-            return page
+            return page if use_public else page.publisher_public
         except Resolver404:
             # Raised if the page is not managed by an apphook
             pass

--- a/cms/test_utils/project/sampleapp/cms_apps.py
+++ b/cms/test_utils/project/sampleapp/cms_apps.py
@@ -11,6 +11,13 @@ from cms.apphook_pool import apphook_pool
 from .models import SampleAppConfig
 
 
+class AppWithNoMenu(CMSApp):
+    app_name = 'app_with_no_menu'
+
+    def get_urls(self, page=None, language=None, **kwargs):
+        return ["cms.test_utils.project.sampleapp.urls"]
+
+
 class SampleApp(CMSApp):
     name = _("Sample App")
     permissions = True


### PR DESCRIPTION
Backport https://github.com/divio/django-cms/pull/6350