### PR TITLE
Fixed #6335 -- Global permissions should take precedence over cached page permissions

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,6 +12,7 @@
   operation was to move a plugin in the top level of same placeholder
 * Fixed a bug where xframe options were processed by clickjacking middleware
   when page was served from cache, rather then get this value from cache
+* Fixed a bug where cached page permissions overrides global permissions
 
 
 === 3.5.2 (2018-04-11) ===

--- a/cms/tests/test_permissions.py
+++ b/cms/tests/test_permissions.py
@@ -74,7 +74,9 @@ class PermissionCacheTests(CMSTestCase):
         cached_permissions = get_permission_cache(self.user_normal, "change_page")
         self.assertIsNone(cached_permissions)
 
-    def test_if_cached_page_permissions_dont_override_global_permissions(self):
+    def test_cached_permission_precedence(self):
+        # refs - https://github.com/divio/django-cms/issues/6335
+        # cached page permissions should not override global permissions
         page = create_page(
             "test page",
             "nav_playground.html",
@@ -92,13 +94,6 @@ class PermissionCacheTests(CMSTestCase):
         can_publish = user_can_publish_page(
             self.user_normal,
             page,
-            Site.objects.get_current(),
-        )
-        self.assertTrue(can_publish)
-
-        can_publish = user_can_publish_page(
-            self.user_normal,
-            self.home_page,
             Site.objects.get_current(),
         )
         self.assertTrue(can_publish)

--- a/cms/tests/test_permissions.py
+++ b/cms/tests/test_permissions.py
@@ -5,11 +5,19 @@ from django.test.utils import override_settings
 from cms.api import create_page, assign_user_to_page
 from cms.cache.permissions import (get_permission_cache, set_permission_cache,
                                    clear_user_permission_cache)
+from cms.models.permissionmodels import GlobalPagePermission
 from cms.test_utils.testcases import CMSTestCase
-from cms.utils.page_permissions import get_change_id_list
+from cms.utils.page_permissions import get_change_id_list, user_can_publish_page
 
 
-@override_settings(CMS_PERMISSION=True)
+@override_settings(
+    CMS_PERMISSION=True,
+    CMS_CACHE_DURATIONS={
+        'menus': 60,
+        'content': 60,
+        'permissions': 60,
+    },
+)
 class PermissionCacheTests(CMSTestCase):
 
     def setUp(self):
@@ -65,3 +73,32 @@ class PermissionCacheTests(CMSTestCase):
         self.home_page.save()
         cached_permissions = get_permission_cache(self.user_normal, "change_page")
         self.assertIsNone(cached_permissions)
+
+    def test_if_cached_page_permissions_dont_override_global_permissions(self):
+        page = create_page(
+            "test page",
+            "nav_playground.html",
+            "en",
+            created_by=self.user_super,
+        )
+        page_permission = GlobalPagePermission.objects.create(
+            can_change=True,
+            can_publish=True,
+            user=self.user_normal,
+        )
+        page_permission.sites.add(Site.objects.get_current())
+        set_permission_cache(self.user_normal, "publish_page", [])
+
+        can_publish = user_can_publish_page(
+            self.user_normal,
+            page,
+            Site.objects.get_current(),
+        )
+        self.assertTrue(can_publish)
+
+        can_publish = user_can_publish_page(
+            self.user_normal,
+            self.home_page,
+            Site.objects.get_current(),
+        )
+        self.assertTrue(can_publish)

--- a/cms/utils/page_permissions.py
+++ b/cms/utils/page_permissions.py
@@ -54,6 +54,9 @@ def _get_page_ids_for_action(user, site, action, check_global=True, use_cache=Tr
         # just return grant all mark
         return GRANT_ALL_PERMISSIONS
 
+    if check_global and has_global_permission(user, site, action=action, use_cache=use_cache):
+        return GRANT_ALL_PERMISSIONS
+
     if use_cache:
         # read from cache if possible
         cached = get_permission_cache(user, action)
@@ -64,9 +67,6 @@ def _get_page_ids_for_action(user, site, action, check_global=True, use_cache=Tr
 
     if cached is not None:
         return cached
-
-    if check_global and has_global_permission(user, site, action=action, use_cache=use_cache):
-        return GRANT_ALL_PERMISSIONS
 
     page_actions = get_page_actions(user, site)
     page_ids = list(page_actions[action])


### PR DESCRIPTION
Fixed #6335