### PR TITLE
Fixed #6572 -- Added missing clear cache for menu when page moved

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 === 3.6.0 (unreleased) ===
 
+* Fixed a bug where menu link is outdated when page moved.
 * Removed the ``cms moderator`` command.
 * Dropped Django < 1.11 support.
 * Removed the translatable content get / set methods from ``CMSPlugin`` model.

--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -564,7 +564,7 @@ class Page(models.Model):
                 self.publisher_public._update_title_path(language)
                 self.mark_as_published(language)
                 self.mark_descendants_as_published(language)
-        self.clear_cache()
+        self.clear_cache(menu=True)
         return self
 
     def _copy_titles(self, target, language, published):


### PR DESCRIPTION
<!--
    If this is a security-related patch stop immediately!

    See http://docs.django-cms.org/en/latest/contributing/development-policies.html
-->


### Summary

Fixes #6572 



### Links to related discussion



### Proposed changes in this pull request

Clear menu cache with other caches when page moved.


### Documentation checklist

* [x] I have updated CHANGELOG.txt if appropriate
* [ ] I have updated the release notes document if appropriate, with:
    * [ ] general notes
    * [ ] bug-fixes
    * [ ] improvements/new features
    * [ ] backwards-incompatible changes
    * [ ] required upgrade steps
    * [ ] names of contributors
* [ ] I have updated other documentation
* [ ] I have added my name to the AUTHORS file
* [ ] This PR's documentation has been approved by Daniele Procida
