### PR TITLE
Fixed #6336 -- request.current_page should always respect draft/live state

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,6 +3,9 @@
 * Removed extra quotation mark from the sideframe button template
 * Fixed a bug where xframe options were processed by clickjacking middleware
   when page was served from cache, rather then get this value from cache
+* Fixed a bug where ``request.current_page`` would always be the public page,
+  regardless of the toolbar status (draft / live). This only affected custom
+  urls from an apphook.
 
 
 === 3.4.6 (2018-03-26) ===

--- a/cms/appresolver.py
+++ b/cms/appresolver.py
@@ -15,6 +15,7 @@ from cms.apphook_pool import apphook_pool
 from cms.models.pagemodel import Page
 from cms.utils.compat import DJANGO_1_8, DJANGO_1_9
 from cms.utils.i18n import get_language_list
+from cms.utils.moderator import use_draft
 
 APP_RESOLVERS = []
 
@@ -38,6 +39,9 @@ def applications_page_check(request, current_page=None, path=None):
     for lang in get_language_list():
         if path.startswith(lang + "/"):
             path = path[len(lang + "/"):]
+
+    use_public = not use_draft(request)
+
     for resolver in APP_RESOLVERS:
         try:
             page_id = resolver.resolve_page_id(path)
@@ -46,7 +50,7 @@ def applications_page_check(request, current_page=None, path=None):
             # If current page was matched, then we have some override for
             # content from cms, but keep current page. Otherwise return page
             # to which was application assigned.
-            return page
+            return page if use_public else page.publisher_public
         except Resolver404:
             # Raised if the page is not managed by an apphook
             pass

--- a/cms/test_utils/project/sampleapp/cms_apps.py
+++ b/cms/test_utils/project/sampleapp/cms_apps.py
@@ -11,6 +11,13 @@ from cms.apphook_pool import apphook_pool
 from .models import SampleAppConfig
 
 
+class AppWithNoMenu(CMSApp):
+    app_name = 'app_with_no_menu'
+
+    def get_urls(self, page=None, language=None, **kwargs):
+        return ["cms.test_utils.project.sampleapp.urls"]
+
+
 class SampleApp(CMSApp):
     name = _("Sample App")
     urls = ["cms.test_utils.project.sampleapp.urls"]

--- a/cms/tests/test_apphooks.py
+++ b/cms/tests/test_apphooks.py
@@ -18,6 +18,7 @@ from cms.app_base import CMSApp
 from cms.apphook_pool import apphook_pool
 from cms.appresolver import applications_page_check, clear_app_resolvers, get_app_patterns
 from cms.models import Title, Page
+from cms.middleware.page import get_page
 from cms.test_utils.project.placeholderapp.models import Example1
 from cms.test_utils.testcases import CMSTestCase
 from cms.tests.test_menu_utils import DumbPageLanguageUrl
@@ -318,20 +319,33 @@ class ApphooksTestCase(CMSTestCase):
         page.save()
         public_page = page.get_public_object()
 
+        with force_language("en"):
+            path = reverse('sample-settings')
+            request = self.get_request(path)
+            request.LANGUAGE_CODE = 'en'
+            attached_to_page = applications_page_check(request, path=path[1:])  # strip leading slash
+            self.assertEqual(attached_to_page.pk, public_page.pk)
+
+        with force_language("de"):
+            path = reverse('sample-settings')
+            request = self.get_request(path)
+            request.LANGUAGE_CODE = 'de'
+            attached_to_page = applications_page_check(request, path=path[1:])  # strip leading slash
+            self.assertEqual(attached_to_page.pk, public_page.pk)
+
         with self.login_user_context(superuser):
             with force_language("en"):
                 path = reverse('sample-settings')
                 request = self.get_request(path + '?%s' % get_cms_setting('CMS_TOOLBAR_URL__EDIT_ON'))
                 request.LANGUAGE_CODE = 'en'
                 attached_to_page = applications_page_check(request, path=path[1:])  # strip leading slash
-                response = self.client.get(path+"?edit")
-                self.assertContains(response, '?redirect=')
+                self.assertEqual(attached_to_page.pk, page.pk)
             with force_language("de"):
                 path = reverse('sample-settings')
                 request = self.get_request(path + '?%s' % get_cms_setting('CMS_TOOLBAR_URL__EDIT_ON'))
                 request.LANGUAGE_CODE = 'de'
                 attached_to_page = applications_page_check(request, path=path[1:])  # strip leading slash
