### PR TITLE
Added missing softroot to the migration copy from Page to PageContent

### DIFF
--- a/cms/migrations/0030_auto_20180810_0629.py
+++ b/cms/migrations/0030_auto_20180810_0629.py
@@ -14,6 +14,7 @@ def update_titles(apps, schema_editor):
             changed_by=page.changed_by,
             changed_date=page.changed_date,
             in_navigation=page.in_navigation,
+            soft_root=page.soft_root,
             limit_visibility_in_menu=page.limit_visibility_in_menu,
             template=page.template,
             xframe_options=page.xframe_options,


### PR DESCRIPTION
## Description

On successful migration from a 3.5 migration the navigation has lost the soft_root setting. This setting is missing from the data migration and has now been added in to ensure that the attribute is carried across.
