### PR TITLE
Remove logic which publishes the first page page as soon as it is created

### DIFF
--- a/cms/admin/forms.py
+++ b/cms/admin/forms.py
@@ -318,8 +318,7 @@ class AddPageForm(BasePageForm):
         )
 
         if is_first and not new_page.is_page_type:
-            # its the first page. publish it right away
-            new_page.publish(translation.language)
+            # its the first page. Make it the homepage
             new_page.set_as_homepage(self._user)
 
         send_post_page_operation(

--- a/cms/test_utils/testcases.py
+++ b/cms/test_utils/testcases.py
@@ -265,6 +265,7 @@ class BaseCMSTestCase(object):
             'title': 'test page %d' % self.counter,
             'slug': 'test-page-%d' % self.counter,
             'parent_node': parent_id,
+            'publish': True,  # Temp added as most tests require the first page to be published
         }
         # required only if user haves can_change_permission
         self.counter += 1

--- a/cms/test_utils/testcases.py
+++ b/cms/test_utils/testcases.py
@@ -265,7 +265,6 @@ class BaseCMSTestCase(object):
             'title': 'test page %d' % self.counter,
             'slug': 'test-page-%d' % self.counter,
             'parent_node': parent_id,
-            'publish': True,  # Temp added as most tests require the first page to be published
         }
         # required only if user haves can_change_permission
         self.counter += 1

--- a/cms/tests/test_page_admin.py
+++ b/cms/tests/test_page_admin.py
@@ -163,31 +163,19 @@ class PageTest(PageTestBase):
         with self.login_user_context(superuser):
             self.assertEqual(Title.objects.all().count(), 0)
             self.assertEqual(Page.objects.all().count(), 0)
-            # crate home and auto publish
+            # create home
             response = self.client.post(URL_CMS_PAGE_ADD, page_data)
             self.assertRedirects(response, URL_CMS_PAGE)
-            page_data = self.get_new_page_data()
-            response = self.client.post(URL_CMS_PAGE_ADD, page_data)
-            self.assertRedirects(response, URL_CMS_PAGE)
-
-            #self.assertEqual(Page.objects.all().count(), 2)
-            #self.assertEqual(Title.objects.all().count(), 2)
 
             title = Title.objects.drafts().get(slug=page_data['slug'])
             self.assertRaises(Title.DoesNotExist, Title.objects.public().get, slug=page_data['slug'])
 
             page = title.page
             page.save()
-            page.publish('en')
 
             self.assertEqual(page.get_title(), page_data['title'])
             self.assertEqual(page.get_slug(), page_data['slug'])
             self.assertEqual(page.get_placeholders('en').count(), 2)
-
-            # were public instances created?
-            self.assertEqual(Title.objects.all().count(), 4)
-            title = Title.objects.drafts().get(slug=page_data['slug'])
-            title = Title.objects.public().get(slug=page_data['slug'])
 
     def test_create_page_with_unconfigured_language(self):
         """
@@ -207,14 +195,14 @@ class PageTest(PageTestBase):
         )
         self.assertEqual(Title.objects.all().count(), 0)
         self.assertEqual(Page.objects.all().count(), 0)
-        # create home and auto publish
+        # create home
         with self.settings(SITE_ID=2):
             # url uses "en" as the request language
             # but the site is configured to use "de" and "fr"
             response = client.post(URL_CMS_PAGE_ADD, self.get_new_page_data())
             self.assertRedirects(response, URL_CMS_PAGE)
-            self.assertEqual(Page.objects.filter(node__site=2).count(), 2)
-            self.assertEqual(Title.objects.filter(language='de').count(), 2)
+            self.assertEqual(Page.objects.filter(node__site=2).count(), 1)
+            self.assertEqual(Title.objects.filter(language='de').count(), 1)
 
         # The user is on site #1 but switches sites using the site switcher
         # on the page changelist.
@@ -224,8 +212,8 @@ class PageTest(PageTestBase):
         # but the site is configured to use "de" and "fr"
         response = client.post(URL_CMS_PAGE_ADD, self.get_new_page_data())
         self.assertRedirects(response, URL_CMS_PAGE)
-        self.assertEqual(Page.objects.filter(node__site=2).count(), 3)
-        self.assertEqual(Title.objects.filter(language='de').count(), 3)
+        self.assertEqual(Page.objects.filter(node__site=2).count(), 2)
+        self.assertEqual(Title.objects.filter(language='de').count(), 2)
 
         Site.objects.clear_cache()
         client.logout()

--- a/cms/tests/test_wizards.py
+++ b/cms/tests/test_wizards.py
@@ -295,34 +295,6 @@ class TestPageWizard(WizardTestMixin, CMSTestCase):
         self.assertIn("id={}".format(cms_page_wizard.id), repr(cms_page_wizard))
         self.assertIn(hex(id(cms_page_wizard)), repr(cms_page_wizard))
 
-    def test_wizard_first_page_published(self):
-        site = get_current_site()
-        superuser = self.get_superuser()
-
-        with self.login_user_context(superuser):
-            request = self.get_request()
-        data = {
-            'title': 'page 1',
-            'slug': 'page_1',
-            'page_type': None,
-        }
-        form = CreateCMSPageForm(
-            data=data,
-            wizard_page=None,
-            wizard_site=site,
-            wizard_language='en',
-            wizard_request=request,
-        )
-        self.assertTrue(form.is_valid())
-        page = form.save()
-
-        self.assertTrue(page.is_published('en'))
-
-        with self.login_user_context(superuser):
-            url = page.get_absolute_url('en')
-            response = self.client.get(url)
-            self.assertEqual(response.status_code, 200)
-
     def test_wizard_create_child_page(self):
         site = get_current_site()
         superuser = self.get_superuser()


### PR DESCRIPTION
- Remove logic in forms which publishes the first page of a site
- Remove tests that check for this

