### PR TITLE
Fixed #6737 -- Fix 'urls.W001' warning with custom apphook urls

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,7 @@
 * Improved apphooks documentation
 * Improved CMSPluginBase documentation
 * Improved documentation related to nested plugins
+* Fixed the 'urls.W001' warning with custom apphook urls
 
 === 3.7.0 (2019-09-25) ===
 

--- a/cms/appresolver.py
+++ b/cms/appresolver.py
@@ -149,7 +149,7 @@ def recurse_patterns(path, pattern_list, page_id, default_args=None,
 
             regex_pattern = regex
             if not DJANGO_1_11:
-                regex_pattern = RegexPattern(regex, name=pattern.name)
+                regex_pattern = RegexPattern(regex, name=pattern.name, is_endpoint=True)
             resolver = URLPattern(regex_pattern, pattern.callback, args,
                                   pattern.name)
         resolver.page_id = page_id

--- a/cms/tests/test_apphooks.py
+++ b/cms/tests/test_apphooks.py
@@ -9,6 +9,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.contrib.sites.models import Site
 from django.core import checks
 from django.core.cache import cache
+from django.core.checks.urls import check_url_config
 from django.test.utils import override_settings
 from django.urls import NoReverseMatch, clear_url_caches, resolve, reverse
 from django.utils import six
@@ -123,6 +124,15 @@ class ApphooksTestCase(CMSTestCase):
         self.reload_urls()
 
         return titles
+
+    @override_settings(ROOT_URLCONF='cms.test_utils.project.fourth_urls_for_apphook_tests')
+    def test_check_url_config(self):
+        """
+        Test for urls config check.
+        """
+        self.apphook_clear()
+        result = check_url_config(None)
+        self.assertEqual(len(result), 0)
 
     @override_settings(CMS_APPHOOKS=['%s.%s' % (APP_MODULE, APP_NAME)])
     def test_explicit_apphooks(self):


### PR DESCRIPTION
…e_patterns

When rewriting the apphooks urls in appresolver.recurse_patterns,
the original RegexPattern.is_endpoint flag is lost, so urls with a callback
view throws an "include with a route ending with a '$'" warning ('urls.W001').

    @apphook_pool.register
    class MyApp(CMSApp):
        name = "MyApp"

        def get_urls(self, page=None, language=None, **kwargs):
            return [
                re_path(r"^$", views.MyAppView.as_view(), name="my-app-index")
                # or this
                # path(r"", views.MyAppView.as_view(), name="my-app-index")
            ]

    $ ./manage.py check
    System check identified some issues:

    WARNINGS:
    ?: (urls.W001) Your URL pattern '^my-app-url/my-view-url/$' [name='my-app-index']
    uses include with a route ending with a '$'. Remove the dollar from the
    route to avoid problems including URLs.

This fix set the is_endpoint=True as in
https://github.com/django/django/blob/stable/2.2.x/django/urls/conf.py#L70