### PR TITLE
Add method that allows to monkeypatch how models are filtered

### DIFF
--- a/cms/utils/helpers.py
+++ b/cms/utils/helpers.py
@@ -127,3 +127,19 @@ def get_admin_model_object_by_id(model_class, obj_id):
     should be visible to the admin.
     """
     return model_class.objects.get(pk=obj_id)
+
+
+def filter_admin_model(model_class, **kwargs):
+    """
+    A method to filter a Model with keyword arguments.
+
+    3rd party applications may change the queryset by the use of monkey-patching.
+    djangocms-versioning is a prime example of this. By having this helper 3rd
+    party applications can monkeypatch this helper to ensure correct results
+    without monkeypatching entire functions of django-cms or through adding
+    their logic directly to django-cms.
+
+    This helper can be reused by applications that wish to get a model that
+    should be visible to the admin.
+    """
+    return model_class.filter(**kwargs)

--- a/cms/views.py
+++ b/cms/views.py
@@ -18,11 +18,12 @@ from django.views.decorators.http import require_POST
 from cms.cache.page import get_page_cache
 from cms.exceptions import LanguageError
 from cms.forms.login import CMSToolbarLoginForm
-from cms.models.pagemodel import TreeNode
+from cms.models import PageContent, TreeNode
 from cms.page_rendering import _handle_no_page, _render_welcome_page, render_pagecontent
 from cms.toolbar.utils import get_toolbar_from_request
 from cms.utils import get_current_site
 from cms.utils.conf import get_cms_setting
+from cms.utils import helpers
 from cms.utils.helpers import is_editable_model
 from cms.utils.i18n import (get_fallback_languages, get_public_languages,
                             get_redirect_on_fallback, get_language_list,
@@ -168,6 +169,9 @@ def details(request, slug):
     # use the page object with populated cache
     content.page = page
     if hasattr(request, 'toolbar'):
+        content = helpers.filter_admin_model(
+            PageContent, page_id=page.pk, language=request_language
+        ).first()
         request.toolbar.set_object(content)
 
     return render_pagecontent(request, content)


### PR DESCRIPTION
## Description
Instead of monkeypatching entire block of methods in djangocms-versioning we can monkeypatch single small methods to accomplish the same thing. 

This PR adds a method `filter_admin_model`. The intended use for this method is to be able to fetch objects that are in draft in djangocms-versioning, that package will monkeypatch that method to modify the behaviour so that draft objects can be found. 

## Checklist

* [x] I have opened this pull request against ``release/4.0.x``
* [ ] I have updated the **CHANGELOG.rst**
* [ ] I have added or modified the tests when changing logic
