### PR TITLE
Fix site id may be lazy

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,6 @@
+=== (next) ===
+* Fixed configuration check, in case SITE_ID is lazy.
+
 === 3.5.3 (2018-11-20) ===
 
 * Fixed ``TreeNode.DoesNotExist`` exception raised when exporting

--- a/cms/utils/conf.py
+++ b/cms/utils/conf.py
@@ -232,10 +232,12 @@ def _ensure_languages_settings(languages):
 
 
 def get_languages():
-    if settings.SITE_ID != hash(settings.SITE_ID):
-        raise ImproperlyConfigured(
-            "SITE_ID must be an integer"
-        )
+    try:
+        int(settings.SITE_ID)
+    except (AttributeError, TypeError, ValueError):
+       raise ImproperlyConfigured(
+           "SITE_ID must be an integer"
+       )
     if not settings.USE_I18N:
         return _ensure_languages_settings(
             {settings.SITE_ID: [{'code': settings.LANGUAGE_CODE, 'name': settings.LANGUAGE_CODE}]})


### PR DESCRIPTION
### Summary

Fixes configuration check, in case SITE_ID is lazy.
After applying this [snippet)]https://djangosnippets.org/snippets/1099/) , the configuration check did not work anymore. Here is a patch to test for integer values. 

### Documentation checklist

* [* ] I have updated CHANGELOG.txt if appropriate
* [ ] I have updated the release notes document if appropriate, with:
    * [ ] general notes
    * [ ] bug-fixes
    * [ ] improvements/new features
    * [ ] backwards-incompatible changes
    * [ ] required upgrade steps
    * [ ] names of contributors
* [ ] I have updated other documentation
* [ ] I have added my name to the AUTHORS file
* [ ] This PR's documentation has been approved by Daniele Procida