-                self.assertEqual(attached_to_page.pk, public_page.pk)
+                self.assertEqual(attached_to_page.pk, page.pk)
 
     @override_settings(ROOT_URLCONF='cms.test_utils.project.second_urls_for_apphook_tests')
     def test_get_root_page_for_apphook_with_instance_namespace(self):
@@ -855,6 +869,83 @@ class ApphooksTestCase(CMSTestCase):
         self.assertTrue('/static/fresh/' in nodes_urls)
 
         self.apphook_clear()
+
+    @override_settings(
+        CMS_APPHOOKS=['cms.test_utils.project.sampleapp.cms_apps.AppWithNoMenu'],
+    )
+    def test_menu_node_is_selected_on_app_root(self):
+        """
+        If a user requests a page with an apphook,
+        the menu should mark the node for that page as selected.
+        """
+        defaults = {
+            'language': 'en',
+            'published': True,
+            'in_navigation': True,
+            'template': 'nav_playground.html',
+        }
+        homepage = create_page('EN-P1', **defaults)
+        app_root = create_page('EN-P2', apphook='AppWithNoMenu', apphook_namespace='app_with_no_menu', **defaults)
+
+        # Public version
+        request = self.get_request('/en/en-p2/?%s' % get_cms_setting('CMS_TOOLBAR_URL__EDIT_ON'))
+        request.current_page = get_page(request)
+        menu_nodes = menu_pool.get_renderer(request).get_nodes()
+        self.assertEqual(len(menu_nodes), 2)
+        self.assertEqual(menu_nodes[0].id, homepage.publisher_public_id)
+        self.assertEqual(menu_nodes[0].selected, False)
+        self.assertEqual(menu_nodes[1].id, app_root.publisher_public_id)
+        self.assertEqual(menu_nodes[1].selected, True)
+
+        # Draft version
+        with self.login_user_context(self.get_superuser()):
+            request = self.get_request('/en/en-p2/?%s' % get_cms_setting('CMS_TOOLBAR_URL__EDIT_ON'))
+            request.current_page = get_page(request)
+            menu_nodes = menu_pool.get_renderer(request).get_nodes()
+            self.assertEqual(len(menu_nodes), 2)
+            self.assertEqual(menu_nodes[0].id, homepage.pk)
+            self.assertEqual(menu_nodes[0].selected, False)
+            self.assertEqual(menu_nodes[1].id, app_root.pk)
+            self.assertEqual(menu_nodes[1].selected, True)
+
+    @override_settings(
+        CMS_APPHOOKS=['cms.test_utils.project.sampleapp.cms_apps.AppWithNoMenu'],
+    )
+    def test_menu_node_is_selected_on_app_sub_path(self):
+        """
+        If a user requests a path belonging to an apphook,
+        the menu should mark the node for the apphook page as selected.
+        """
+        # Refs - https://github.com/divio/django-cms/issues/6336
+        defaults = {
+            'language': 'en',
+            'published': True,
+            'in_navigation': True,
+            'template': 'nav_playground.html',
+        }
+        homepage = create_page('EN-P1', **defaults)
+        app_root = create_page('EN-P2', apphook='AppWithNoMenu', apphook_namespace='app_with_no_menu', **defaults)
+
+        # Public version
+        request = self.get_request('/en/en-p2/settings/?%s' % get_cms_setting('CMS_TOOLBAR_URL__EDIT_ON'))
+        request.current_page = get_page(request)
+        menu_nodes = menu_pool.get_renderer(request).get_nodes()
+        self.assertEqual(len(menu_nodes), 2)
+        self.assertEqual(menu_nodes[0].id, homepage.publisher_public_id)
+        self.assertEqual(menu_nodes[0].selected, False)
+        self.assertEqual(menu_nodes[1].id, app_root.publisher_public_id)
+        self.assertEqual(menu_nodes[1].selected, True)
+
+        # Draft version
+        with self.login_user_context(self.get_superuser()):
+            request = self.get_request('/en/en-p2/settings/?%s' % get_cms_setting('CMS_TOOLBAR_URL__EDIT_ON'))
+            request.current_page = get_page(request)
+            menu_nodes = menu_pool.get_renderer(request).get_nodes()
+            self.assertEqual(len(menu_nodes), 2)
+            self.assertEqual(menu_nodes[0].id, homepage.pk)
+            self.assertEqual(menu_nodes[0].selected, False)
+            self.assertEqual(menu_nodes[1].id, app_root.pk)
+            self.assertEqual(menu_nodes[1].selected, True)
 
 
 class ApphooksPageLanguageUrlTestCase(CMSTestCase):


### PR DESCRIPTION
Backport https://github.com/divio/django-cms/pull/6354