### PR TITLE
The language menu only shows active translations and points to preview url

### DIFF
--- a/cms/cms_toolbars.py
+++ b/cms/cms_toolbars.py
@@ -313,13 +313,16 @@ class BasicToolbar(CMSToolbar):
     def add_language_menu(self):
         if settings.USE_I18N and not self._language_menu:
             self._language_menu = self.toolbar.get_or_create_menu(LANGUAGE_MENU_IDENTIFIER, _('Language'), position=-1)
-            language_changer = getattr(self.request, '_language_changer', DefaultLanguageChanger(self.request))
+            page = self.request.current_page
             for code, name in get_language_tuple(self.current_site.pk):
                 try:
-                    url = language_changer(code)
-                except NoReverseMatch:
+                    content = page.get_title_obj(code, fallback=False)
+                    url = get_object_preview_url(content)
+                    disabled = False
+                except (NoReverseMatch, AttributeError):
                     url = DefaultLanguageChanger(self.request)(code)
-                self._language_menu.add_link_item(name, url=url, active=self.current_lang == code)
+                    disabled = True
+                self._language_menu.add_link_item(name, url=url, active=self.current_lang == code, disabled=disabled)
 
     def get_username(self, user=None, default=''):
         user = user or self.request.user

--- a/cms/tests/test_toolbar.py
+++ b/cms/tests/test_toolbar.py
@@ -463,6 +463,36 @@ class ToolbarTests(ToolbarTestBase):
         toolbar = CMSToolbar(request)
         self.assertTrue(toolbar.show_toolbar)
 
+    def test_change_language_menu_two_languages(self):
+        """
+        Only english language is active. German and English is not disabled.
+        The language link points to the preview url instead of live url.
+        """
+        page = create_page("english-page", "nav_playground.html", "en")
+        german_content = create_title("de", "german content", page)
+        english_content = page.get_title_obj('en')
+        staff = self.get_staff()
+        self.client.force_login(staff)
+
+        response = self.client.get(page.get_absolute_url())
+        menus = response.context['cms_toolbar'].menus
+        language_menu = menus['language-menu']
+        english = language_menu.items[0]
+        english_url = get_object_preview_url(english_content)
+        not_disabled_languages = [i for i in language_menu.items if i.disabled == False]
+
+        german = language_menu.items[1]
+        german_url = get_object_preview_url(german_content)
+
+        self.assertEqual(german.active, False)
+        self.assertEqual(german.disabled, False)
+        self.assertEqual(german.url, german_url)
+
+        self.assertEqual(english.active, True)
+        self.assertEqual(english.disabled, False)
+        self.assertEqual(english.url, english_url)
+        self.assertEqual(len(not_disabled_languages), 2, 'Only two languages are not disabled')
+
     def test_show_toolbar_staff(self):
         page = create_page("toolbar-page", "nav_playground.html", "en")
         page_content = self.get_page_title_obj(page)


### PR DESCRIPTION
## Description

The language menu should point to the preview url instead of the live url. The reason for this is that content may not be available for whatever reason. Ie if a page is not published in djangocms-versioning this page should return 404 for the live url. 

We further clarify that a translation is not available by disabling the item if we can't successfully resolve the path. 

## Checklist

* [x] I have opened this pull request against ``release/4.0.x``
* [ ] I have updated the **CHANGELOG.rst**
* [x] I have added or modified the tests when changing logic

Note: This currently does not work well with drafts/versioning, as `get_title_obj` can't find a draft. 
