### PR TITLE
Integrate wizards with app registration

### DIFF
--- a/cms/cms_config.py
+++ b/cms/cms_config.py
@@ -1,0 +1,22 @@
+from cms.app_base import CMSAppExtension, CMSAppConfig
+from cms.cms_wizards import cms_page_wizard, cms_subpage_wizard
+
+
+class CMSCoreConfig(CMSAppConfig):
+    cms_enabled = True
+    cms_wizards = [cms_page_wizard, cms_subpage_wizard]
+
+
+class CMSCoreExtensions(CMSAppExtension):
+
+    def __init__(self):
+        self.wizards = {}  # this is instead of wizard_pool._entries
+
+    def configure_wizards(self, cms_config):
+        if not hasattr(cms_config, 'cms_wizards'):
+            return
+        for wizard in cms_config.cms_wizards:
+            self.wizards[wizard.id] = wizard
+
+    def configure_app(self, cms_config):
+        self.configure_wizards(cms_config)

--- a/cms/cms_config.py
+++ b/cms/cms_config.py
@@ -13,9 +13,13 @@ class CMSCoreConfig(CMSAppConfig):
 class CMSCoreExtensions(CMSAppExtension):
 
     def __init__(self):
-        self.wizards = {}  # this is instead of wizard_pool._entries
+        self.wizards = {}
 
     def configure_wizards(self, cms_config):
+        """
+        Adds all registered wizards from apps that define them to the
+        wizards dictionary on this class
+        """
         if not hasattr(cms_config, 'cms_wizards'):
             # The cms_wizards settings is optional. If it's not here
             # just move on.
@@ -27,8 +31,8 @@ class CMSCoreExtensions(CMSAppExtension):
                 raise ImproperlyConfigured(
                     "all wizards defined in cms_wizards must inherit "
                     "from cms.wizards.wizard_base.Wizard")
-        for wizard in cms_config.cms_wizards:
-            self.wizards[wizard.id] = wizard
+            else:
+                self.wizards[wizard.id] = wizard
 
     def configure_app(self, cms_config):
         self.configure_wizards(cms_config)

--- a/cms/cms_config.py
+++ b/cms/cms_config.py
@@ -1,3 +1,4 @@
+from logging import getLogger
 from collections import Iterable
 
 from django.core.exceptions import ImproperlyConfigured
@@ -5,6 +6,9 @@ from django.core.exceptions import ImproperlyConfigured
 from cms.app_base import CMSAppExtension, CMSAppConfig
 from cms.cms_wizards import cms_page_wizard, cms_subpage_wizard
 from cms.wizards.wizard_base import Wizard
+
+
+logger = getLogger(__name__)
 
 
 class CMSCoreConfig(CMSAppConfig):
@@ -31,13 +35,10 @@ class CMSCoreExtensions(CMSAppExtension):
                     "from cms.wizards.wizard_base.Wizard"
                 )
             elif wizard.id in self.wizards:
-                pass
-                # TODO: This is currently breaking various tests
-                # raise ImproperlyConfigured(
-                #    "Wizard for model {} has already been registered".format(
-                #        wizard.get_model()
-                #    )
-                #)
+                msg = "Wizard for model {} has already been registered".format(
+                    wizard.get_model()
+                )
+                logger.warning(msg)
             else:
                 self.wizards[wizard.id] = wizard
 

--- a/cms/cms_config.py
+++ b/cms/cms_config.py
@@ -1,5 +1,8 @@
+from django.core.exceptions import ImproperlyConfigured
+
 from cms.app_base import CMSAppExtension, CMSAppConfig
 from cms.cms_wizards import cms_page_wizard, cms_subpage_wizard
+from cms.wizards.wizard_base import Wizard
 
 
 class CMSCoreConfig(CMSAppConfig):
@@ -14,7 +17,16 @@ class CMSCoreExtensions(CMSAppExtension):
 
     def configure_wizards(self, cms_config):
         if not hasattr(cms_config, 'cms_wizards'):
+            # The cms_wizards settings is optional. If it's not here
+            # just move on.
             return
+        if type(cms_config.cms_wizards) != list:
+            raise ImproperlyConfigured("cms_wizards must be a list")
+        for wizard in cms_config.cms_wizards:
+            if not isinstance(wizard, Wizard):
+                raise ImproperlyConfigured(
+                    "all wizards defined in cms_wizards must inherit "
+                    "from cms.wizards.wizard_base.Wizard")
         for wizard in cms_config.cms_wizards:
             self.wizards[wizard.id] = wizard
 

