### PR TITLE
Ported: Override urlconf_module so that Django system checks don't crash.

### DIFF
--- a/cms/appresolver.py
+++ b/cms/appresolver.py
@@ -56,12 +56,20 @@ class AppRegexURLResolver(URLResolver):
         super(AppRegexURLResolver, self).__init__(*args, **kwargs)
 
     @property
+    def urlconf_module(self):
+        # It is valid for urlconf_module to be a list of patterns. So we just
+        # return the list here.
+        #
+        # See https://github.com/django/django/blob/2.2.4/django/urls/resolvers.py#L578
+        #
+        return self.url_patterns_dict.get(get_language(), [])
+
+    # On URLResolver the url_patterns property is cached and thus calls made after
+    # language changes (different return values for get_language()) would not return the
+    # right value. Overriding here prevents caching.
+    @property
     def url_patterns(self):
-        language = get_language()
-        if language in self.url_patterns_dict:
-            return self.url_patterns_dict[language]
-        else:
-            return []
+        return self.urlconf_module
 
     def resolve_page_id(self, path):
         """Resolves requested path similar way how resolve does, but instead

--- a/cms/tests/test_apphooks.py
+++ b/cms/tests/test_apphooks.py
@@ -5,6 +5,7 @@ import sys
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
 from django.contrib.sites.models import Site
+from django.core import checks
 from django.core.cache import cache
 from django.test.utils import override_settings
 from django.urls import NoReverseMatch, clear_url_caches, resolve, reverse
@@ -147,6 +148,17 @@ class ApphooksTestCase(CMSTestCase):
         response = self.client.get('/en/blankapp/')
         self.assertTemplateUsed(response, 'nav_playground.html')
 
+        self.apphook_clear()
+
+    @override_settings(ROOT_URLCONF='cms.test_utils.project.urls_for_apphook_tests')
+    def test_apphook_does_not_crash_django_checks(self):
+        # This test case reproduced the situation causing the error reported in issue #6717.
+        self.apphook_clear()
+        superuser = get_user_model().objects.create_superuser('admin', 'admin@admin.com', 'admin')
+        create_page("apphooked-page", "nav_playground.html", "en",
+                    created_by=superuser, apphook="SampleApp")
+        self.reload_urls()
+        checks.run_checks()
         self.apphook_clear()
 
     @override_settings(ROOT_URLCONF='cms.test_utils.project.urls_for_apphook_tests')


### PR DESCRIPTION
## Description

This fix is ported from Develop and is required for Django 2.2 to work with Management commands: https://github.com/divio/django-cms/commit/efbeaa0be5f9cac12d51ffdbca7716a01a68740a

Without this fix, Django system checks in Django 2.2 will try to resolve the
"app_resolver" module, which does not exist. Overriding ``urlconf_module``
prevents the issue.

