### PR TITLE
Remove publish / unpublish buttons from page changelist

### DIFF
--- a/cms/templates/admin/cms/page/tree/menu.html
+++ b/cms/templates/admin/cms/page/tree/menu.html
@@ -108,26 +108,7 @@
                                     </a>
                                 </li>
                                 {# hide if page is empty #}
-                                {% if lang in page_languages %}
-                                    {% if ancestors|items_are_published:lang %}
-                                        {% if page|is_dirty:lang or not page|is_published:lang %}
-                                            <li>
-                                                <a href="{% url opts|admin_urlname:'publish_page' page.id lang %}?redirect_language={{ preview_language }}{% if request.GET.page_id %}&amp;redirect_page_id={{ request.GET.page_id }}{% endif %}" class="js-cms-tree-lang-trigger">
-                                                    <span class="cms-icon cms-icon-check-o"></span>
-                                                    <span>{% autoescape on %}{% trans "Publish" %}{% endautoescape %}</span>
-                                                </a>
-                                            </li>
-                                        {% endif %}
-                                        {% if page|is_published:lang %}
-                                            <li>
-                                                <a href="{% url opts|admin_urlname:'unpublish' page.id lang %}?redirect_language={{ preview_language }}{% if request.GET.page_id %}&amp;redirect_page_id={{ request.GET.page_id }}{% endif %}" class="js-cms-tree-lang-trigger">
-                                                    <span class="cms-icon cms-icon-forbidden"></span>
-                                                    <span>{% autoescape on %}{% trans "Unpublish" %}{% endautoescape %}</span>
-                                                </a>
-                                            </li>
-                                        {% endif %}
-                                    {% endif %}
-                                {% else %}
+                                {% if not lang in page_languages %}
                                     <li>
                                         <a href="{% url opts|admin_urlname:'change' page.id %}?language={{ lang }}">
                                             <span class="cms-icon cms-icon-cogs"></span>


### PR DESCRIPTION
- Remove publish button from changelist dropdown
- Remove unpublish button from changelist dropdown
- Remove any backend test that checks for these two buttons
- Leave the preview button
- New pages should show a green circle for the language that way just created
- New pages should show a white circle for the languages that are not yet configured
