### PR TITLE
Move var declaration inside closure to make it available to firefox (#6854)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ Changelog
 3.7.3 (unreleased)
 ==================
 
-* ...
+* Fixed apphooks config select in Firefox
 
 
 3.7.2 (2020-04-22)

--- a/cms/static/cms/js/widgets/forms.apphookselect.js
+++ b/cms/static/cms/js/widgets/forms.apphookselect.js
@@ -11,10 +11,10 @@ __webpack_public_path__ = require('../modules/get-dist-path')('bundle.forms.apph
 // APP HOOK SELECT
 require.ensure([], function (require) {
     var $ = require('jquery');
-    var apphooks_configuration = window.apphooks_configuration || {};
 
     // shorthand for jQuery(document).ready();
     $(function () {
+        var apphooks_configuration = window.apphooks_configuration || {};
         var appHooks = $('#application_urls, #id_application_urls');
         var selected = appHooks.find('option:selected');
         var appNsRow = $('.form-row.application_namespace, .form-row.field-application_namespace');


### PR DESCRIPTION
backport #6854