### PR TITLE
Introduce get_admin_title_obj

### DIFF
--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -727,7 +727,7 @@ class PageAdmin(admin.ModelAdmin):
 
     def edit_title_fields(self, request, page_id, language):
         page = self.get_object(page_id)
-        translation = page.get_title_obj(language, fallback=False)
+        translation = page.get_admin_title_obj(language, fallback=False)
 
         if not self.has_change_permission(request, obj=page):
             return HttpResponseForbidden(force_text(_("You do not have permission to edit this page")))
@@ -946,7 +946,6 @@ class PageContentAdmin(admin.ModelAdmin):
     def add_view(self, request, form_url='', extra_context=None):
         site = get_site(request)
         language = get_site_language_from_request(request, site_id=site.pk)
-
         if extra_context is None:
             extra_context = {}
 
@@ -1222,7 +1221,7 @@ class PageContentAdmin(admin.ModelAdmin):
         if not target_language or not target_language in get_language_list(site_id=page.node.site_id):
             return HttpResponseBadRequest(force_text(_("Language must be set to a supported language!")))
 
-        target_page_content = page.get_title_obj(target_language, fallback=False)
+        target_page_content = page.get_admin_title_obj(target_language, fallback=False)
 
         for placeholder in source_page_content.get_placeholders():
             # TODO: Handle missing placeholder
@@ -1468,7 +1467,7 @@ class PageContentAdmin(admin.ModelAdmin):
                 'opts': self.opts,
                 'site': site,
                 'page': page,
-                'page_content': page.get_title_obj(language, fallback=True),
+                'page_content': page.get_admin_title_obj(language, fallback=True),
                 'page_content_type': page_content_type,
                 'node': page.node,
                 'ancestors': [node.item for node in page.node.get_cached_ancestors()],

--- a/cms/cms_toolbars.py
+++ b/cms/cms_toolbars.py
@@ -339,7 +339,7 @@ class PageToolbar(CMSToolbar):
     watch_models = [Page, PageType]
 
     def get_page_content(self):
-        page_content = self.page.get_title_obj(language=self.current_lang, fallback=False)
+        page_content = self.page.get_admin_title_obj(language=self.current_lang, fallback=False)
         return page_content or None
 
     def has_page_change_permission(self):

--- a/cms/extensions/toolbar.py
+++ b/cms/extensions/toolbar.py
@@ -71,7 +71,7 @@ class ExtensionToolbar(CMSToolbar):
         page = self._get_page()
         urls = []
         if language:
-            titles = page.get_title_obj(language),
+            titles = page.get_admin_title_obj(language),
         else:
             titles = page.pagecontent_set.filter(language__in=get_language_list(page.node.site_id))
         # Titles

--- a/cms/management/commands/subcommands/copy.py
+++ b/cms/management/commands/subcommands/copy.py
@@ -54,9 +54,9 @@ class CopyLangCommand(SubcommandsCommand):
             # copy title
             if from_lang in page.get_languages():
 
-                title = page.get_title_obj(to_lang, fallback=False)
+                title = page.get_admin_title_obj(to_lang, fallback=False)
                 if isinstance(title, EmptyPageContent):
-                    title = page.get_title_obj(from_lang)
+                    title = page.get_admin_title_obj(from_lang)
                     if verbose:
                         self.stdout.write('copying title %s from language %s\n' % (title.title, from_lang))
                     title.id = None

--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -199,6 +199,8 @@ class Page(models.Model):
         super(Page, self).__init__(*args, **kwargs)
         self.urls_cache = {}
         self.title_cache = {}
+        # to pre-emptive usage from get_admin_title_obj
+        self.admin_title_cache = {}
 
     def __str__(self):
         try:
@@ -775,6 +777,16 @@ class Page(models.Model):
         from cms.models import EmptyPageContent
 
         return EmptyPageContent(language)
+
+    def get_admin_title_obj(self, language=None, fallback=True, force_reload=False):
+        """
+        Used in places where it is ok to fetch pagecontent that is not yet
+        publically available.
+
+        In vanilla django-cms it is an alias for get_title_obj. But this can
+        be monkeypatched by other packages such as djangocms-versioning.
+        """
+        return self.get_title_obj(language=language, fallback=fallback, force_reload=force_reload)
 
     def get_page_content_obj_attribute(self, attrname, language=None, fallback=True, force_reload=False):
         """Helper function for getting attribute or None from wanted/current title.

--- a/cms/page_rendering.py
+++ b/cms/page_rendering.py
@@ -21,6 +21,7 @@ def render_page(request, page, current_language, slug):
     context['current_page'] = page
     context['has_change_permissions'] = user_can_change_page(request.user, page)
     context['has_view_permissions'] = user_can_view_page(request.user, page)
+    context['pagecontent'] = page.title_cache[current_language]
 
     cant_view_page = any([
         not context['has_view_permissions'],

--- a/cms/templatetags/cms_admin.py
+++ b/cms/templatetags/cms_admin.py
@@ -27,7 +27,7 @@ def get_admin_url_for_language(page, language):
         admin_url += '?cms_page={}&language={}'.format(page.pk, language)
         return admin_url
 
-    page_content = page.get_title_obj(language, fallback=False)
+    page_content = page.get_admin_title_obj(language, fallback=False)
     return admin_reverse('cms_pagecontent_change', args=[page_content.pk])
 
 

--- a/cms/views.py
+++ b/cms/views.py
@@ -164,11 +164,12 @@ def details(request, slug):
     if page.login_required and not request.user.is_authenticated:
         return redirect_to_login(urlquote(request.get_full_path()), settings.LOGIN_URL)
 
-    content = page.get_title_obj(language=request_language)
+    content = page.get_title_obj(language=request_language, fallback=False)
     # use the page object with populated cache
     content.page = page
     if hasattr(request, 'toolbar'):
-        request.toolbar.set_object(content)
+        toolbar_content = page.get_admin_title_obj(language=request_language)
+        request.toolbar.set_object(toolbar_content)
 
     return render_pagecontent(request, content)
 
@@ -258,6 +259,7 @@ def render_object_preview(request, content_type_id, object_id):
         return HttpResponseBadRequest('Requested object does not support frontend rendering')
 
     toolbar = get_toolbar_from_request(request)
+
     toolbar.set_object(content_type_obj)
     render_func = extension.toolbar_enabled_models[model]
     return render_func(request, content_type_obj)


### PR DESCRIPTION
The following method allow you to fetch pagecontent that is
safe for admin usage. This allows for modifying store objects
in the cache that would not show up for an end user.

It also allows for a clean way of mocking for external packages.

* [x] I have opened this pull request against ``release/4.0.x``
* [ ] I have updated the **CHANGELOG.rst**
* [x] I have added or modified the tests when changing logic

Tests for this functionality can be found here https://github.com/divio/djangocms-versioning/pull/217

This PR supersedes #6820 