### PR TITLE
Removed unpublish button from toolbar

### DIFF
--- a/cms/cms_toolbars.py
+++ b/cms/cms_toolbars.py
@@ -9,7 +9,7 @@ from django.db.models import Q
 from django.utils.translation import override as force_language, ugettext_lazy as _
 
 from cms.api import get_page_draft, can_change_page
-from cms.constants import TEMPLATE_INHERITANCE_MAGIC, PUBLISHER_STATE_PENDING
+from cms.constants import TEMPLATE_INHERITANCE_MAGIC
 from cms.models import Placeholder, Title, Page, PageType, StaticPlaceholder
 from cms.toolbar.items import TemplateItem, REFRESH_PAGE
 from cms.toolbar_base import CMSToolbar
@@ -285,10 +285,6 @@ class PageToolbar(CMSToolbar):
             self.page_change_permission = can_change_page(self.request)
         return self.page_change_permission
 
-    def page_is_pending(self, page, language):
-        return (page.publisher_public_id and
-                page.publisher_public.get_publisher_state(language) == PUBLISHER_STATE_PENDING)
-
     def in_apphook(self):
         with force_language(self.toolbar.request_language):
             try:
@@ -338,21 +334,6 @@ class PageToolbar(CMSToolbar):
         self.init_placeholders()
         self.add_draft_live()
         self.add_structure_mode()
-
-    def has_dirty_objects(self):
-        language = self.current_lang
-
-        if self.page:
-            if self.dirty_statics:
-                # There's dirty static placeholders on this page.
-                # Only show the page as dirty (publish button) if the page
-                # translation has been configured.
-                dirty = self.page.has_translation(language)
-            else:
-                dirty = (self.page.is_dirty(language) or self.page_is_pending(self.page, language))
-        else:
-            dirty = bool(self.dirty_statics)
-        return dirty
 
     # Buttons
     def add_draft_live(self):

--- a/cms/cms_toolbars.py
+++ b/cms/cms_toolbars.py
@@ -235,7 +235,6 @@ class PageToolbar(CMSToolbar):
             self.statics = StaticPlaceholder.objects.filter(
                 Q(draft__in=placeholder_ids) | Q(public__in=placeholder_ids)
             )
-            self.dirty_statics = [sp for sp in self.statics if sp.dirty]
         else:
             if toolbar.structure_mode_active and not toolbar.uses_legacy_structure_mode:
                 # User has explicitly requested structure mode
@@ -246,7 +245,6 @@ class PageToolbar(CMSToolbar):
 
             self.placeholders = renderer.get_rendered_placeholders()
             self.statics = renderer.get_rendered_static_placeholders()
-            self.dirty_statics = [sp for sp in self.statics if sp.dirty]
 
     def add_structure_mode(self):
         if self.page and not self.page.application_urls:

--- a/cms/cms_toolbars.py
+++ b/cms/cms_toolbars.py
@@ -295,9 +295,6 @@ class PageToolbar(CMSToolbar):
             publish_permission = all(sp.has_publish_permission(self.request) for sp in self.dirty_statics)
         return publish_permission
 
-    def has_unpublish_permission(self):
-        return self.has_publish_permission()
-
     def has_page_change_permission(self):
         if not hasattr(self, 'page_change_permission'):
             self.page_change_permission = can_change_page(self.request)


### PR DESCRIPTION
Removed the unpublish features from the toolbar. No tests failed. The publish and unpublish buttons are still present on the page drop down in the toolbar.