### PR TITLE
EmptyPageContent should raise a 404

### DIFF
--- a/cms/page_rendering.py
+++ b/cms/page_rendering.py
@@ -7,6 +7,7 @@ from django.urls import Resolver404, resolve, reverse
 from cms import __version__
 from cms import constants
 from cms.cache.page import set_page_cache
+from cms.models import EmptyPageContent
 from cms.utils.page import get_page_template_from_request
 from cms.utils.page_permissions import user_can_change_page, user_can_view_page
 
@@ -21,7 +22,11 @@ def render_page(request, page, current_language, slug):
     context['has_change_permissions'] = user_can_change_page(request.user, page)
     context['has_view_permissions'] = user_can_view_page(request.user, page)
 
-    if not context['has_view_permissions']:
+    cant_view_page = any([
+        not context['has_view_permissions'],
+        isinstance(page.get_title_obj(current_language), EmptyPageContent)
+    ])
+    if cant_view_page:
         return _handle_no_page(request)
 
     template = get_page_template_from_request(request)


### PR DESCRIPTION
## Description

If a page does not contain any pagecontent it will return an `EmptyPageContent`. We should not try to render this `EmptyPageContent`, instead we should return a 404. This solves issues related to versioning down the line. If a page is in draft only, it will return an `EmptyPageContent`, and thus we don't want this page to be rendered at all. 

## Related resources
This PR depends on #6790, once that PR is merged this PR can be rebased against current master. I've based this PR on that branch to show that tests are passing. 

Please review the last commit to see the relevant changes. 

## Checklist

* [x] I have opened this pull request against ``release/4.0.x``
* [x] I have updated the **CHANGELOG.rst**
* [x] I have added or modified the tests when changing logic
