### PR TITLE
fix plural issue in django-cms

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,10 @@ Changelog
 * Introduced support for Django 3.1
 * Dropped support for Python 2.7 and Python 3.4
 * Dropped support for Django < 2.2
+* Removed ``djangocms-column`` from the manual installation instructions
+* Removed duplicate ``attr`` declaration from the documentation
+* Fixed a reference to a wrong variable in log messages in ``utils/conf.py``
+* Fixed an issue in ``wizards/create.html`` where the error message did not use the plural form
 
 
 3.7.4 (2020-07-21)

--- a/cms/templates/cms/wizards/create.html
+++ b/cms/templates/cms/wizards/create.html
@@ -11,7 +11,7 @@
 
         {% if form.errors %}
             <p class="errornote">
-                {% trans "Please correct the error below." %}
+                {% blocktrans count form.errors|length as counter %}Please correct the error below.{% plural %}Please correct the errors below.{% endblocktrans %}
             </p>
         {% endif %}
 


### PR DESCRIPTION
## Description

Fixes an issue in ``wizards/create.html`` where the error message did not use the plural form. This occurs when generating the translation files via `` django-admin.py makemessages -l en --no-location``.

Also adding missing changelog entries in preparation for the django CMS 3.8.0 RC1 release.

## Checklist

* [x] I have opened this pull request against ``develop``
* [x] I have updated the **CHANGELOG.rst**
* [x] I have added or modified the tests when changing logic
