### PR TITLE
Fixed #6002 -- Prevent users from moving homepage under another page

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -18,6 +18,7 @@
 * Fixed a bug with expanding static placeholder by clicking on "Expand All" button
 * Fixed a bug where descendant pages with a custom url would lose the overwritten
   url on save.
+* Added form validation logic to prevent users from moving the home page under another page.
 
 
 === 3.5.2 (2018-04-11) ===

--- a/cms/admin/forms.py
+++ b/cms/admin/forms.py
@@ -832,6 +832,13 @@ class PageTreeForm(forms.Form):
 
 class MovePageForm(PageTreeForm):
 
+    def clean(self):
+        cleaned_data = super(MovePageForm, self).clean()
+
+        if self.page.is_home and cleaned_data.get('target'):
+            self.add_error('target', force_text(_('You can\'t move the home page inside another page')))
+        return cleaned_data
+
     def get_tree_options(self):
         options = super(MovePageForm, self).get_tree_options()
         target_node, target_node_position = options

--- a/cms/tests/test_page_admin.py
+++ b/cms/tests/test_page_admin.py
@@ -1144,6 +1144,24 @@ class PageTest(PageTestBase):
             page3 = Page.objects.get(pk=page3.pk)
             self.assertEqual(page3.get_path(), page_data2['slug'] + "/" + page_data3['slug'])
 
+    def test_user_cant_nest_home_page(self):
+        """
+        Users should not be able to move the home-page
+        inside another node of the tree.
+        """
+        homepage = create_page("home", "nav_playground.html", "en", published=True)
+        homepage.set_as_homepage()
+        home_sibling_1 = create_page("root-1", "nav_playground.html", "en", published=True)
+
+        payload = {'id': homepage.pk, 'position': 0, 'target': home_sibling_1}
+
+        with self.login_user_context(self.get_superuser()):
+            endpoint = self.get_admin_url(Page, 'move_page', homepage.pk)
+            response = self.client.post(endpoint, payload)
+
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.json().get('status', 400), 400)
+
     def test_move_home_page(self):
         """
         Users should be able to move the home-page


### PR DESCRIPTION
Backport https://github.com/divio/django-cms/pull/6369