### PR TITLE
Provide a general get method that can be monkeypatched

### DIFF
--- a/cms/admin/forms.py
+++ b/cms/admin/forms.py
@@ -35,6 +35,7 @@ from cms.plugin_pool import plugin_pool
 from cms.signals.apphook import set_restart_trigger
 from cms.utils.conf import get_cms_setting
 from cms.utils.compat.forms import UserChangeForm
+from cms.utils import helpers
 from cms.utils.i18n import (
     get_language_list,
     get_site_language_from_request,
@@ -1340,7 +1341,7 @@ class RequestToolbarForm(forms.Form):
             raise forms.ValidationError(message)
 
         try:
-            generic_obj = model_class.objects.get(pk=obj_id)
+            generic_obj = helpers.get_admin_model_object_by_id(model_class, obj_id)
         except model_class.DoesNotExist:
             message = 'Invalid object lookup. Both obj_id and obj_type are required'
             raise forms.ValidationError(message)

--- a/cms/utils/helpers.py
+++ b/cms/utils/helpers.py
@@ -111,3 +111,19 @@ def is_editable_model(model_class):
     except KeyError:
         return False
     return isinstance(admin_class, FrontendEditableAdminMixin)
+
+
+def get_admin_model_object_by_id(model_class, obj_id):
+    """
+    A method to fetch an object by object id.
+
+    3rd party applications may change the queryset by the use of monkey-patching.
+    djangocms-versioning is a prime example of this. By having this helper 3rd
+    party applications can monkeypatch this helper to ensure correct results
+    without monkeypatching entire functions of django-cms or through adding
+    their logic directly to django-cms.
+
+    This helper can be reused by applications that wish to get a model that
+    should be visible to the admin.
+    """
+    return model_class.objects.get(pk=obj_id)


### PR DESCRIPTION
## Description
Sometimes we need to monkeypatch the get method in djangocms-versioning to get drafts. Rather than monkeypatching whole blocks of methods we can provide a single method that needs to be monkeypatched. 

If new issues crops up related to djangocms-versioning this method would be used in that place. 

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``release/4.0.x``
* [ ] I have updated the **CHANGELOG.rst**
* [ ] I have added or modified the tests when changing logic
