### PR TITLE
Changed url() function from re_path() for Django 2

### DIFF
--- a/cms/urls.py
+++ b/cms/urls.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from django.conf import settings
-from django.conf.urls import include, url
+from django.urls import include, re_path
 
 from cms import views
 from cms.apphook_pool import apphook_pool
@@ -22,8 +22,8 @@ else:
 
 
 urlpatterns.extend([
-    url(r'^cms_login/$', views.login, name='cms_login'),
-    url(r'^cms_wizard/', include('cms.wizards.urls')),
-    url(regexp, views.details, name='pages-details-by-slug'),
-    url(r'^$', views.details, {'slug': ''}, name='pages-root'),
+    re_path(r'^cms_login/$', views.login, name='cms_login'),
+    re_path(r'^cms_wizard/', include('cms.wizards.urls')),
+    re_path(regexp, views.details, name='pages-details-by-slug'),
+    re_path(r'^$', views.details, {'slug': ''}, name='pages-root'),
 ])


### PR DESCRIPTION
I have changed url() function to re_path() for Django 2.2 updates and also changed the imported module from django.conf.urls to django.urls

<!--
    If this is a security-related patch stop immediately!
    See http://docs.django-cms.org/en/latest/contributing/development-policies.html
-->


### Summary

Fixes #


### Links to related discussion


### Proposed changes in this pull request


### General checklist

* [ ] I have updated the CHANGELOG.txt
* [ ] I have created backports if necessary
* [ ] I have updated the documentation and/or amended the upgrade section
      if necessary
