### PR TITLE
Fixed #6002 --  Prevent users from moving homepage under another page

### DIFF
--- a/cms/admin/forms.py
+++ b/cms/admin/forms.py
@@ -843,7 +843,6 @@ class MovePageForm(PageTreeForm):
 
         if self.page.is_home and cleaned_data.get('target'):
             self.add_error('target', force_text(_('You can\'t move the home page to this place')))
-
         return cleaned_data
 
     def get_tree_options(self):

--- a/cms/admin/forms.py
+++ b/cms/admin/forms.py
@@ -838,11 +838,12 @@ class PageTreeForm(forms.Form):
 
 
 class MovePageForm(PageTreeForm):
+
     def clean(self):
         cleaned_data = super(MovePageForm, self).clean()
 
         if self.page.is_home and cleaned_data.get('target'):
-            self.add_error('target', force_text(_('You can\'t move the home page to this place')))
+            self.add_error('target', force_text(_('You can\'t move the home page inside another page')))
         return cleaned_data
 
     def get_tree_options(self):

--- a/cms/admin/forms.py
+++ b/cms/admin/forms.py
@@ -839,11 +839,12 @@ class PageTreeForm(forms.Form):
 
 class MovePageForm(PageTreeForm):
     def clean(self):
-        cleaned_data = super().clean()
+        cleaned_data = super(MovePageForm, self).clean()
 
-        # The user doesn't have permission to do this anymore
-        if self.page.is_home and cleaned_data.get('target', None):
+        if self.page.is_home and cleaned_data.get('target'):
             self.add_error('target', force_text(_('You can\'t move the home page to this place')))
+
+        return cleaned_data
 
     def get_tree_options(self):
         options = super(MovePageForm, self).get_tree_options()

--- a/cms/admin/forms.py
+++ b/cms/admin/forms.py
@@ -838,6 +838,12 @@ class PageTreeForm(forms.Form):
 
 
 class MovePageForm(PageTreeForm):
+    def clean(self):
+        cleaned_data = super().clean()
+
+        # The user doesn't have permission to do this anymore
+        if self.page.is_home and cleaned_data.get('target', None):
+            self.add_error('target', force_text(_('You can\'t move the home page to this place')))
 
     def get_tree_options(self):
         options = super(MovePageForm, self).get_tree_options()

--- a/cms/tests/test_page_admin.py
+++ b/cms/tests/test_page_admin.py
@@ -1145,6 +1145,24 @@ class PageTest(PageTestBase):
             page3 = Page.objects.get(pk=page3.pk)
             self.assertEqual(page3.get_path(), page_data2['slug'] + "/" + page_data3['slug'])
 
+    def test_user_cant_neast_home_page(self):
+        """
+        Users should not be able to move the home-page
+        inside another node of the tree.
+        """
+        homepage = create_page("home", "nav_playground.html", "en", published=True)
+        homepage.set_as_homepage()
+        home_sibling_1 = create_page("root-1", "nav_playground.html", "en", published=True)
+
+        payload = {'id': homepage.pk, 'position': 0, 'target': home_sibling_1}
+
+        with self.login_user_context(self.get_superuser()):
+            endpoint = self.get_admin_url(Page, 'move_page', homepage.pk)
+            response = self.client.post(endpoint, payload)
+
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.json().get('status', 400), 400)
+
     def test_move_home_page(self):
         """
         Users should be able to move the home-page

--- a/cms/tests/test_page_admin.py
+++ b/cms/tests/test_page_admin.py
@@ -1145,7 +1145,7 @@ class PageTest(PageTestBase):
             page3 = Page.objects.get(pk=page3.pk)
             self.assertEqual(page3.get_path(), page_data2['slug'] + "/" + page_data3['slug'])
 
-    def test_user_cant_neast_home_page(self):
+    def test_user_cant_nest_home_page(self):
         """
         Users should not be able to move the home-page
         inside another node of the tree.


### PR DESCRIPTION
Fixed #6002

### Summary
Preventing users from moving homepage under another page

### Fixes
Preventing users via form validation to moving homepage under another page