### PR TITLE
Fix add translation form, as AddPageForm expects cms_page parameter

### DIFF
--- a/cms/cms_toolbars.py
+++ b/cms/cms_toolbars.py
@@ -386,7 +386,7 @@ class PageToolbar(CMSToolbar):
                 page_add_url = admin_reverse('cms_pagecontent_add')
 
                 for code, name in add:
-                    url = add_url_parameters(page_add_url, page=self.page.pk, language=code)
+                    url = add_url_parameters(page_add_url, cms_page=self.page.pk, language=code)
                     add_plugins_menu.add_modal_item(name, url=url)
 
             if remove:


### PR DESCRIPTION
<!--
    If this is a security-related patch stop immediately!

    See http://docs.django-cms.org/en/latest/contributing/development-policies.html
-->


### Summary

Fixes #



### Links to related discussion



### Proposed changes in this pull request


### Documentation checklist

* [ ] I have updated CHANGELOG.txt if appropriate
* [ ] I have updated the release notes document if appropriate, with:
    * [ ] general notes
    * [ ] bug-fixes
    * [ ] improvements/new features
    * [ ] backwards-incompatible changes
    * [ ] required upgrade steps
    * [ ] names of contributors
* [ ] I have updated other documentation
* [ ] I have added my name to the AUTHORS file
* [ ] This PR's documentation has been approved by Daniele Procida