--- a/cms/cms_wizards.py
+++ b/cms/cms_wizards.py
@@ -52,6 +52,3 @@ cms_subpage_wizard = CMSSubPageWizard(
     model=Page,
     description=_(u"Create a page below the current page.")
 )
-
-wizard_pool.register(cms_page_wizard)
-wizard_pool.register(cms_subpage_wizard)

--- a/cms/cms_wizards.py
+++ b/cms/cms_wizards.py
@@ -4,7 +4,6 @@ from django.utils.translation import ugettext_lazy as _
 from cms.models import Page
 from cms.utils.page_permissions import user_can_add_page, user_can_add_subpage
 
-from .wizards.wizard_pool import wizard_pool
 from .wizards.wizard_base import Wizard
 
 from .forms.wizards import CreateCMSPageForm, CreateCMSSubPageForm

--- a/cms/test_utils/project/backwards_wizards/cms_wizards.py
+++ b/cms/test_utils/project/backwards_wizards/cms_wizards.py
@@ -1,4 +1,5 @@
 from cms.test_utils.project.backwards_wizard.wizards import wizard
+from cms.wizards.wizard_pool import wizard_pool
 
 
 # NOTE: We keep this line separate from the actual wizard definition

--- a/cms/test_utils/project/backwards_wizards/cms_wizards.py
+++ b/cms/test_utils/project/backwards_wizards/cms_wizards.py
@@ -1,0 +1,7 @@
+from cms.test_utils.project.backwards_wizard.wizards import wizard
+
+
+# NOTE: We keep this line separate from the actual wizard definition
+# because if both are in the same file then importing the wizard causes
+# this line to run, which makes it impossible to test properly
+wizard_pool.register(wizard)

--- a/cms/test_utils/project/backwards_wizards/cms_wizards.py
+++ b/cms/test_utils/project/backwards_wizards/cms_wizards.py
@@ -1,4 +1,4 @@
-from cms.test_utils.project.backwards_wizard.wizards import wizard
+from cms.test_utils.project.backwards_wizards.wizards import wizard
 from cms.wizards.wizard_pool import wizard_pool
 
 

--- a/cms/test_utils/project/backwards_wizards/wizards.py
+++ b/cms/test_utils/project/backwards_wizards/wizards.py
@@ -1,5 +1,4 @@
 from cms.wizards.wizard_base import Wizard
-from cms.wizards.wizard_pool import wizard_pool
 
 from cms.test_utils.project.sampleapp.forms import SampleWizardForm
 

--- a/cms/test_utils/project/backwards_wizards/wizards.py
+++ b/cms/test_utils/project/backwards_wizards/wizards.py
@@ -1,0 +1,16 @@
+from cms.wizards.wizard_base import Wizard
+from cms.wizards.wizard_pool import wizard_pool
+
+from cms.test_utils.project.sampleapp.forms import SampleWizardForm
+
+
+class SampleWizard(Wizard):
+    pass
+
+
+wizard = SampleWizard(
+    title="Sample",
+    weight=505,
+    form=SampleWizardForm,
+    description="Create something",
+)

--- a/cms/test_utils/project/sampleapp/cms_config.py
+++ b/cms/test_utils/project/sampleapp/cms_config.py
@@ -1,0 +1,7 @@
+from cms.app_base import CMSAppConfig
+from cms.test_utils.project.sampleapp.cms_wizards import sample_wizard
+
+
+class SampleAppConfig(CMSAppConfig):
+    cms_enabled = True
+    cms_wizards = [sample_wizard]

--- a/cms/test_utils/project/sampleapp/cms_wizards.py
+++ b/cms/test_utils/project/sampleapp/cms_wizards.py
@@ -1,0 +1,15 @@
+from cms.wizards.wizard_base import Wizard
+
+from cms.test_utils.project.sampleapp.forms import SampleWizardForm
+
+
+class SampleWizard(Wizard):
+    pass
+
+
+sample_wizard = SampleWizard(
+    title="Sample",
+    weight=105,
+    form=SampleWizardForm,
+    description="Create a new Sample",
+)

--- a/cms/test_utils/project/sampleapp/forms.py
+++ b/cms/test_utils/project/sampleapp/forms.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
+from django import forms
 from django.contrib.auth.forms import AuthenticationForm
+
+from cms.test_utils.project.sampleapp.models import Category
 
 
 class LoginForm(AuthenticationForm):
