### PR TITLE
Fixed tests by installing a specific version of djangocms-text-ckeditor instead of master

### DIFF
--- a/test_requirements/django-1.10.txt
+++ b/test_requirements/django-1.10.txt
@@ -3,3 +3,4 @@ Django>=1.10,<1.11
 django-reversion==1.10,<1.11
 https://github.com/KristianOellegaard/django-hvad/archive/master.zip
 django-formtools
+djangocms-text-ckeditor<=3.6.1

--- a/test_requirements/django-1.11.txt
+++ b/test_requirements/django-1.11.txt
@@ -3,3 +3,4 @@ Django>=1.11,<2.0
 django-reversion>=2.0
 https://github.com/KristianOellegaard/django-hvad/archive/master.zip
 django-formtools
+djangocms-text-ckeditor

--- a/test_requirements/django-1.8.txt
+++ b/test_requirements/django-1.8.txt
@@ -2,3 +2,4 @@
 Django>=1.8,<1.9
 django-hvad==1.5
 django-formtools
+djangocms-text-ckeditor<=3.6.1

--- a/test_requirements/django-1.9.txt
+++ b/test_requirements/django-1.9.txt
@@ -2,3 +2,4 @@
 Django>=1.9,<1.10
 django-hvad==1.5
 django-formtools
+djangocms-text-ckeditor<=3.6.1

--- a/test_requirements/requirements_base.txt
+++ b/test_requirements/requirements_base.txt
@@ -8,7 +8,6 @@ dj-database-url
 djangocms-admin-style>=1.0
 django-sekizai>=0.9
 django-classy-tags>=0.7.2
-https://github.com/divio/djangocms-text-ckeditor/archive/master.zip
 https://github.com/ojii/django-better-test/archive/8aa2407d097fe3789b74682f0e6bd7d15d449416.zip#egg=django-better-test
 https://github.com/ojii/django-app-manage/archive/65da18ef234a4e985710c2c0ec760023695b40fe.zip#egg=django-app-manage
 iptools


### PR DESCRIPTION
Django versions below `1.11` don't work with the newest version of `djangocms-text-ckeditor`, because we removed support for them. This PR change installing the package to use `pip` with a specific version instead of installing it directly from branch `master` for all `Django` versions.

https://github.com/divio/djangocms-text-ckeditor/blob/master/CHANGELOG.rst#370-2018-12-05