### PR TITLE
Add support for tel: and mailto: URIs in Advanced Page Settings redir…

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,6 +9,33 @@
 * Added ``page_title`` parameter for ``cms.api.create_page()`` and ``cms.api.create_title()``.
 * Introduced Django 2.0 support.
 * Introduced Django 2.1 support.
+* Add support for tel: and mailto: URIs in Advanced Page Settings redirect field
+
+
+=== 3.5.3 (2018-11-20) ===
+
+* Fixed ``TreeNode.DoesNotExist`` exception raised when exporting
+  and loading database contents via ``dumpdata`` and ``loaddata``.
+* Fixed a bug where ``request.current_page`` would always be the public page,
+  regardless of the toolbar status (draft / live). This only affected custom
+  urls from an apphook.
+* Removed extra quotation mark from the sideframe button template
+* Fixed a bug where structureboard tried to preload markup when using legacy
+  renderer
+* Fixed a bug where updates on other tab are not correctly propagated if the
+  operation was to move a plugin in the top level of same placeholder
+* Fixed a bug where xframe options were processed by clickjacking middleware
+  when page was served from cache, rather then get this value from cache
+* Fixed a bug where cached page permissions overrides global permissions
+* Fixed a bug where plugins that are not rendered in content wouldn't be
+  editable in structure board
+* Fixed a bug with expanding static placeholder by clicking on "Expand All" button
+* Fixed a bug where descendant pages with a custom url would lose the overwritten
+  url on save.
+* Fixed a bug where setting the ``on_delete`` option on ``PlaceholderField``
+  and ``PageField`` fields would be ignored.
+* Fixed a bug when deleting a modal from changelist inside a modal
+
 
 === 3.5.2 (2018-04-11) ===
 

--- a/cms/forms/fields.py
+++ b/cms/forms/fields.py
@@ -5,7 +5,7 @@ from django.forms.fields import EMPTY_VALUES
 from django.utils.translation import ugettext_lazy as _
 
 from cms.forms.utils import get_site_choices, get_page_choices
-from cms.forms.validators import validate_url
+from cms.forms.validators import validate_url_extra
 from cms.forms.widgets import PageSelectWidget, PageSmartLinkWidget
 from cms.models.pagemodel import Page
 
@@ -79,7 +79,7 @@ class PageSelectFormField(forms.MultiValueField):
 
 class PageSmartLinkField(forms.CharField):
     widget = PageSmartLinkWidget
-    default_validators = [validate_url]
+    default_validators = [validate_url_extra]
 
     def __init__(self, max_length=None, min_length=None, placeholder_text=None,
                  ajax_view=None, *args, **kwargs):

--- a/cms/forms/validators.py
+++ b/cms/forms/validators.py
@@ -1,5 +1,7 @@
 from __future__ import unicode_literals
 
+import re
+
 from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator, URLValidator
 from django.utils.encoding import force_text
@@ -21,6 +23,20 @@ def validate_url(value):
     except ValidationError:
         # Fallback to absolute urls
         URLValidator()(value)
+
+
+def validate_url_extra(value):
+    try:
+        # Try normal validator first
+        validate_url(value)
+    except ValidationError:
+        # Fallback to absolute urls
+        if re.match(r'^tel:[0-9\+\#\*\-\.\(\)]+$', value):
+            pass
+        elif re.match(r'^mailto:\S+$', value):
+            pass
+        else:
+            raise
 
 
 def validate_url_uniqueness(site, path, language, exclude_page=None):


### PR DESCRIPTION
### Summary
Add support for tel: and mailto: URIs in Advanced Page Settings redirect field

### Documentation checklist

* [x] I have updated CHANGELOG.txt if appropriate
* [ ] I have updated the release notes document if appropriate, with:
    * [ ] general notes
    * [ ] bug-fixes
    * [ ] improvements/new features
    * [ ] backwards-incompatible changes
    * [ ] required upgrade steps
    * [ ] names of contributors
* [ ] I have updated other documentation
* [x] I have added my name to the AUTHORS file
* [ ] This PR's documentation has been approved by Daniele Procida
