### PR TITLE
Fixed #6595 -- missing clear cache for a menu after copied page

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,8 +1,5 @@
 === 3.6.0 (unreleased) ===
 
-* Fixed a bug where menu link is outdated when page was copied.
-* Fixed a bug where menu link is outdated when page moved.
-* Fixed a bug where menu link is outdated when page is created.
 * Removed the ``cms moderator`` command.
 * Dropped Django < 1.11 support.
 * Removed the translatable content get / set methods from ``CMSPlugin`` model.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 === 3.6.0 (unreleased) ===
 
+* Fixed a bug where menu link is outdated when page was copied.
 * Fixed a bug where menu link is outdated when page moved.
 * Fixed a bug where menu link is outdated when page is created.
 * Removed the ``cms moderator`` command.

--- a/cms/admin/forms.py
+++ b/cms/admin/forms.py
@@ -898,6 +898,7 @@ class CopyPageForm(PageTreeForm):
             copy_permissions=copy_permissions,
             target_site=self._site,
         )
+        new_page.clear_cache(menu=True)
         return new_page
 
     def _get_tree_options_for_root(self, position):


### PR DESCRIPTION
Based on issue #6595