@@ -13,3 +16,10 @@ class LoginForm2(AuthenticationForm):
 class LoginForm3(AuthenticationForm):
     def __init__(self, request=None, *args, **kwargs):
         super(LoginForm3, self).__init__(request, *args, **kwargs)
+
+
+class SampleWizardForm(forms.ModelForm):
+
+    class Meta:
+        model = Category
+        exclude = []

--- a/cms/tests/test_cms_config.py
+++ b/cms/tests/test_cms_config.py
@@ -2,6 +2,7 @@ from mock import Mock
 
 from django.apps import apps
 
+from cms.app_registration import get_cms_extension_apps, get_cms_config_apps
 from cms.cms_config import CMSCoreExtensions
 from cms.cms_wizards import cms_page_wizard, cms_subpage_wizard
 from cms.test_utils.project.sampleapp.cms_wizards import sample_wizard
@@ -34,6 +35,14 @@ class ConfigureWizardsUnitTestCase(CMSTestCase):
 
 
 class ConfigureWizardsIntegrationTestCase(CMSTestCase):
+
+    def setUp(self):
+        # The results of get_cms_extension_apps and get_cms_config_apps
+        # are cached. Clear this cache because installed apps change
+        # between tests and therefore unlike in a live environment,
+        # results of this function can change between tests
+        get_cms_extension_apps.cache_clear()
+        get_cms_config_apps.cache_clear()
 
     def test_adds_all_wizards_to_dict(self):
         setup_cms_apps()

--- a/cms/tests/test_cms_config.py
+++ b/cms/tests/test_cms_config.py
@@ -15,6 +15,10 @@ from cms.wizards.wizard_base import Wizard
 class ConfigureWizardsUnitTestCase(CMSTestCase):
 
     def test_adds_wizards_to_dict(self):
+        """
+        If the wizard setting is correctly defined, add the wizards to the
+        dictionary of wizards
+        """
         extensions = CMSCoreExtensions()
         wizard1 = Mock(id=111, spec=Wizard)
         wizard2 = Mock(id=222, spec=Wizard)
@@ -27,6 +31,10 @@ class ConfigureWizardsUnitTestCase(CMSTestCase):
             extensions.wizards, {111: wizard1, 222: wizard2})
 
     def test_doesnt_raise_exception_when_wizards_dict_undefined(self):
+        """
+        If the wizard setting is not present in the config, simply
+        ignore this. The wizard setting is optional.
+        """
         extensions = CMSCoreExtensions()
         cms_config = Mock(cms_enabled=True, spec=[])
 
@@ -36,6 +44,10 @@ class ConfigureWizardsUnitTestCase(CMSTestCase):
             self.fail("Raises exception when cms_wizards undefined")
 
     def test_raises_exception_if_doesnt_inherit_from_wizard_class(self):
