### PR TITLE
Removed bad migration character for Placeholder relations that are not a Many to Many relationship (PlaceholderField)

### DIFF
--- a/cms/migrations/0033_placeholder_source_data_migration.py
+++ b/cms/migrations/0033_placeholder_source_data_migration.py
@@ -41,7 +41,7 @@ def forwards(apps, schema_editor):
                             object_id=obj.pk,
                         )
                     else:
-                        obj_placeholder_field.content_type_id = cur_ct_obj.pk,
+                        obj_placeholder_field.content_type_id = cur_ct_obj.pk
                         obj_placeholder_field.object_id = obj.pk
                         obj.save()
 


### PR DESCRIPTION
## Description

Fixed an error where a Placeholder field that was a One to Many relationship was receiving a tuple instead of an id due to a rogue comma.