### PR TITLE
Squash integration

### DIFF
--- a/.squash.yml
+++ b/.squash.yml
@@ -1,0 +1,20 @@
+deployments:
+  default:
+    dockerimage: ubuntu:19.10
+    build_steps:
+      - apt-get update && apt-get install -y python python-pip virtualenv libssl-dev libpq-dev git build-essential libfontconfig1 libfontconfig1-dev
+      - apt-get install -y locales
+      - sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && locale-gen
+      - export LC_ALL=en_US.UTF-8
+      - export LANG=en_US.UTF-8
+      - export LANGUAGE=en_US.UTF-8
+      - pip install setuptools pip --upgrade --force-reinstall
+      - pip install djangocms-installer
+    launch_steps:
+      - mkdir myproject
+      - cd myproject
+      - djangocms -f -s -p . mysite
+      - sed -i -e 's/ALLOWED_HOSTS.*/ALLOWED_HOSTS = ["*"]/' /myproject/mysite/settings.py
+      - python manage.py migrate
+      - python manage.py runserver 0.0.0.0:80
+    auto_deploy_on_commits: true


### PR DESCRIPTION
### Summary

I'd like to propose this patch to use [Squash.io](https://www.squash.io/) on this repository. I believe this will help developers and maintainers to quickly validate each PR on its own fully functional staging environment, and running on an isolated VM.

Please let me know what you think and if you have any questions, thanks.


### Links to related discussion

N/A

### Proposed changes in this pull request

Example of Django-CMS working with Squash:

https://squash-tmp1-nejdm.squash.io/
Login as admin/admin

It takes just a few minutes to load, and the environment will stay active for 3 hours in a row, you can restart as many times as needed, [more info here](https://www.squash.io/docs/how-it-works-quick-intro/).

Squash is free for Open Source, maintainers just need to [signup here](https://www.squash.io/sign-up/) and reach out to the [support](https://www.squash.io/support/) through the chat window and we will enable a **forever free** Open Source account **with higher limits than our regular free account**.  Once this is done, Squash will post a comment on each Pull Request [like this ](https://github.com/emiquelito/django-cms-2.0/pull/1)- see screenshot:

![Screen Shot 2019-11-07 at 7 46 12 PM](https://user-images.githubusercontent.com/98694/68445484-46ef5180-0197-11ea-872e-a774f7c267da.png)

Please note that in this PR we are also enabling the [Automated Checks feature](https://www.squash.io/docs/automated-checks/), see the last line in the YAML file. This will make Squash trigger a separate VM for each commit and give a pass or fail based on a success response. You can also extend this to run Selenium/Cypress and other tests on top of that Squash deployment.

See:

![squash io integration by emiquelito · Pull Request  1 · emiquelito django-cms-2 0](https://user-images.githubusercontent.com/98694/68445629-ab121580-0197-11ea-8904-8e81ea6e7761.png)

### General checklist

I've not updated the CHANGELOG.txt yet, wanted to validate this with the team first.

* [ ] I have updated the CHANGELOG.txt
* [ ] I have created backports if necessary
* [ ] I have updated the documentation and/or amended the upgrade section
      if necessary
