### PR TITLE
Fix simple typo: seperated -> separated

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,7 @@ Changelog
 * Improved apphooks documentation.
 * Improved CMSPluginBase documentation.
 * Improved documentation related to nested plugins.
+* Fixed a simple typo in the docstring for cms.utils.helpers.normalize_name
 
 
 3.7.0 (2019-09-25)

--- a/cms/utils/helpers.py
+++ b/cms/utils/helpers.py
@@ -42,7 +42,7 @@ class classproperty(object):
 
 def normalize_name(name):
     """
-    Converts camel-case style names into underscore seperated words. Example::
+    Converts camel-case style names into underscore separated words. Example::
 
         >>> normalize_name('oneTwoThree')
         'one_two_three'


### PR DESCRIPTION
## Description

 Small typo in docstring for cms.utils.helpers.normalize_name

## Related resources

* Closes #6766 

## Checklist

* [x] I have opened this pull request against ``develop``
* [x] I have updated the **CHANGELOG.rst**
* [x] I have added or modified the tests when changing logic (No change)
