### PR TITLE
Move var declaration inside closure to make it available to firefox

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,13 @@ Changelog
 =========
 
 
-3.7.2 (unreleased)
+3.7.3 (unreleased)
+==================
+
+* Fixed apphooks config select in Firefox
+
+
+3.7.2 (2020-04-22)
 ==================
 
 * Added support for Django 3.0

--- a/cms/static/cms/js/widgets/forms.apphookselect.js
+++ b/cms/static/cms/js/widgets/forms.apphookselect.js
@@ -11,10 +11,10 @@ __webpack_public_path__ = require('../modules/get-dist-path')('bundle.forms.apph
 // APP HOOK SELECT
 require.ensure([], function (require) {
     var $ = require('jquery');
-    var apphooks_configuration = window.apphooks_configuration || {};
 
     // shorthand for jQuery(document).ready();
     $(function () {
+        var apphooks_configuration = window.apphooks_configuration || {};
         var appHooks = $('#application_urls, #id_application_urls');
         var selected = appHooks.find('option:selected');
         var appNsRow = $('.form-row.application_namespace, .form-row.field-application_namespace');


### PR DESCRIPTION
## Description

`window.apphooks_configuration` is not read by firefox if declared outside the closure

Moving it inside closure make it reachable by firefox

## Related resources

Fix #6853 

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop``
* [x] I have updated the **CHANGELOG.rst**
* [ ] I have added or modified the tests when changing logic