+        """
+        If one or more of the wizards defined in the wizard setting
+        do not inherit from the Wizard class, raise an exception
+        """
         extensions = CMSCoreExtensions()
         wizard = Mock(id=3, spec=object)
         cms_config = Mock(
@@ -45,6 +57,9 @@ class ConfigureWizardsUnitTestCase(CMSTestCase):
             extensions.configure_wizards(cms_config)
 
     def test_raises_exception_if_not_list(self):
+        """
+        If the wizard setting isn't a list, raise an exception.
+        """
         extensions = CMSCoreExtensions()
         wizard = Mock(id=6, spec=Wizard)
         cms_config = Mock(
@@ -65,6 +80,10 @@ class ConfigureWizardsIntegrationTestCase(CMSTestCase):
         get_cms_config_apps.cache_clear()
 
     def test_adds_all_wizards_to_dict(self):
+        """
+        Check that all wizards are picked up from both cms.cms_config
+        and sampleapp.cms_config
+        """
         setup_cms_apps()
 
         app = apps.get_app_config('cms')

--- a/cms/tests/test_cms_config.py
+++ b/cms/tests/test_cms_config.py
@@ -1,0 +1,49 @@
+from mock import Mock
+
+from django.apps import apps
+
+from cms.cms_config import CMSCoreExtensions
+from cms.cms_wizards import cms_page_wizard, cms_subpage_wizard
+from cms.test_utils.project.sampleapp.cms_wizards import sample_wizard
+from cms.test_utils.testcases import CMSTestCase
+from cms.utils.setup import setup_cms_apps
+
+
+class ConfigureWizardsUnitTestCase(CMSTestCase):
+
+    def test_adds_wizards_to_dict(self):
+        extensions = CMSCoreExtensions()
+        wizard1 = Mock(id=111)
+        wizard2 = Mock(id=222)
+        cms_config = Mock(
+            cms_enabled=True, cms_wizards=[wizard1, wizard2])
+
+        extensions.configure_wizards(cms_config)
+
+        self.assertDictEqual(
+            extensions.wizards, {111: wizard1, 222: wizard2})
+
+    def test_doesnt_raise_exception_when_wizards_dict_undefined(self):
+        extensions = CMSCoreExtensions()
+        cms_config = Mock(cms_enabled=True, spec=[])
+
+        try:
+            extensions.configure_wizards(cms_config)
+        except AttributeError:
+            self.fail("Raises exception when cms_wizards undefined")
+
+
+class ConfigureWizardsIntegrationTestCase(CMSTestCase):
+
+    def test_adds_all_wizards_to_dict(self):
+        setup_cms_apps()
+
+        app = apps.get_app_config('cms')
+        # cms core defines wizards in its config, as does sampleapp
+        # all of these wizards should have been picked up and added
+        expected_wizards = {
+            cms_page_wizard.id: cms_page_wizard,
+            cms_subpage_wizard.id: cms_subpage_wizard,
+            sample_wizard.id: sample_wizard,
+        }
+        self.assertDictEqual(app.cms_extension.wizards, expected_wizards)

--- a/cms/tests/test_cms_config_wizards.py
+++ b/cms/tests/test_cms_config_wizards.py
@@ -24,9 +24,7 @@ class ConfigureWizardsUnitTestCase(CMSTestCase):
         wizard2 = Mock(id=222, spec=Wizard)
         cms_config = Mock(
             cms_enabled=True, cms_wizards=[wizard1, wizard2])
-
         extensions.configure_wizards(cms_config)
-
         self.assertDictEqual(
             extensions.wizards, {111: wizard1, 222: wizard2})
 
@@ -37,9 +35,8 @@ class ConfigureWizardsUnitTestCase(CMSTestCase):
         """
         extensions = CMSCoreExtensions()
         cms_config = Mock(cms_enabled=True, spec=[])
-
         try:
-            extensions.configure_wizards(cms_config)
+            extensions.configure_app(cms_config)
         except AttributeError:
             self.fail("Raises exception when cms_wizards undefined")
 
@@ -52,21 +49,31 @@ class ConfigureWizardsUnitTestCase(CMSTestCase):
         wizard = Mock(id=3, spec=object)
         cms_config = Mock(
             cms_enabled=True, cms_wizards=[wizard])
-
         with self.assertRaises(ImproperlyConfigured):
             extensions.configure_wizards(cms_config)
 
-    def test_raises_exception_if_not_list(self):
+    def test_raises_exception_if_not_iterable(self):
         """
-        If the wizard setting isn't a list, raise an exception.
+        If the wizard setting isn't iterable, raise an exception.
         """
         extensions = CMSCoreExtensions()
         wizard = Mock(id=6, spec=Wizard)
         cms_config = Mock(
             cms_enabled=True, cms_wizards=wizard)
-
         with self.assertRaises(ImproperlyConfigured):
             extensions.configure_wizards(cms_config)
+
+    # TODO: Currently adding this check breaks various tests elsewhere
+    #~ def test_cant_register_the_same_wizard_twice(self):
+        #~ """
+        #~ If a wizard is already added to the dict, raise an exception.
+        #~ """
+        #~ extensions = CMSCoreExtensions()
+        #~ wizard = Mock(id=81, spec=Wizard)
+        #~ cms_config = Mock(
+            #~ cms_enabled=True, cms_wizards=[wizard, wizard])
+        #~ with self.assertRaises(ImproperlyConfigured):
+            #~ extensions.configure_wizards(cms_config)
 
 
 class ConfigureWizardsIntegrationTestCase(CMSTestCase):
@@ -85,7 +92,6 @@ class ConfigureWizardsIntegrationTestCase(CMSTestCase):
         and sampleapp.cms_config
         """
         setup_cms_apps()
-
         app = apps.get_app_config('cms')
         # cms core defines wizards in its config, as does sampleapp
         # all of these wizards should have been picked up and added

--- a/cms/tests/test_wizards.py
+++ b/cms/tests/test_wizards.py
@@ -11,6 +11,7 @@ from django.utils.encoding import smart_text
 from django.utils.translation import ugettext as _
 
 from cms.api import create_page, publish_page
+from cms.app_registration import get_cms_extension_apps, get_cms_config_apps
 from cms.cms_wizards import cms_page_wizard, cms_subpage_wizard
 from cms.constants import TEMPLATE_INHERITANCE_MAGIC
 from cms.forms.wizards import CreateCMSPageForm, CreateCMSSubPageForm
@@ -497,6 +498,14 @@ class TestPageWizard(WizardTestMixin, CMSTestCase):
 
 
 class TestWizardHelpers(CMSTestCase):
+
+    def setUp(self):
+        # The results of get_cms_extension_apps and get_cms_config_apps
+        # are cached. Clear this cache because installed apps change
+        # between tests and therefore unlike in a live environment,
+        # results of this function can change between tests
+        get_cms_extension_apps.cache_clear()
+        get_cms_config_apps.cache_clear()
 
     def test_get_entries_orders_by_weight(self):
         # The test setup registers two wizards from cms itself

--- a/cms/tests/test_wizards.py
+++ b/cms/tests/test_wizards.py
@@ -176,21 +176,35 @@ class TestWizardPool(WizardTestMixin, CMSTestCase):
             extension.wizards = expected_wizards
 
     def test_discovered_returns_true(self):
-        # Backwards compatibility
+        """
+        Test for backwards compatibility of the discovered property.
+        This should always return True because discovering of wizards
+        now happens in the app registration system so as far as the
+        wizard_pool is concerned they are always discovered.
+        """
         self.assertTrue(wizard_pool.discovered)
 
     def test_is_registered_for_registered_wizard(self):
-        # Backwards compatibility
+        """
+        Test for backwards compatibility of is_registered when checking
+        a registered wizard.
+        """
         is_registered = wizard_pool.is_registered(cms_page_wizard)
         self.assertTrue(is_registered)
 
     def test_is_registered_for_unregistered_wizard(self):
-        # Backwards compatibility
+        """
+        Test for backwards compatibility of is_registered when checking
+        an unregistered wizard.
+        """
         is_registered = wizard_pool.is_registered(self.page_wizard)
         self.assertFalse(is_registered)
 
     def test_unregister_registered_wizard(self):
-        # Test for backwards compatibility only.
+        """
+        Test for backwards compatibility of the unregister method.
+        Removes a wizard from the wizards dict.
+        """
         was_unregistered = wizard_pool.unregister(cms_page_wizard)
 
         registered_wizards = apps.get_app_config('cms').cms_extension.wizards
@@ -198,17 +212,27 @@ class TestWizardPool(WizardTestMixin, CMSTestCase):
         self.assertTrue(was_unregistered)
 
     def test_unregister_unregistered_wizard(self):
-        # Test for backwards compatibility only.
+        """
+        Test for backwards compatibility of the unregister method.
+        Returns False if wizard not fount.
+        """
         was_unregistered = wizard_pool.unregister(self.page_wizard)
         self.assertFalse(was_unregistered)
 
     def test_register_already_registered_wizard(self):
-        # Test for backwards compatibility only.
+        """
+        Test for backwards compatibility of the register method.
+        Raises AlreadyRegisteredException if the wizard is already
+        registered.
+        """
         with self.assertRaises(AlreadyRegisteredException):
             wizard_pool.register(cms_page_wizard)
 
     def test_register_unregistered_wizard(self):
-        # Test for backwards compatibility only.
+        """
+        Test for backwards compatibility of the register method.
+        Adds the wizard to the wizards dict.
+        """
         wizard_pool.register(self.page_wizard)
 
         registered_wizards = apps.get_app_config('cms').cms_extension.wizards
@@ -540,6 +564,10 @@ class TestWizardHelpers(CMSTestCase):
         get_cms_config_apps.cache_clear()
 
     def test_get_entries_orders_by_weight(self):
+        """
+        The get_entries function returns the registered wizards
+        ordered by weight.
+        """
         # The test setup registers two wizards from cms itself
         # (cms_page_wizard and cms_subpage_wizard) and one from
         # test_utils.project.sampleapp (sample_wizard)
@@ -553,10 +581,22 @@ class TestWizardHelpers(CMSTestCase):
         self.assertListEqual(entries, expected)
 
     def test_get_entry_returns_wizard_by_id(self):
+        """
+        The get_entry function returns the wizard when a wizard id is
+        supplied.
+        """
         entry = get_entry(sample_wizard.id)
         self.assertEqual(entry, sample_wizard)
 
     def test_get_entry_returns_wizard_by_object(self):
+        """
+        The get_entry function returns the wizard when a wizard is
+        supplied.
+
+        NOTE: This is a little weird as we're simply returning the
+        object we're passing to get_entry, but keeping it this way for
+        backwards compatibility.
+        """
         entry = get_entry(sample_wizard)
         self.assertEqual(entry, sample_wizard)
 
@@ -564,6 +604,9 @@ class TestWizardHelpers(CMSTestCase):
 class TestEntryChoices(CMSTestCase):
 
     def test_generates_choices_in_weighted_order(self):
+        """
+        The entry_choices function returns the wizards ordered by weight
+        """
         user = self.get_superuser()
         page = create_page('home', 'nav_playground.html', 'en', published=True)
 
@@ -581,6 +624,10 @@ class TestEntryChoices(CMSTestCase):
         Mock(return_value=False)
     )
     def test_doesnt_generate_choice_if_user_doesnt_have_permission(self):
+        """
+        The entry_choices function only returns the wizards that the
+        user has permissions for
+        """
         user = self.get_superuser()
         page = create_page('home', 'nav_playground.html', 'en', published=True)
 

--- a/cms/tests/test_wizards.py
+++ b/cms/tests/test_wizards.py
@@ -236,6 +236,27 @@ class TestWizardPool(WizardTestMixin, CMSTestCase):
         wizard_pool.get_entry(cms_page_wizard)
         mocked_get_entry.assert_called_once()
 
+    @override_settings(INSTALLED_APPS=[
+        'cms',
+        'treebeard',
+        'cms.test_utils.project.backwards_wizards',
+        'cms.test_utils.project.sampleapp',  # adds itself anyway before this is overridden
+    ])
+    def test_old_registration_still_works(self):
+        extension = apps.get_app_config('cms').cms_extension
+        extension.wizards = {}
+        from cms.utils.setup import setup_cms_apps
+        setup_cms_apps()
+        app = apps.get_app_config('cms')
+        from cms.test_utils.project.backwards_wizards.wizards import wizard
+        expected_wizards = {
+            cms_page_wizard.id: cms_page_wizard,
+            cms_subpage_wizard.id: cms_subpage_wizard,
+            wizard.id: wizard,
+            sample_wizard.id: sample_wizard,
+        }
+        self.assertDictEqual(app.cms_extension.wizards, expected_wizards)
+
 
 class TestPageWizard(WizardTestMixin, CMSTestCase):
 

--- a/cms/utils/setup.py
+++ b/cms/utils/setup.py
@@ -3,6 +3,7 @@ from django.core.exceptions import ImproperlyConfigured
 
 from cms.app_registration import (
     autodiscover_cms_configs,
+    backwards_compatibility_config,
     configure_cms_apps,
     get_cms_extension_apps,
 )
@@ -54,3 +55,4 @@ def setup_cms_apps():
     autodiscover_cms_configs()
     cms_apps = get_cms_extension_apps()
     configure_cms_apps(cms_apps)
+    backwards_compatibility_config()

--- a/cms/wizards/helpers.py
+++ b/cms/wizards/helpers.py
@@ -5,12 +5,19 @@ from cms.wizards.wizard_base import Wizard
 
 
 def get_entries():
+    """
+    Returns a list of (wizard.id, wizard) tuples (for all registered
+    wizards) ordered by weight
+    """
     wizards = apps.get_app_config('cms').cms_extension.wizards
     return [value for (key, value) in sorted(
             wizards.items(), key=lambda e: getattr(e[1], 'weight'))]
 
 
 def get_entry(entry_key):
+    """
+    Returns a wizard object based on its id.
+    """
     if isinstance(entry_key, Wizard):
         entry_key = entry_key.id
     return apps.get_app_config('cms').cms_extension.wizards[entry_key]

--- a/cms/wizards/helpers.py
+++ b/cms/wizards/helpers.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+from django.apps import apps
+
+
+def get_entries():
+    wizards = apps.get_app_config('cms').cms_extension.wizards
+    return [value for (key, value) in sorted(
+            wizards.items(), key=lambda e: getattr(e[1], 'weight'))]

--- a/cms/wizards/helpers.py
+++ b/cms/wizards/helpers.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 from django.apps import apps
 
-from cms.wizards.wizard_base import Wizard
-
 
 def get_entries():
     """
@@ -18,6 +16,4 @@ def get_entry(entry_key):
     """
     Returns a wizard object based on its id.
     """
-    if isinstance(entry_key, Wizard):
-        entry_key = entry_key.id
     return apps.get_app_config('cms').cms_extension.wizards[entry_key]

--- a/cms/wizards/helpers.py
+++ b/cms/wizards/helpers.py
@@ -1,8 +1,16 @@
 # -*- coding: utf-8 -*-
 from django.apps import apps
 
+from cms.wizards.wizard_base import Wizard
+
 
 def get_entries():
     wizards = apps.get_app_config('cms').cms_extension.wizards
     return [value for (key, value) in sorted(
             wizards.items(), key=lambda e: getattr(e[1], 'weight'))]
+
+
+def get_entry(entry_key):
+    if isinstance(entry_key, Wizard):
+        entry_key = entry_key.id
+    return apps.get_app_config('cms').cms_extension.wizards[entry_key]

--- a/cms/wizards/wizard_pool.py
+++ b/cms/wizards/wizard_pool.py
@@ -2,7 +2,7 @@
 from django.utils.module_loading import autodiscover_modules
 from django.utils.translation import ugettext as _
 
-from cms.wizards.helpers import get_entries
+from cms.wizards.helpers import get_entries, get_entry
 from cms.wizards.wizard_base import Wizard
 
 
@@ -102,12 +102,11 @@ class WizardPool(object):
         Wizard instance or its "id" (which is the PK of its underlying
         content-type).
 
-        NOTE: This method triggers pool discovery.
+        NOTE: This method is here for backwards compatibility only.
+        Use cms.wizards.helpers.get_enty when possible.
         """
-        self._discover()
-        if isinstance(entry, Wizard):
-            entry = entry.id
-        return self._entries[entry]
+        # TODO: Deprecated warning
+        return get_entry(entry)
 
     def get_entries(self):
         """

--- a/cms/wizards/wizard_pool.py
+++ b/cms/wizards/wizard_pool.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from django.apps import apps
-from django.utils.module_loading import autodiscover_modules
 from django.utils.translation import ugettext as _
 
 from cms.wizards.helpers import get_entries, get_entry
@@ -51,7 +50,6 @@ class WizardPool(object):
 
         Raises AlreadyRegisteredException if the entry is already registered.
         """
-        # TODO: Use the new app registration instead of this
         # TODO: Add deprecation warning
         assert isinstance(entry, Wizard), u"entry must be an instance of Wizard"
         if self.is_registered(entry, passive=True):

--- a/cms/wizards/wizard_pool.py
+++ b/cms/wizards/wizard_pool.py
@@ -15,7 +15,7 @@ def entry_choices(user, page):
     Yields a list of wizard entries that the current user can use based on their
     permission to add instances of the underlying model objects.
     """
-    for entry in wizard_pool.get_entries():
+    for entry in get_entries():
         if entry.user_has_add_permission(user, page=page):
             yield (entry.id, entry.title)
 

--- a/cms/wizards/wizard_pool.py
+++ b/cms/wizards/wizard_pool.py
@@ -2,7 +2,8 @@
 from django.utils.module_loading import autodiscover_modules
 from django.utils.translation import ugettext as _
 
-from .wizard_base import Wizard
+from cms.wizards.helpers import get_entries
+from cms.wizards.wizard_base import Wizard
 
 
 class AlreadyRegisteredException(Exception):
@@ -70,6 +71,8 @@ class WizardPool(object):
 
         Raises AlreadyRegisteredException if the entry is already registered.
         """
+        # TODO: Use the new app registration instead of this
+        # TODO: Add deprecation warning
         assert isinstance(entry, Wizard), u"entry must be an instance of Wizard"
         if self.is_registered(entry, passive=True):
             model = entry.get_model()
@@ -110,10 +113,10 @@ class WizardPool(object):
         """
         Returns all entries in weight-order.
 
-        NOTE: This method triggers pool discovery.
+        NOTE: This method is here for backwards compatibility only.
+        Use cms.wizards.helpers.get_entries when possible.
         """
-        self._discover()
-        return [value for (key, value) in sorted(
-            self._entries.items(), key=lambda e: getattr(e[1], 'weight'))]
+        # TODO: Deprecated warning
+        return get_entries()
 
 wizard_pool = WizardPool()

--- a/cms/wizards/wizard_pool.py
+++ b/cms/wizards/wizard_pool.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from django.apps import apps
 from django.utils.module_loading import autodiscover_modules
 from django.utils.translation import ugettext as _
 
@@ -21,49 +22,28 @@ def entry_choices(user, page):
 
 
 class WizardPool(object):
-    _entries = {}
-    _discovered = False
-
-    def __init__(self):
-        self._reset()
-
-    # PRIVATE METHODS -----------------
-
-    def _discover(self):
-        if not self._discovered:
-            autodiscover_modules('cms_wizards')
-            self._discovered = True
-
-    def _clear(self):
-        """Simply empties the pool but does not clear the discovered flag."""
-        self._entries = {}
-
-    def _reset(self):
-        """Clears the wizard pool and clears the discovered flag."""
-        self._clear()
-        self._discovered = False
-
-    # PUBLIC METHODS ------------------
 
     @property
     def discovered(self):
         """
-        A public getter for the private property _discovered. Note, there is no
-        public setter.
+        Returns whether all the wizards have been autodiscovered.
+
+        NOTE: This property is for backwards compatibility only
         """
-        return self._discovered
+        # TODO: Add deprecation warning
+        # Always return True because autodiscovering now happens through
+        # the app registration system, so we no longer do any
+        # discovering of registered wizards here
+        return True
 
     def is_registered(self, entry, **kwargs):
         """
         Returns True if the provided entry is registered.
 
-        NOTE: This method triggers pool discovery unless a «passive» kwarg
-        is set to True
+        NOTE: This method is for backwards compatibility only
         """
-        passive = kwargs.get('passive', False)
-        if not passive:
-            self._discover()
-        return entry.id in self._entries
+        # TODO: Add deprecation warning
+        return entry.id in apps.get_app_config('cms').cms_extension.wizards
 
     def register(self, entry):
         """
@@ -80,7 +60,7 @@ class WizardPool(object):
                 _(u"A wizard has already been registered for model: %s") %
                 model.__name__)
         else:
-            self._entries[entry.id] = entry
+            apps.get_app_config('cms').cms_extension.wizards[entry.id] = entry
 
     def unregister(self, entry):
         """
@@ -88,11 +68,12 @@ class WizardPool(object):
 
         Returns True if the entry was successfully registered, else False.
 
-        NOTE: This method triggers pool discovery.
+        NOTE: This method is here for backwards compatibility only.
         """
+        # TODO: Add deprecation warning
         assert isinstance(entry, Wizard), u"entry must be an instance of Wizard"
-        if self.is_registered(entry, passive=True):
-            del self._entries[entry.id]
+        if self.is_registered(entry):
+            del apps.get_app_config('cms').cms_extension.wizards[entry.id]
             return True
         return False
 

--- a/cms/wizards/wizard_pool.py
+++ b/cms/wizards/wizard_pool.py
@@ -22,19 +22,6 @@ def entry_choices(user, page):
 
 class WizardPool(object):
 
-    @property
-    def discovered(self):
-        """
-        Returns whether all the wizards have been autodiscovered.
-
-        NOTE: This property is for backwards compatibility only
-        """
-        # TODO: Add deprecation warning
-        # Always return True because autodiscovering now happens through
-        # the app registration system, so we no longer do any
-        # discovering of registered wizards here
-        return True
-
     def is_registered(self, entry, **kwargs):
         """
         Returns True if the provided entry is registered.
@@ -86,15 +73,5 @@ class WizardPool(object):
         """
         # TODO: Deprecated warning
         return get_entry(entry)
-
-    def get_entries(self):
-        """
-        Returns all entries in weight-order.
-
-        NOTE: This method is here for backwards compatibility only.
-        Use cms.wizards.helpers.get_entries when possible.
-        """
-        # TODO: Deprecated warning
-        return get_entries()
 
 wizard_pool = WizardPool()


### PR DESCRIPTION
### Summary

Implement wizards via the new app registration system. Ensure backwards compatibility

### Proposed changes in this pull request
This changes (although ensures backwards compatibility with) how wizards will be registered with the cms going forwards. From now on to register wizards one needs to do the following:

1. Create a cms_config.py file in the app (if one doesn't exist already)
1. Implement a class that inherits from `app_base.CMSAppConfig` (if it doesn't exist already) and make sure it has the following attributes:
```
class Config(CMSAppConfig):
    cms_enabled = True
    cms_wizards = [wizard1, wizard2]
```
where wizard1 and wizard2 are wizards as they are currently defined in cms_wizards.py

### Documentation checklist

* [ ] I have updated CHANGELOG.txt if appropriate
* [ ] I have updated the release notes document if appropriate, with:
    * [ ] general notes
    * [ ] bug-fixes
    * [ ] improvements/new features
    * [ ] backwards-incompatible changes
    * [ ] required upgrade steps
    * [ ] names of contributors
* [ ] I have updated other documentation
* [ ] I have added my name to the AUTHORS file
* [ ] This PR's documentation has been approved by Daniele Procida
