### PR TITLE
Bumped the version number up to release 4.0.0 to avoid confusion with…

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,3 @@
-=== 4.0.0 (unreleased) ===
-
-
 === 3.6.0 (unreleased) ===
 
 * Removed the ``cms moderator`` command.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,6 @@
+=== 4.0.0 (unreleased) ===
+
+
 === 3.6.0 (unreleased) ===
 
 * Removed the ``cms moderator`` command.

--- a/cms/__init__.py
+++ b/cms/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '3.5.2'
+__version__ = '4.0.0'
 
 default_app_config = 'cms.apps.CMSConfig'

--- a/cms/__init__.py
+++ b/cms/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '4.0.0'
+__version__ = '4.0.0dev1'
 
 default_app_config = 'cms.apps.CMSConfig'


### PR DESCRIPTION
There has been a few cases where developers have been working on the wrong version of the CMS, especially when testing the new app integration features. Please let me know if I need to change anything.
