### PR TITLE
Fix documentation bug regarding CMSPluginBase

### DIFF
--- a/docs/reference/plugins.rst
+++ b/docs/reference/plugins.rst
@@ -130,8 +130,9 @@ CMSPluginBase Attributes and Methods Reference
 
     .. attribute:: module
 
-        Will group the plugin in the plugin picker. If module is ``None``,
-        plugin is listed in the "Generic" group.
+        Will group the plugin in the plugin picker. If the module
+        attribute is not provided plugin is listed in the "Generic"
+        group.
 
 
     .. attribute:: name


### PR DESCRIPTION
### Summary

The documentation advertises that you can set the module attribute of
custom plugins to None.  If the user attempts this django they won't be able
to start up when django.contrib.admin.site.urls is included in urls.py
(tested with django 1.11.25 and django-cms 3.7.0).

I strongly recommend backporting this to the 3.7.x release branch.

* [ ] I have updated the CHANGELOG.txt
* [ ] I have created backports if necessary
* [ ] I have updated the documentation and/or amended the upgrade section
      if necessary
