### PR TITLE
Fixes #6440 - `render_plugin_block` template tag

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,7 @@
 * Fixed a bug where cached page permissions overrides global permissions
 * Fixed a bug where editing pages with primary keys greater than 9999 would throw an
   exception.
+* Fixed a regression which caused the `render_plugin_block` template tag to not work.
 
 
 === 3.4.6 (2018-03-26) ===

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,7 +6,7 @@
 * Fixed a bug where cached page permissions overrides global permissions
 * Fixed a bug where editing pages with primary keys greater than 9999 would throw an
   exception.
-* Fixed a regression which caused the `render_plugin_block` template tag to not work.
+* Fixed a regression which caused the `render_plugin_block` template tag not to work.
 
 
 === 3.4.6 (2018-03-26) ===

--- a/cms/templates/cms/toolbar/render_plugin_block.html
+++ b/cms/templates/cms/toolbar/render_plugin_block.html
@@ -1,2 +1,0 @@
-{% load l10n %}
-<div class="cms-plugin cms-plugin-{{ plugin.id|unlocalize }}">{{ inner }}</div>

--- a/cms/templatetags/cms_tags.py
+++ b/cms/templatetags/cms_tags.py
@@ -276,15 +276,15 @@ class RenderPluginBlock(InclusionTag):
     """
 
     name = 'render_plugin_block'
-    template = "cms/toolbar/render_plugin_block.html"
+    template = "cms/toolbar/plugin.html"
     options = Options(
         Argument('plugin'),
         blocks=[('endrender_plugin_block', 'nodelist')],
     )
 
     def get_context(self, context, plugin, nodelist):
-        context['inner'] = nodelist.render(context)
-        context['plugin'] = plugin
+        context['content'] = nodelist.render(context)
+        context['instance'] = plugin
         return context
 
 


### PR DESCRIPTION
### Summary

Fixes #6440



### Links to related discussion
#6440


### Proposed changes in this pull request

Change template of `render_plugin_block` template tag and names of context variables.

### Documentation checklist

* [x] I have updated CHANGELOG.txt if appropriate
* [ ] I have updated the release notes document if appropriate, with: <--- where 
    * [ ] general notes
    * [ ] bug-fixes  <--- should I create a `3.4.7.rst` file?
    * [ ] improvements/new features
    * [ ] backwards-incompatible changes
    * [ ] required upgrade steps
    * [ ] names of contributors
* [ ] I have updated other documentation <--- don't think this is needed
* [x] I have added my name to the AUTHORS file <--- wasn't necessary 
* [ ] This PR's documentation has been approved by Daniele Procida
