### PR TITLE
Fix not rendering AliasPlugin in same static_placeholder with differrents languages  in edit mode

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+Unreleased
+==================
+Fix rendering AliasPlugin in static_placerholder in edit mode.
+
 
 3.7.1 (2019-11-26)
 ==================

--- a/cms/templates/cms/plugins/alias.html
+++ b/cms/templates/cms/plugins/alias.html
@@ -1,1 +1,1 @@
-{% load cms_alias_tags %}{% if request and not instance.is_recursive %}{% render_alias_plugin instance %}{% endif %}
+{% load cms_alias_tags %}{% if request and not instance.is_recursive or request.toolbar.edit_mode_active %}{% render_alias_plugin instance %}{% endif %}


### PR DESCRIPTION
## Description
I wanted to do a alias a navbar plugin in a same static_placeholder in translation context, but it did not appear in edit mode.

## Checklist

* [ ] I have opened this pull request against ``develop``
* [x] I have updated the **CHANGELOG.rst**
* [ ] I have added or modified the tests when changing logic
