### PR TITLE
Dependency update of test_requirements

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,7 @@ Changelog
 * Improved documentation related to nested plugins.
 * Updated installation tutorial.
 * Fixed a simple typo in the docstring for ``cms.utils.helpers.normalize_name``.
+* Changed pyenchant version in the base_requirement.txt to pre-release 3.0.0a1
 
 
 3.7.0 (2019-09-25)

--- a/test_requirements/requirements_base.txt
+++ b/test_requirements/requirements_base.txt
@@ -15,7 +15,7 @@ iptools
 sphinx==1.8.5
 sphinxcontrib-spelling
 pyflakes==1.1.0
-pyenchant
+pyenchant==3.0.0a1
 # required to run the server for integration tests
 djangocms-helper
 mock>=2.0.0


### PR DESCRIPTION
## Description

When trying to run tests you need to install the test requirements for django-2.2.
This also includes the pyenchant package, which at the current official version created an error, which is discussed [here](https://github.com/pyenchant/pyenchant/issues/164)
I updated the test_requirement.txt to the current pre-release and it is working now, though it should be changed as soon as the pre-release becomes an official release.

## Related resources

[ImportError: The 'enchant' C library was not found. Please install it via your OS package manager, or use a pre-built binary wheel from PyPI. #164](https://github.com/pyenchant/pyenchant/issues/164)

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop``
* [x] I have updated the **CHANGELOG.rst**
* [x] I have added or modified the tests when changing logic
